### PR TITLE
Refactor Prometheus Client Creation for Better Robustness and Portability

### DIFF
--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -1,5 +1,4 @@
 import os
-import json
 from kubernetes import client, config
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
 from krkn_ai.utils.fs import env_is_truthy

--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -53,14 +53,16 @@ class TestPrometheusUtils:
     @patch("krkn_ai.utils.prometheus.client.CustomObjectsApi")
     @patch("krkn_ai.utils.prometheus.config.new_client_from_config")
     @patch("krkn_ai.utils.prometheus.KrknPrometheus")
-    def test_create_client_autodiscovery_openshift(self, mock_prom_class, mock_new_client, mock_api_class, _, __):
+    def test_create_client_autodiscovery_openshift(
+        self, mock_prom_class, mock_new_client, mock_api_class, _, __
+    ):
         """Should auto-discover URL and token on OpenShift clusters using Python client."""
         # Mock Route discovery
         mock_api = mock_api_class.return_value
         mock_api.list_namespaced_custom_object.return_value = {
             "items": [{"spec": {"host": "thanos-query.apps.cluster.com"}}]
         }
-        
+
         # Mock Token extraction
         mock_api_client = mock_new_client.return_value
         mock_api_client.configuration.api_key = {"authorization": "Bearer k8s-token"}
@@ -93,7 +95,7 @@ class TestPrometheusUtils:
         """Should raise connection error if discovery fails on OpenShift."""
         mock_api = mock_api_class.return_value
         mock_api.list_namespaced_custom_object.side_effect = Exception("API error")
-        
+
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(PrometheusConnectionError) as exc:
                 create_prometheus_client("/tmp/test-kubeconfig")
@@ -106,7 +108,7 @@ class TestPrometheusUtils:
         """Should handle empty route lists gracefully on OpenShift."""
         mock_api = mock_api_class.return_value
         mock_api.list_namespaced_custom_object.return_value = {"items": []}
-        
+
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(PrometheusConnectionError):
                 create_prometheus_client("/tmp/test-kubeconfig")


### PR DESCRIPTION
### Summary
This PR addresses [Issue #98](https://github.com/krkn-chaos/krkn-ai/issues/98) by refactoring the `create_prometheus_client()` function in `krkn_ai/utils/prometheus.py` to use the Kubernetes Python client library instead of shell commands (`kubectl` and `oc`). This improves error handling, eliminates external binary dependencies, and enhances reliability across different environments.

### Key Changes
- **Replaced shell commands with API calls**: 
  - `is_openshift()` now uses `kubernetes.client.CustomObjectsApi` to query cluster versions directly.
  - `_discover_openshift_prometheus_url()` fetches routes via `list_namespaced_custom_object()`.
  - `_discover_openshift_prometheus_token()` extracts tokens from the kubeconfig context instead of running `oc whoami -t`.
- **Enhanced error handling**: Added specific checks for missing routes, invalid tokens, and connection failures with actionable error messages.
- **Updated unit tests**: Modified `tests/unit/utils/test_prometheus.py` to mock the Kubernetes Python client, ensuring comprehensive coverage of all scenarios.
- **Improved logic flow**: Streamlined the discovery priority to avoid unnecessary operations on non-OpenShift clusters.

### Why Shift from kubectl/oc to kubeconfig?
- **Portability**: Eliminates dependency on installed binaries (`kubectl`, `oc`), which may not be available in containerized or minimal environments.
- **Performance**: Direct API calls are faster than spawning subprocesses and parsing stdout.
- **Reliability**: Structured data handling reduces parsing errors; token extraction from kubeconfig is more consistent than CLI commands.
- **Maintainability**: Official Kubernetes Python client provides better exception handling and version compatibility.


### References
- [Kubernetes Python Client Documentation](https://kubernetes.io/docs/reference/python/)

Fixes #98 