### PR TITLE
feat: add issue comment command bot for assignment, labels and state management

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -40,7 +40,7 @@ jobs:
 
             // Known commands that are NOT label shortcuts
             const knownCommands = new Set([
-              'assign', 'unassign', 'label', 'unlabel', 
+              'assign', 'unassign', 'label', 'unlabel',
               'close', 'reopen', 'help'
             ]);
 
@@ -50,14 +50,14 @@ jobs:
 
             async function ensureLabelsLoaded() {
               if (labelMap !== null) return;
-              
+
               // Paginate to fetch all labels (handles repos with >100 labels)
               repoLabels = await github.paginate(github.rest.issues.listLabelsForRepo, {
                 owner,
                 repo,
                 per_page: 100
               });
-              
+
               labelMap = new Map();
               for (const label of repoLabels) {
                 const commandName = label.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
@@ -79,7 +79,7 @@ jobs:
 
             async function hasWritePermission(username) {
               if (cachedPermission !== null) return cachedPermission;
-              
+
               try {
                 const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner,
@@ -224,7 +224,7 @@ jobs:
                     });
 
                     actualLabel = inputLabel;
-                    
+
                     // Invalidate cache so the new label is available
                     labelMap = null;
                     repoLabels = null;
@@ -291,7 +291,7 @@ jobs:
                 if (isCommand(line, "close")) {
                   const isIssueAuthor = issue.user.login.toLowerCase() === commenter.toLowerCase();
                   const hasMaintainerAccess = await hasWritePermission(commenter);
-                  
+
                   if (!isIssueAuthor && !hasMaintainerAccess) {
                     responses.push("Only maintainers or the issue author can close this issue.");
                     continue;


### PR DESCRIPTION
### **User description**
## Summary

Implements an issue management bot that enables contributors and maintainers to manage issues through comment commands. 

Fixes #91
## Features

### Assignment Commands
| Command | Description | Who Can Use |
|---------|-------------|-------------|
| `/assign` | Self-assign to an issue | Issue author or users with write access |
| `/assign @user` | Assign another user | Maintainers only |
| `/unassign` | Remove yourself | Anyone assigned |
| `/unassign @user` | Remove another user | Maintainers only |

### Label Commands  
| Command | Description | Who Can Use |
|---------|-------------|-------------|
| `/label <name>` | Add a label | Maintainers only |
| `/unlabel <name>` | Remove a label | Maintainers only |
| `/<label-name>` | Shortcut to add label (e.g., `/bug`) | Maintainers only |

### Issue State Commands
| Command | Description | Who Can Use |
|---------|-------------|-------------|
| `/close` | Close the issue | Maintainers only |
| `/reopen` | Reopen the issue | Maintainers only |
| `/help` | Show available commands | Anyone |

## Implementation Details

- **Single workflow file**: `.github/workflows/issue-bot.yml`
- **Efficient API usage**: Lazy-loads labels only when needed, caches permission checks
- **Pagination support**: Handles repositories with 100+ labels
- **Graceful error handling**: Provides informative messages when GitHub API restrictions apply
- **Multiple commands**: Supports multiple commands in a single comment (one per line)
- **Aggregated responses**: Bot replies with a single comment containing all responses

## Permission Handling

GitHub's API only allows assigning users who:
1. Created the issue (can always self-assign to their own issue)
2. Have write/admin access to the repository
3. Are organization members with appropriate permissions

For first-time contributors on issues they didn't create, the bot responds with a helpful message explaining the limitation and indicates a maintainer will assist.

## Testing

1. Create a new issue and comment `/assign` → Should assign yourself 
2. Comment `/help` → Should display available commands 
3. Comment `/bug` (if label exists) → Should add label (maintainers) or show permission error 
4. On someone else's issue, comment `/assign` → Should explain GitHub's limitation


___

### **PR Type**
Enhancement


___

### **Description**
- Implements comprehensive issue management bot with command support

- Supports assignment, labeling, and state management via comments

- Enables label shortcuts and dynamic command recognition

- Includes permission-based access control and error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Issue Comment Created"] --> B["Parse Commands"]
  B --> C["Permission Check"]
  C --> D["Execute Commands"]
  D --> E["Assignment/Labels/State"]
  E --> F["Aggregate Response"]
  F --> G["Post Single Comment"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue-bot.yml</strong><dd><code>Complete issue bot workflow implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/issue-bot.yml

<ul><li>Implements GitHub Actions workflow triggered on issue comments<br> <li> Supports <code>/assign</code>, <code>/unassign</code>, <code>/label</code>, <code>/unlabel</code>, <code>/close</code>, <code>/reopen</code>, and <br><code>/help</code> commands<br> <li> Includes lazy-loaded label caching with pagination for repositories <br>with 100+ labels<br> <li> Implements permission-based access control with cached permission <br>checks<br> <li> Handles dynamic label shortcuts (e.g., <code>/bug</code>) and aggregates responses <br>into single comment<br> <li> Provides graceful error handling for GitHub API restrictions and <br>unknown commands</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/101/files#diff-54f11fea131284994a8a8ecc407887000d9afe4def86bac1fcf73d6aa1afb759">+435/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

