### PR TITLE
feat:add node taints to cpu and memory scenarios

### DIFF
--- a/krkn_ai/models/cluster_components.py
+++ b/krkn_ai/models/cluster_components.py
@@ -20,6 +20,7 @@ class Node(BaseModel):
     free_cpu: float = 0
     free_mem: float = 0
     interfaces: List[str] = []
+    taints: List[str] = []
 
 
 class ClusterComponents(BaseModel):

--- a/krkn_ai/models/scenario/scenario_cpu_hog.py
+++ b/krkn_ai/models/scenario/scenario_cpu_hog.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import json
 
 from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
@@ -42,6 +43,8 @@ class NodeCPUHogScenario(Scenario):
             node = rng.choice(nodes)
             self.node_selector.value = f"kubernetes.io/hostname={node.name}"
             self.number_of_nodes.value = 1
+            # Set taints for the selected node
+            self.taint.value = json.dumps(node.taints) if node.taints else '[]'
             # self.node_cpu_core.value = node.free_cpu * 0.001  # convert to cores from millicores
         else:
             # scenario 2: Select a label
@@ -52,6 +55,22 @@ class NodeCPUHogScenario(Scenario):
             label = rng.choice(list(all_labels.keys()))
             self.node_selector.value = label
             self.number_of_nodes.value = rng.randint(1, all_labels[label])
+
+            # Get taints from matching nodes
+            key, value = label.split('=', 1)
+            matching_nodes = [n for n in nodes if n.labels.get(key) == value]
+            
+            # Collect all unique taints from matching nodes
+            all_taints = []
+            seen = set()
+            for node in matching_nodes:
+                if node.taints:
+                    for taint in node.taints:
+                        if taint not in seen:
+                            seen.add(taint)
+                            all_taints.append(taint)
+            
+            self.taint.value = json.dumps(all_taints) if all_taints else '[]'
 
             # get the minimum free cpu core for the selected label
             # min_cpu_core_milli = float('inf')

--- a/krkn_ai/models/scenario/scenario_memory_hog.py
+++ b/krkn_ai/models/scenario/scenario_memory_hog.py
@@ -1,4 +1,5 @@
 from collections import Counter
+import json
 
 from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
@@ -42,6 +43,8 @@ class NodeMemoryHogScenario(Scenario):
             node = rng.choice(nodes)
             self.node_selector.value = f"kubernetes.io/hostname={node.name}"
             self.number_of_nodes.value = 1
+            # Set taints for the selected node
+            self.taint.value = json.dumps(node.taints) if node.taints else '[]'
         else:
             # scenario 2: Select a label
             all_labels = Counter()
@@ -51,6 +54,22 @@ class NodeMemoryHogScenario(Scenario):
             label = rng.choice(list(all_labels.keys()))
             self.node_selector.value = label
             self.number_of_nodes.value = rng.randint(1, all_labels[label])
+
+            # Get taints from matching nodes
+            key, value = label.split('=', 1)
+            matching_nodes = [n for n in nodes if n.labels.get(key) == value]
+            
+            # Collect all unique taints from matching nodes
+            all_taints = []
+            seen = set()
+            for node in matching_nodes:
+                if node.taints:
+                    for taint in node.taints:
+                        if taint not in seen:
+                            seen.add(taint)
+                            all_taints.append(taint)
+            
+            self.taint.value = json.dumps(all_taints) if all_taints else '[]'
 
         self.number_of_workers.mutate()
         self.node_memory_percentage.mutate()

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -115,9 +115,20 @@ class ClusterManager:
                     for label in node.metadata.labels:
                         if re.match(pattern, label):
                             labels[label] = node.metadata.labels[label]
+            # Get node taints and format as strings: "key:effect" or "key=value:effect"
+            taints = []
+            if node.spec.taints is not None:
+                for taint in node.spec.taints:
+                    if taint.value is not None:
+                        taint_str = f"{taint.key}={taint.value}:{taint.effect}"
+                    else:
+                        taint_str = f"{taint.key}:{taint.effect}"
+                    taints.append(taint_str)
+
             node_component = Node(
                 name=node.metadata.name,
-                labels=labels
+                labels=labels,
+                taints=taints
             )
 
             try:


### PR DESCRIPTION
Close https://github.com/krkn-chaos/krkn-ai/issues/40
Support taints such as 
taints=[
                "node-role.kubernetes.io/master:NoSchedule",  
                "dedicated=workload:NoSchedule",  
]
taints will be added in cpu hog and memory hog scenario