### PR TITLE
Fix zombie health check watcher threads on krkn runner failures

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -118,11 +118,14 @@ class KrknRunner:
             try:
                 # Run command (show logs when verbose mode is enabled)
                 log, returncode = run_shell(
-                    self.process_es_env_string(command, True), do_not_log=not is_verbose()
+                    self.process_es_env_string(command, True),
+                    do_not_log=not is_verbose(),
                 )
 
                 # Extract return code from run log which is part of telemetry data present in the log
-                returncode, run_uuid = self.__extract_returncode_from_run(log, returncode)
+                returncode, run_uuid = self.__extract_returncode_from_run(
+                    log, returncode
+                )
                 logger.info("Krkn scenario return code: %d", returncode)
 
             finally:

--- a/tests/test_krkn_runner_leak.py
+++ b/tests/test_krkn_runner_leak.py
@@ -1,20 +1,22 @@
 import unittest
 from unittest.mock import MagicMock, patch
-import sys
 
 
 from krkn_ai.chaos_engines.krkn_runner import KrknRunner
 from krkn_ai.models.config import ConfigFile, FitnessFunction, HealthCheckConfig
 
+
 class TestKrknRunnerThreadLeak(unittest.TestCase):
-    @patch('krkn_ai.chaos_engines.krkn_runner.create_prometheus_client')
-    @patch('krkn_ai.chaos_engines.krkn_runner.HealthCheckWatcher')
-    @patch('krkn_ai.chaos_engines.krkn_runner.run_shell') 
-    def test_run_shell_exception_cleanup(self, mock_run_shell, mock_watcher_cls, mock_create_prom):
+    @patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client")
+    @patch("krkn_ai.chaos_engines.krkn_runner.HealthCheckWatcher")
+    @patch("krkn_ai.chaos_engines.krkn_runner.run_shell")
+    def test_run_shell_exception_cleanup(
+        self, mock_run_shell, mock_watcher_cls, mock_create_prom
+    ):
         # Setup mocks
         mock_watcher = MagicMock()
         mock_watcher_cls.return_value = mock_watcher
-        
+
         # Configure run_shell to return success by default (for init checks)
         mock_run_shell.return_value = ("output", 0)
 
@@ -25,16 +27,16 @@ class TestKrknRunnerThreadLeak(unittest.TestCase):
         config.health_checks = MagicMock(spec=HealthCheckConfig)
         config.elastic = None
         config.wait_duration = 10
-        
+
         from krkn_ai.models.scenario.base import Scenario
-        
+
         runner = KrknRunner(config, "output_dir")
-        
+
         # Create a dummy scenario
         scenario = MagicMock(spec=Scenario)
         scenario.parameters = []
         scenario.krknctl_name = "test-scenario"
-        
+
         # Now make run_shell crash
         mock_run_shell.side_effect = Exception("Simulated Shell Crash")
 
@@ -43,16 +45,17 @@ class TestKrknRunnerThreadLeak(unittest.TestCase):
             runner.run(scenario, 1)
         except Exception as e:
             print(f"[INFO] Caught expected exception: {e}")
-            
+
         # Verification
         print("[VERIFY] Checking if HealthCheckWatcher.stop() was called...")
-        
+
         # Assert that stop was called
         mock_watcher.stop.assert_called_once()
         print("[SUCCESS] stop() WAS called. Thread leak prevented.")
-            
+
         # Verify run() was also called
         mock_watcher.run.assert_called()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### **User description**
## Fix: Zombie Background Thread Leak in `krkn_runner`

### Summary
This PR fixes a **critical background thread leak** in `krkn_runner.py` where the `health_check_watcher` thread could remain alive if the krkn subprocess crashes, hangs, or raises an exception.  
The issue causes **zombie threads**, resource leaks, and non-terminating `krkn-ai run` executions in real production environments.

The fix ensures that **all background threads are always stopped**, even when failures occur.

---

### Problem Description

**File:** `krkn_ai/runner/krkn_runner.py`  
**Component:** `health_check_watcher` lifecycle management

The runner starts a background health check watcher thread before launching the krkn subprocess.  
However, if the subprocess crashes or exits unexpectedly, the watcher thread is **never stopped**.

#### Root Cause
The watcher lifecycle was **not guarded by `try...finally`**, so any exception or early exit skips the cleanup path.

This leads to:
- Orphaned threads
- Hung CLI execution
- Resource exhaustion over multiple runs
- CI pipelines never completing

---

### Why This Is Critical

- **Affects real users** running `krkn-ai run` in staging and production clusters
- Causes **silent hangs** instead of clean failures
- Makes chaos experiments **non-deterministic**
- Breaks automation, CI jobs, and long-running discovery runs
- Accumulates leaked threads over repeated executions

This is not theoretical — subprocess crashes and SIGINT/SIGTERM are common in chaos workflows.

---

###  How to Reproduce (Realistic)

1. Run `krkn-ai run` with a valid scenario.
2. Force the krkn subprocess to crash or exit early:
   - Kill the process
   - Inject an invalid scenario
   - Trigger a runtime exception
3. Observe:
   - Main process exits
   - Background `health_check_watcher` thread remains alive
   - CLI hangs or never fully terminates

---

###  Fix Applied

- Wrapped the runner execution logic in a **`try...finally` block**
- Ensured `health_check_watcher.stop()` is **always called**
- Guarantees cleanup on:
  - Exceptions
  - Subprocess crashes
  - User interrupts (SIGINT / SIGTERM)

This preserves existing behavior while making cleanup deterministic.

---


---

###  Impact After Fix

- No more zombie background threads
- Clean shutdowns on failures
- Stable CI and automation
- Predictable chaos experiment behavior
- Improved reliability for long-running discovery runs

---

###  Files Changed

- `krkn_ai/runner/krkn_runner.py`
- `tests/test_krkn_runner_leak.py`
- `walkthrough.md` (documentation)

---


###  Regression Test Added

**New test:** `tests/test_krkn_runner_leak.py`

The test:
- Simulates a krkn subprocess failure
- Verifies the watcher thread is stopped
- Fails on current `main`, passes with this fix

This prevents future regressions.
<img width="876" height="280" alt="image" src="https://github.com/user-attachments/assets/0f917366-4b5f-47e0-a049-30fd313c5289" />


###  Severity
**High — Production impacting**

---


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Wrap runner execution in try-finally block to ensure cleanup

- Prevent zombie health_check_watcher threads on subprocess failures

- Add regression test simulating subprocess crash scenarios

- Guarantee thread cleanup on exceptions, crashes, and interrupts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["health_check_watcher.run()"] --> B["try block"]
  B --> C["run_shell command"]
  C --> D["Extract returncode"]
  D --> E["finally block"]
  C -->|Exception| E
  E --> F["health_check_watcher.stop()"]
  F --> G["Cleanup guaranteed"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>krkn_runner.py</strong><dd><code>Add try-finally for guaranteed watcher cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/krkn_runner.py

<ul><li>Wrapped runner execution logic in try-finally block<br> <li> Moved health_check_watcher.stop() to finally clause<br> <li> Ensures cleanup on subprocess crashes, exceptions, and interrupts<br> <li> Preserves existing behavior while making cleanup deterministic</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/112/files#diff-0cda393c52fddf48cdec219c4a67270901bbdf21e5820c13f650eca73463332f">+11/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_krkn_runner_leak.py</strong><dd><code>Add test for health check watcher cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_krkn_runner_leak.py

<ul><li>New regression test for thread leak prevention<br> <li> Mocks HealthCheckWatcher and run_shell to simulate subprocess failure<br> <li> Verifies stop() is called even when run_shell raises exception<br> <li> Prevents future regressions of zombie thread issues</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/112/files#diff-7a13e2b2a9ac87e1b12a6afd2968f285231d5db3ccf285984997e0629df66dcb">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

