### PR TITLE
replace mutable default args with pydatinc Field

### DIFF
--- a/krkn_ai/models/app.py
+++ b/krkn_ai/models/app.py
@@ -25,7 +25,7 @@ class FitnessScoreResult(BaseModel):
 
 
 class FitnessResult(BaseModel):
-    scores: List[FitnessScoreResult] = []
+    scores: List[FitnessScoreResult] = Field(default_factory=list)
     health_check_failure_score: float = 0.0  # Health check failure score
     health_check_response_time_score: float = 0.0  # Health check response time score
     krkn_failure_score: float = 0.0  # Krkn failure score
@@ -42,7 +42,9 @@ class CommandRunResult(BaseModel):
     start_time: datetime.datetime  # Start date timestamp of the test
     end_time: datetime.datetime  # End date timestamp of the test
     fitness_result: FitnessResult  # Fitness result measured for scenario.
-    health_check_results: Dict[str, List[HealthCheckResult]] = {}
+    health_check_results: Dict[str, List[HealthCheckResult]] = Field(
+        default_factory=dict
+    )
     run_uuid: Optional[str] = (
         None  # Unique identifier generated from krkn engine during scenario execution
     )

--- a/krkn_ai/models/cluster_components.py
+++ b/krkn_ai/models/cluster_components.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional, Union
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class Container(BaseModel):
@@ -9,14 +9,14 @@ class Container(BaseModel):
 
 class Pod(BaseModel):
     name: str
-    labels: Dict[str, str] = {}
-    containers: List[Container] = []
+    labels: Dict[str, str] = Field(default_factory=dict)
+    containers: List[Container] = Field(default_factory=list)
     disabled: bool = False
 
 
 class PVC(BaseModel):
     name: str
-    labels: Dict[str, str] = {}
+    labels: Dict[str, str] = Field(default_factory=dict)
     current_usage_percentage: Optional[float] = None
     disabled: bool = False
 
@@ -29,8 +29,8 @@ class ServicePort(BaseModel):
 
 class Service(BaseModel):
     name: str
-    labels: Dict[str, str] = {}
-    ports: List[ServicePort] = []
+    labels: Dict[str, str] = Field(default_factory=dict)
+    ports: List[ServicePort] = Field(default_factory=list)
     disabled: bool = False
 
 
@@ -41,26 +41,26 @@ class VMI(BaseModel):
 
 class Namespace(BaseModel):
     name: str
-    pods: List[Pod] = []
-    services: List[Service] = []
-    pvcs: List[PVC] = []
-    vmis: List[VMI] = []
+    pods: List[Pod] = Field(default_factory=list)
+    services: List[Service] = Field(default_factory=list)
+    pvcs: List[PVC] = Field(default_factory=list)
+    vmis: List[VMI] = Field(default_factory=list)
     disabled: bool = False
 
 
 class Node(BaseModel):
     name: str
-    labels: Dict[str, str] = {}
+    labels: Dict[str, str] = Field(default_factory=dict)
     free_cpu: float = 0
     free_mem: float = 0
-    interfaces: List[str] = []
-    taints: List[str] = []
+    interfaces: List[str] = Field(default_factory=list)
+    taints: List[str] = Field(default_factory=list)
     disabled: bool = False
 
 
 class ClusterComponents(BaseModel):
-    namespaces: List[Namespace] = []
-    nodes: List[Node] = []
+    namespaces: List[Namespace] = Field(default_factory=list)
+    nodes: List[Node] = Field(default_factory=list)
 
     def get_active_components(self) -> "ClusterComponents":
         """

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -112,7 +112,7 @@ class FitnessFunction(BaseModel):
     include_krkn_failure: bool = True
     include_health_check_failure: bool = True
     include_health_check_response_time: bool = True
-    items: List[FitnessFunctionItem] = []
+    items: List[FitnessFunctionItem] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def check_fitness_definition_exists(self):
@@ -139,7 +139,7 @@ class HealthCheckApplicationConfig(BaseModel):
 
 class HealthCheckConfig(BaseModel):
     stop_watcher_on_failure: bool = False
-    applications: List[HealthCheckApplicationConfig] = []
+    applications: List[HealthCheckApplicationConfig] = Field(default_factory=list)
 
 
 class OutputConfig(BaseModel):
@@ -191,7 +191,7 @@ class AdaptiveMutation(BaseModel):
 
 class ConfigFile(BaseModel):
     kubeconfig_file_path: str  # Path to kubeconfig
-    parameters: Dict[str, str] = {}
+    parameters: Dict[str, str] = Field(default_factory=dict)
 
     generations: Optional[int] = (
         20  # Total number of generations to run. Ignored if duration is set.

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Union
+from typing import List, Union, Optional
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
 from krkn_ai.utils import run_shell
@@ -74,8 +74,10 @@ class ClusterManager:
         self,
         namespace: Namespace,
         pod_labels_patterns: Union[str, List[str], None] = None,
-        skip_pod_name_patterns: List[str] = [],
+        skip_pod_name_patterns: Optional[List[str]] = None,
     ) -> List[Pod]:
+        if skip_pod_name_patterns is None:
+            skip_pod_name_patterns = []
         pod_labels_patterns = self.__process_pattern(pod_labels_patterns)
 
         pods = self.core_api.list_namespaced_pod(namespace=namespace.name).items


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace mutable default arguments with Pydantic `Field(default_factory=...)`

- Prevents shared state issues across model instances

- Fixes #97 related to mutable defaults

- Updates multiple model classes across app, cluster components, and config files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mutable Default Args<br/>= [], = {}"] -->|Replace with| B["Field default_factory<br/>list, dict"]
  B -->|Applied to| C["Pydantic Models<br/>app.py, cluster_components.py<br/>config.py, cluster_manager.py"]
  C -->|Result| D["Prevent Shared State<br/>Issues"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Fix mutable defaults in FitnessResult and CommandRunResult</code></dd></summary>
<hr>

krkn_ai/models/app.py

<ul><li>Replace <code>scores: List[FitnessScoreResult] = []</code> with <br><code>Field(default_factory=list)</code><br> <li> Replace <code>health_check_results: Dict[str, List[HealthCheckResult]] = {}</code> <br>with <code>Field(default_factory=dict)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/100/files#diff-92796e26125d1c9690ea0b2139bfc29b880714f1d6ecc2db317c73852da7246e">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cluster_components.py</strong><dd><code>Fix mutable defaults across all cluster component models</code>&nbsp; </dd></summary>
<hr>

krkn_ai/models/cluster_components.py

<ul><li>Add <code>Field</code> import from pydantic<br> <li> Replace mutable defaults in <code>Pod</code> class (labels, containers)<br> <li> Replace mutable defaults in <code>PVC</code> class (labels)<br> <li> Replace mutable defaults in <code>Service</code> class (labels, ports)<br> <li> Replace mutable defaults in <code>Namespace</code> class (pods, services, pvcs, <br>vmis)<br> <li> Replace mutable defaults in <code>Node</code> class (labels, interfaces, taints)<br> <li> Replace mutable defaults in <code>ClusterComponents</code> class (namespaces, <br>nodes)</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/100/files#diff-2727764c31bc854f0cb30faf61a207d200df358728db81c1959cb61898aa1fde">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Fix mutable defaults in fitness and health check config models</code></dd></summary>
<hr>

krkn_ai/models/config.py

<ul><li>Replace <code>items: List[FitnessFunctionItem] = []</code> with <br><code>Field(default_factory=list)</code> in <code>FitnessFunction</code><br> <li> Replace <code>applications: List[HealthCheckApplicationConfig] = []</code> with <br><code>Field(default_factory=list)</code> in <code>HealthCheckConfig</code><br> <li> Replace <code>parameters: Dict[str, str] = {}</code> with <br><code>Field(default_factory=dict)</code> in <code>ConfigFile</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/100/files#diff-ace9d17bb9da13204eb3951dcc7c3d8c621232ebab65c7a94b6a59839899fe01">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cluster_manager.py</strong><dd><code>Fix mutable default argument in list_pods method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/cluster_manager.py

<ul><li>Add <code>Optional</code> import from typing<br> <li> Change <code>skip_pod_name_patterns</code> parameter from mutable default <code>[]</code> to <br><code>Optional[List[str]] = None</code><br> <li> Add None check and initialize empty list inside method body</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/100/files#diff-abf857e47ad5265b200c601042a8e5f9edf26341293d54005f63a9e7d591c955">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

