### PR TITLE
fix: resolve CSV parser error when scenarios have varying SLO columns

### DIFF
--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -175,8 +175,9 @@ class HealthCheckReporter:
             try:
                 existing_df = pd.read_csv(report_path)
                 df = pd.concat([existing_df, new_row], ignore_index=True)
-            except pd.errors.EmptyDataError:
-                # File exists but is empty
+            except (pd.errors.EmptyDataError, pd.errors.ParserError) as e:
+                # File exists but is empty or malformed, start fresh
+                logger.warning("Could not read existing CSV (%s), starting fresh: %s", report_path, e)
                 df = new_row
         else:
             df = new_row


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes a `pandas.errors.ParserError` that occurred when `sort_fitness_result_csv()` attempted to read a malformed CSV file caused by inconsistent column counts.

Fixes #30
## Problem

When running scenarios (e.g., DNS outage with limited pods), the following error occurred:

```
[INFO] | Generation 2 |
[INFO] --------------------------------------------------------
[INFO] Scenario dns-outage(60, downloads-5559f98db4-h6c2t, openshift-console, false, true, tcp,udp, 53) already evaluated, skipping fitness calculation.
[INFO] Scenario dns-outage(60, downloads-5559f98db4-h6c2t, openshift-console, false, true, tcp,udp, 53) already evaluated, skipping fitness calculation.
[INFO] Best Fitness: 9.000000
[DEBUG] Best generation report saved to ./tmp/results/reports/best_scenarios.yaml
[DEBUG] Saving health check report
[DEBUG] Health check report saved to ./tmp/results/reports/health_check_report.csv
[ERROR] Something went wrong: Error tokenizing data. C error: Expected 4 fields in line 30, saw 8
Traceback (most recent call last):
  File "/home/milei/krkn-ai/krkn_ai/cli/cmd.py", line 81, in run
    genetic.save()
  File "/home/milei/krkn-ai/krkn_ai/algorithm/genetic.py", line 304, in save
    self.health_check_reporter.sort_fitness_result_csv()
  File "/home/milei/krkn-ai/krkn_ai/reporter/health_check_reporter.py", line 162, in sort_fitness_result_csv
    df = pd.read_csv(report_path)
pandas.errors.ParserError: Error tokenizing data. C error: Expected 4 fields in line 30, saw 8
```
## Solution

Changed to a read-concat-write approach that ensures consistent columns across all rows:

```python
# New code
new_row = pd.DataFrame([{...}])

if os.path.isfile(report_path):
    try:
        existing_df = pd.read_csv(report_path)
        df = pd.concat([existing_df, new_row], ignore_index=True)
    except pd.errors.EmptyDataError:
        # File exists but is empty
        df = new_row
else:
    df = new_row

df.to_csv(report_path, index=False)
```

`pd.concat()` automatically aligns columns across DataFrames, filling missing values with NaN. This ensures the CSV always has consistent columns and `sort_fitness_result_csv()` can read it without errors.

## Test Plan

- [x] All existing unit tests pass (8 tests in `test_health_check_reporter.py`)
- [x] All unit tests pass (136 tests total)
- [x] Manually verified fix resolves the ParserError with varying SLO columns


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes CSV parser error from inconsistent column counts across rows

- Replaces append mode with read-concat-write approach for consistency

- Handles empty files and missing columns with automatic NaN filling

- Adds documentation explaining dynamic SLO column handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New fitness result"] --> B["Create new row DataFrame"]
  B --> C{"CSV file exists?"}
  C -->|Yes| D["Read existing CSV"]
  D --> E{"File empty?"}
  E -->|No| F["Concatenate DataFrames"]
  E -->|Yes| G["Use new row only"]
  C -->|No| G
  F --> H["Write consistent CSV"]
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_check_reporter.py</strong><dd><code>Replace append mode with read-concat-write CSV handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/reporter/health_check_reporter.py

<ul><li>Changed <code>write_fitness_result()</code> from append mode to read-concat-write <br>pattern<br> <li> Replaced <code>df.to_csv(..., mode='a', header=not file_exists)</code> with full <br>rewrite approach<br> <li> Added <code>pd.concat()</code> to automatically align columns across DataFrames<br> <li> Added exception handling for empty CSV files<br> <li> Enhanced docstring with explanation of dynamic SLO column handling</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/93/files#diff-10799b92355eb413bc2680369d330b355fc16ff0506639824ccadab9a17ff1e3">+17/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

