### PR TITLE
Fix missing live logs when enabling debug verbosity

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -15,7 +15,7 @@ from krkn_ai.models.scenario.base import Scenario, BaseScenario, CompositeDepend
 from krkn_ai.models.scenario.factory import ScenarioFactory
 from krkn_ai.utils import run_shell
 from krkn_ai.utils.fs import env_is_truthy
-from krkn_ai.utils.logger import get_logger
+from krkn_ai.utils.logger import get_logger, is_verbose
 from krkn_ai.utils.prometheus import create_prometheus_client
 from krkn_ai.utils.rng import rng
 
@@ -106,8 +106,8 @@ class KrknRunner:
             # Start watching application urls for health checks
             health_check_watcher.run()
 
-            # Run command
-            log, returncode = run_shell(self.process_es_env_string(command, True), do_not_log=True)
+            # Run command (show logs when verbose mode is enabled)
+            log, returncode = run_shell(self.process_es_env_string(command, True), do_not_log=not is_verbose())
             
             # Extract return code from run log which is part of telemetry data present in the log
             returncode, run_uuid = self.__extract_returncode_from_run(log, returncode)

--- a/krkn_ai/utils/logger.py
+++ b/krkn_ai/utils/logger.py
@@ -5,15 +5,17 @@ from typing import Optional
 
 _LOGGER_INITIALIZED = False
 _LOG_DIR: Optional[str] = None
+_VERBOSE: bool = False
 
 def init_logger(output_dir: Optional[str] = None, verbose: bool = False):
     """Initialize global logger configuration once."""
 
-    global _LOGGER_INITIALIZED, _LOG_DIR
+    global _LOGGER_INITIALIZED, _LOG_DIR, _VERBOSE
     if _LOGGER_INITIALIZED:
         return
 
     _LOG_DIR = output_dir
+    _VERBOSE = verbose
     log_level = logging.DEBUG if verbose else logging.INFO
 
     # Create root-safe parent logger name
@@ -69,3 +71,8 @@ def get_logger(name: str) -> logging.Logger:
 
 def get_log_dir() -> Optional[str]:
     return _LOG_DIR
+
+
+def is_verbose() -> bool:
+    """Return whether verbose mode is enabled."""
+    return _VERBOSE


### PR DESCRIPTION

### Description

This PR fixes the issue where chaos scenario container logs weren't being printed when running with verbose mode (`-vvv`).

Fixes #11
### The Problem

When running `krkn_ai run -vvv`, the debug log level was set correctly, but the actual output from the chaos scenario commands (krknctl/podman) was being silently discarded. This made it difficult to debug scenario execution issues.

### What I Changed

The `run_shell()` function in `krkn_runner.py` was always called with `do_not_log=True`, which suppressed all command output regardless of verbosity settings.

Added `is_verbose()` helper in the logger module and used it to control whether scenario logs get printed.

**Files changed:**
- `krkn_ai/utils/logger.py` - Added `is_verbose()` function
- `krkn_ai/chaos_engines/krkn_runner.py` - Use `is_verbose()` to show logs in verbose mode

### Before

Running with `-vvv` did NOT show the chaos scenario container logs:

```
INFO  | Generation 1 |
INFO  --------------------------------------------------------
INFO  Running scenario: pod-scenarios(robot-shop, service=payment, .*, 1, 60, 60)
INFO  Krkn scenario return code: 0
INFO  Fitness score: 5.0
```

### After

Running with `-vvv` now shows the chaos scenario container logs:

```
INFO  | Generation 1 |
INFO  --------------------------------------------------------
INFO  Running scenario: pod-scenarios(robot-shop, service=payment, .*, 1, 60, 60)
DEBUG Running command: krknctl
DEBUG time="2025-08-04T12:20:31Z" level=info msg="starting pod-scenarios"
DEBUG time="2025-08-04T12:20:31Z" level=info msg="targeting pod payment-5d8cd6f594-8jj9v"
DEBUG time="2025-08-04T12:20:32Z" level=info msg="pod deleted successfully"
DEBUG time="2025-08-04T12:20:32Z" level=info msg="waiting for pod recovery..."
DEBUG time="2025-08-04T12:21:45Z" level=info msg="scenario completed"
INFO  Krkn scenario return code: 0
INFO  Fitness score: 5.0
```

The container output (krknctl scenario execution logs) is now visible when running with verbose mode, making debugging much easier.

### Testing

- All existing tests pass
- Manually verified `-vv` flag now shows container logs

