### PR TITLE
fix: health check to use configured status_code instead of hardcoded 200

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -47,7 +47,7 @@ class HealthCheckWatcher:
             try:
                 resp = requests.get(health_check.url, timeout=health_check.timeout)
                 status = resp.status_code
-                success = (status == 200)
+                success = (status == health_check.status_code)
                 error = None
             except Exception as e:
                 status = -1


### PR DESCRIPTION
### **User description**
## Summary

- Fixed bug where health check ignored the configured `status_code` and always compared against 200
- Endpoints returning 201, 204, or other valid success codes now work correctly

Fixes #84
## Problem

The health check config allows users to set a custom `status_code`, but the code was ignoring it:

```yaml
health_checks:
  applications:
    - name: create-api
      url: "http://example.com/api/create"
      status_code: 201  # This was being ignored
```

Line 50 in `health_check_watcher.py` had `success = (status == 200)` hardcoded instead of using the configured value.

## Solution

Changed line 50 from:
```python
success = (status == 200)
```
to:
```python
success = (status == health_check.status_code)
```

## Test plan

- [x] Verified custom status_code 201 is now respected
- [x] Verified default status_code 200 still works
- [x] Verified mismatched codes are correctly marked as failures
- [x] All existing unit tests pass


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed health check to respect configured `status_code` instead of hardcoded 200

- Endpoints returning custom success codes (201, 204, etc.) now work correctly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Health Check Request"] --> B["Get Response Status"]
  B --> C["Compare with Configured status_code"]
  C --> D["Mark as Success/Failure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_check_watcher.py</strong><dd><code>Use configured status_code in health check validation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/health_check_watcher.py

<ul><li>Changed hardcoded status code comparison from 200 to use <br><code>health_check.status_code</code><br> <li> Allows health checks to respect custom configured status codes (201, <br>204, etc.)<br> <li> Fixes bug where non-200 success responses were incorrectly marked as <br>failures</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/88/files#diff-7bc26c6651e54020598e15513a8a7cc0141ee4c00a235cff7f7e73dc3d361b00">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

