### PR TITLE
fix: raise ValueError when node metrics not found

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -287,6 +287,8 @@ class ClusterManager:
                 usage_mem = item["usage"]["memory"]    # e.g. "1024Mi"
                 return self.parse_cpu(usage_cpu), self.parse_memory(usage_mem)
 
+        raise ValueError(f"Metrics not found for node: {node}")
+
     @staticmethod
     def parse_cpu(cpu_str: str):
         """


### PR DESCRIPTION
### **User description**
### Description

Fixes implicit `None` return in `__fetch_node_metrics()` that causes `TypeError` when unpacking.

### Problem

The `__fetch_node_metrics()` method in `cluster_manager.py` returned `None` implicitly when a node was not found in the metrics API response. This caused:

```
TypeError: cannot unpack non-iterable NoneType object
```

at line 228 where the caller expects a tuple:
```python
usage_cpu, usage_mem = self.__fetch_node_metrics(node.metadata.name)
```

### Solution

Added explicit `raise ValueError` when node is not found in metrics:

```python
raise ValueError(f"Metrics not found for node: {node}")
```

Closes #85


___

### **PR Type**
Bug fix


___

### **Description**
- Raises ValueError when node metrics not found instead of returning None

- Prevents TypeError when unpacking metrics tuple in caller code

- Fixes implicit None return causing unpacking failures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["__fetch_node_metrics called"] --> B{"Node found in metrics?"}
  B -->|Yes| C["Return cpu, memory tuple"]
  B -->|No| D["Raise ValueError"]
  D --> E["Prevent TypeError on unpacking"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster_manager.py</strong><dd><code>Add ValueError for missing node metrics</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/cluster_manager.py

<ul><li>Added explicit <code>raise ValueError</code> when node is not found in metrics API <br>response<br> <li> Prevents implicit None return that caused TypeError during tuple <br>unpacking<br> <li> Error message includes the node name for debugging</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/86/files#diff-abf857e47ad5265b200c601042a8e5f9edf26341293d54005f63a9e7d591c955">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

