### PR TITLE
fix: add namespace parameter to node hog scenarios

### DIFF
--- a/krkn_ai/models/scenario/scenario_cpu_hog.py
+++ b/krkn_ai/models/scenario/scenario_cpu_hog.py
@@ -15,6 +15,7 @@ class NodeCPUHogScenario(Scenario):
     chaos_duration: TotalChaosDurationParameter = TotalChaosDurationParameter()
     # node_cpu_core: NodeCPUCoreParameter = NodeCPUCoreParameter()
     node_cpu_percentage: NodeCPUPercentageParameter = NodeCPUPercentageParameter()
+    namespace: NamespaceParameter = NamespaceParameter(value="default")
     node_selector: NodeSelectorParameter = NodeSelectorParameter()
     taint: TaintParameter = TaintParameter()
     number_of_nodes: NumberOfNodesParameter = NumberOfNodesParameter()
@@ -30,6 +31,7 @@ class NodeCPUHogScenario(Scenario):
             self.chaos_duration,
             # self.node_cpu_core,
             self.node_cpu_percentage,
+            self.namespace,
             self.node_selector,
             self.taint,
             self.number_of_nodes,

--- a/krkn_ai/models/scenario/scenario_memory_hog.py
+++ b/krkn_ai/models/scenario/scenario_memory_hog.py
@@ -17,6 +17,7 @@ class NodeMemoryHogScenario(Scenario):
     chaos_duration: TotalChaosDurationParameter = TotalChaosDurationParameter()
     node_memory_percentage: NodeMemoryPercentageParameter = NodeMemoryPercentageParameter()
     number_of_workers: NumberOfWorkersParameter = NumberOfWorkersParameter()
+    namespace: NamespaceParameter = NamespaceParameter(value="default")
     node_selector: NodeSelectorParameter = NodeSelectorParameter()
     taint: TaintParameter = TaintParameter()
     number_of_nodes: NumberOfNodesParameter = NumberOfNodesParameter()
@@ -32,6 +33,7 @@ class NodeMemoryHogScenario(Scenario):
             self.chaos_duration,
             self.node_memory_percentage,
             self.number_of_workers,
+            self.namespace,
             self.node_selector,
             self.taint,
             self.number_of_nodes,


### PR DESCRIPTION
### Summary

Node CPU/memory hog scenarios were failing in container execution because the namespace parameter wasn’t being passed, so krkn defaulted to `.*` and the API rejected it. This PR adds an explicit namespace parameter (defaulting to `default`) to both CPU and memory hog scenarios, consistent with the IO hog scenario.

Fixes #67 


### What changed

- Added `namespace` parameter to `NodeCPUHogScenario` and `NodeMemoryHogScenario`
- Included the new parameter in the scenario parameter list so it gets passed to krkn
- Verified locally with unit tests

### Why

Container runs were failing with namespaces `".*"` not found. Explicitly passing a valid namespace fixes the error and keeps behavior consistent across node hog scenarios.

### Testing

- `pytest tests/unit/`
