### PR TITLE
Refactor node selection logic into reusable helper and fix inconsistent error handling

### DIFF
--- a/krkn_ai/models/scenario/scenario_cpu_hog.py
+++ b/krkn_ai/models/scenario/scenario_cpu_hog.py
@@ -1,17 +1,14 @@
-from collections import Counter
-import json
-
-from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
 from krkn_ai.models.scenario.parameters import (
     HogScenarioImageParameter,
-    NodeCPUPercentageParameter,
     NamespaceParameter,
+    NodeCPUPercentageParameter,
     NodeSelectorParameter,
     NumberOfNodesParameter,
     TaintParameter,
     TotalChaosDurationParameter,
 )
+from krkn_ai.utils.node_selector import select_nodes
 
 
 class NodeCPUHogScenario(Scenario):
@@ -46,49 +43,12 @@ class NodeCPUHogScenario(Scenario):
         ]
 
     def mutate(self):
+        """Mutate scenario parameters with random node selection."""
         nodes = self._cluster_components.nodes
+        selection = select_nodes(nodes, scenario_name=self.name)
 
-        # scenario 1: Select a random node
-        if rng.random() < 0.5:
-            node = rng.choice(nodes)
-            self.node_selector.value = f"kubernetes.io/hostname={node.name}"
-            self.number_of_nodes.value = 1
-            # Set taints for the selected node
-            self.taint.value = json.dumps(node.taints) if node.taints else "[]"
-            # self.node_cpu_core.value = node.free_cpu * 0.001  # convert to cores from millicores
-        else:
-            # scenario 2: Select a label
-            all_labels = Counter()
-            for node in nodes:
-                for label, value in node.labels.items():
-                    all_labels[f"{label}={value}"] += 1
-            label = rng.choice(list(all_labels.keys()))
-            self.node_selector.value = label
-            self.number_of_nodes.value = rng.randint(1, all_labels[label])
-
-            # Get taints from matching nodes
-            key, value = label.split("=", 1)
-            matching_nodes = [n for n in nodes if n.labels.get(key) == value]
-
-            # Collect all unique taints from matching nodes
-            all_taints = []
-            seen = set()
-            for node in matching_nodes:
-                if node.taints:
-                    for taint in node.taints:
-                        if taint not in seen:
-                            seen.add(taint)
-                            all_taints.append(taint)
-
-            self.taint.value = json.dumps(all_taints) if all_taints else "[]"
-
-            # get the minimum free cpu core for the selected label
-            # min_cpu_core_milli = float('inf')
-            # for node in nodes:
-            #     if label in node.labels and node.labels[label] == label.split("=")[1]:
-            #         min_cpu_core_milli = min(min_cpu_core_milli, node.free_cpu)
-            # if min_cpu_core_milli == float('inf'):
-            #     min_cpu_core_milli = 2000 # 2000m CPU
-            # self.node_cpu_core.value = min_cpu_core_milli * 0.001  # convert to cores from millicores
+        self.node_selector.value = selection.node_selector
+        self.number_of_nodes.value = selection.number_of_nodes
+        self.taint.value = selection.taints_json
 
         self.node_cpu_percentage.mutate()

--- a/krkn_ai/models/scenario/scenario_io_hog.py
+++ b/krkn_ai/models/scenario/scenario_io_hog.py
@@ -1,7 +1,3 @@
-from collections import Counter
-import json
-
-from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
 from krkn_ai.models.scenario.parameters import (
     HogScenarioImageParameter,
@@ -15,7 +11,7 @@ from krkn_ai.models.scenario.parameters import (
     TaintParameter,
     TotalChaosDurationParameter,
 )
-from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.node_selector import select_nodes
 
 
 class NodeIOHogScenario(Scenario):
@@ -54,46 +50,13 @@ class NodeIOHogScenario(Scenario):
         ]
 
     def mutate(self):
+        """Mutate scenario parameters with random node selection."""
         nodes = self._cluster_components.nodes
+        selection = select_nodes(nodes, scenario_name=self.name)
 
-        if len(nodes) == 0:
-            raise ScenarioParameterInitError(
-                "No nodes found in cluster components for node-io-hog scenario"
-            )
-
-        all_labels = Counter()
-        for node in nodes:
-            for label, value in node.labels.items():
-                all_labels[f"{label}={value}"] += 1
-
-        # scenario 1: Select a random node
-        if rng.random() < 0.5 or len(all_labels) == 0:
-            node = rng.choice(nodes)
-            self.node_selector.value = f"kubernetes.io/hostname={node.name}"
-            self.number_of_nodes.value = 1
-            # Set taints for the selected node
-            self.taint.value = json.dumps(node.taints) if node.taints else "[]"
-        else:
-            # scenario 2: Select a label
-            label = rng.choice(list(all_labels.keys()))
-            self.node_selector.value = label
-            self.number_of_nodes.value = rng.randint(1, all_labels[label])
-
-            # Get taints from matching nodes
-            key, value = label.split("=", 1)
-            matching_nodes = [n for n in nodes if n.labels.get(key) == value]
-
-            # Collect all unique taints from matching nodes
-            all_taints = []
-            seen = set()
-            for node in matching_nodes:
-                if node.taints:
-                    for taint in node.taints:
-                        if taint not in seen:
-                            seen.add(taint)
-                            all_taints.append(taint)
-
-            self.taint.value = json.dumps(all_taints) if all_taints else "[]"
+        self.node_selector.value = selection.node_selector
+        self.number_of_nodes.value = selection.number_of_nodes
+        self.taint.value = selection.taints_json
 
         self.io_workers.mutate()
         self.io_write_bytes.mutate()

--- a/krkn_ai/utils/node_selector.py
+++ b/krkn_ai/utils/node_selector.py
@@ -1,0 +1,130 @@
+"""
+Node selection utilities for chaos engineering scenarios.
+
+This module provides reusable functions for selecting nodes by hostname or label,
+collecting unique taints, and building node selector strings for Kubernetes.
+"""
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List
+
+from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.rng import rng
+
+if TYPE_CHECKING:
+    from krkn_ai.models.cluster_components import Node
+
+
+@dataclass
+class NodeSelectionResult:
+    """Result of node selection containing selector, count, and taints."""
+
+    node_selector: str
+    number_of_nodes: int
+    taints_json: str
+
+
+def collect_unique_taints(nodes: List["Node"]) -> List[str]:
+    """
+    Collect unique taints from a list of nodes, preserving order.
+
+    Args:
+        nodes: List of Node objects to collect taints from.
+
+    Returns:
+        List of unique taint strings in order of first occurrence.
+    """
+    seen = set()
+    unique_taints = []
+    for node in nodes:
+        if node.taints:
+            for taint in node.taints:
+                if taint not in seen:
+                    seen.add(taint)
+                    unique_taints.append(taint)
+    return unique_taints
+
+
+def build_label_counter(nodes: List["Node"]) -> Counter:
+    """
+    Build a Counter of all label=value pairs across nodes.
+
+    Args:
+        nodes: List of Node objects to analyze.
+
+    Returns:
+        Counter mapping "label=value" strings to their frequency.
+    """
+    all_labels: Counter = Counter()
+    for node in nodes:
+        for label, value in node.labels.items():
+            all_labels[f"{label}={value}"] += 1
+    return all_labels
+
+
+def get_nodes_matching_label(nodes: List["Node"], label_selector: str) -> List["Node"]:
+    """
+    Get all nodes matching a label=value selector.
+
+    Args:
+        nodes: List of Node objects to filter.
+        label_selector: String in "key=value" format.
+
+    Returns:
+        List of nodes where labels[key] == value.
+    """
+    key, value = label_selector.split("=", 1)
+    return [n for n in nodes if n.labels.get(key) == value]
+
+
+def select_nodes(nodes: List["Node"], scenario_name: str = "node-hog") -> NodeSelectionResult:
+    """
+    Randomly select nodes by hostname or by label.
+
+    This function implements a random selection strategy:
+    - 50% chance: Select a single node by its hostname
+    - 50% chance: Select nodes by a random label (if labels exist)
+
+    Args:
+        nodes: List of available Node objects.
+        scenario_name: Name of the scenario for error messages.
+
+    Returns:
+        NodeSelectionResult containing:
+            - node_selector: Kubernetes node selector string
+            - number_of_nodes: Count of nodes to target
+            - taints_json: JSON string of deduplicated taints
+
+    Raises:
+        ScenarioParameterInitError: If the nodes list is empty.
+    """
+    if not nodes:
+        raise ScenarioParameterInitError(
+            f"No nodes found in cluster components for {scenario_name} scenario"
+        )
+
+    all_labels = build_label_counter(nodes)
+
+    # Strategy: 50% single node by hostname, 50% by label (if labels available)
+    select_by_hostname = rng.random() < 0.5 or len(all_labels) == 0
+
+    if select_by_hostname:
+        node = rng.choice(nodes)
+        return NodeSelectionResult(
+            node_selector=f"kubernetes.io/hostname={node.name}",
+            number_of_nodes=1,
+            taints_json=json.dumps(node.taints) if node.taints else "[]",
+        )
+
+    # Select by label
+    label = rng.choice(list(all_labels.keys()))
+    matching_nodes = get_nodes_matching_label(nodes, label)
+    unique_taints = collect_unique_taints(matching_nodes)
+
+    return NodeSelectionResult(
+        node_selector=label,
+        number_of_nodes=rng.randint(1, all_labels[label]),
+        taints_json=json.dumps(unique_taints) if unique_taints else "[]",
+    )

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -127,6 +127,13 @@ class TestNodeCPUHogScenario:
         assert scenario.node_cpu_percentage.value <= 100
         assert scenario.number_of_nodes.value >= 1
 
+    def test_node_cpu_hog_scenario_raises_error_when_no_nodes(self):
+        """Test that NodeCPUHogScenario raises error when no nodes exist"""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+
+        with pytest.raises(ScenarioParameterInitError, match="No nodes found"):
+            NodeCPUHogScenario(cluster_components=cluster)
+
 
 class TestAppOutageScenario:
     """Test AppOutageScenario class"""

--- a/tests/unit/utils/test_node_selector.py
+++ b/tests/unit/utils/test_node_selector.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for the node_selector utility module.
+"""
+
+import json
+import pytest
+
+from krkn_ai.models.cluster_components import Node
+from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.node_selector import (
+    NodeSelectionResult,
+    build_label_counter,
+    collect_unique_taints,
+    get_nodes_matching_label,
+    select_nodes,
+)
+
+
+class TestCollectUniqueTaints:
+    """Tests for collect_unique_taints function"""
+
+    def test_collects_taints_from_single_node(self):
+        """Test collecting taints from a single node"""
+        nodes = [Node(name="node1", taints=["NoSchedule:key=val"])]
+        result = collect_unique_taints(nodes)
+        assert result == ["NoSchedule:key=val"]
+
+    def test_deduplicates_taints_across_nodes(self):
+        """Test that duplicate taints are removed"""
+        nodes = [
+            Node(name="node1", taints=["NoSchedule:key=val"]),
+            Node(name="node2", taints=["NoSchedule:key=val", "NoExecute:other=val"]),
+        ]
+        result = collect_unique_taints(nodes)
+        assert len(result) == 2
+        assert "NoSchedule:key=val" in result
+        assert "NoExecute:other=val" in result
+
+    def test_preserves_order_of_first_occurrence(self):
+        """Test that taints are returned in order of first occurrence"""
+        nodes = [
+            Node(name="node1", taints=["taint-a", "taint-b"]),
+            Node(name="node2", taints=["taint-c", "taint-a"]),
+        ]
+        result = collect_unique_taints(nodes)
+        assert result == ["taint-a", "taint-b", "taint-c"]
+
+    def test_handles_empty_nodes_list(self):
+        """Test with no nodes"""
+        assert collect_unique_taints([]) == []
+
+    def test_handles_nodes_without_taints(self):
+        """Test with nodes that have no taints"""
+        nodes = [Node(name="node1", taints=[]), Node(name="node2", taints=[])]
+        assert collect_unique_taints(nodes) == []
+
+
+class TestBuildLabelCounter:
+    """Tests for build_label_counter function"""
+
+    def test_counts_labels_correctly(self):
+        """Test that labels are counted correctly"""
+        nodes = [
+            Node(name="node1", labels={"env": "prod", "zone": "us-west"}),
+            Node(name="node2", labels={"env": "prod", "zone": "us-east"}),
+            Node(name="node3", labels={"env": "dev"}),
+        ]
+        result = build_label_counter(nodes)
+        assert result["env=prod"] == 2
+        assert result["env=dev"] == 1
+        assert result["zone=us-west"] == 1
+        assert result["zone=us-east"] == 1
+
+    def test_handles_empty_nodes_list(self):
+        """Test with no nodes"""
+        result = build_label_counter([])
+        assert len(result) == 0
+
+    def test_handles_nodes_without_labels(self):
+        """Test with nodes that have no labels"""
+        nodes = [Node(name="node1", labels={})]
+        result = build_label_counter(nodes)
+        assert len(result) == 0
+
+
+class TestGetNodesMatchingLabel:
+    """Tests for get_nodes_matching_label function"""
+
+    def test_returns_matching_nodes(self):
+        """Test that correct nodes are returned"""
+        nodes = [
+            Node(name="node1", labels={"env": "prod"}),
+            Node(name="node2", labels={"env": "prod"}),
+            Node(name="node3", labels={"env": "dev"}),
+        ]
+        result = get_nodes_matching_label(nodes, "env=prod")
+        assert len(result) == 2
+        assert all(n.labels["env"] == "prod" for n in result)
+
+    def test_returns_empty_list_when_no_match(self):
+        """Test with no matching nodes"""
+        nodes = [Node(name="node1", labels={"env": "dev"})]
+        result = get_nodes_matching_label(nodes, "env=prod")
+        assert result == []
+
+    def test_handles_label_with_equals_in_value(self):
+        """Test labels where value contains equals sign"""
+        nodes = [Node(name="node1", labels={"key": "val=ue"})]
+        result = get_nodes_matching_label(nodes, "key=val=ue")
+        assert len(result) == 1
+
+
+class TestSelectNodes:
+    """Tests for select_nodes function"""
+
+    def test_raises_error_on_empty_nodes(self):
+        """Test that ScenarioParameterInitError is raised for empty nodes"""
+        with pytest.raises(ScenarioParameterInitError, match="No nodes found"):
+            select_nodes([], scenario_name="test-scenario")
+
+    def test_includes_scenario_name_in_error(self):
+        """Test that error message includes the scenario name"""
+        with pytest.raises(ScenarioParameterInitError, match="my-scenario"):
+            select_nodes([], scenario_name="my-scenario")
+
+    def test_returns_node_selection_result(self):
+        """Test that result is a NodeSelectionResult"""
+        nodes = [Node(name="node1", labels={"env": "prod"})]
+        result = select_nodes(nodes)
+        assert isinstance(result, NodeSelectionResult)
+
+    def test_result_has_valid_node_selector(self):
+        """Test that node_selector is a non-empty string"""
+        nodes = [Node(name="node1", labels={"env": "prod"})]
+        result = select_nodes(nodes)
+        assert isinstance(result.node_selector, str)
+        assert len(result.node_selector) > 0
+
+    def test_result_has_valid_number_of_nodes(self):
+        """Test that number_of_nodes is a positive integer"""
+        nodes = [Node(name="node1", labels={"env": "prod"})]
+        result = select_nodes(nodes)
+        assert result.number_of_nodes >= 1
+
+    def test_result_has_valid_json_taints(self):
+        """Test that taints_json is valid JSON"""
+        nodes = [Node(name="node1", labels={"env": "prod"}, taints=["taint1"])]
+        result = select_nodes(nodes)
+        parsed = json.loads(result.taints_json)
+        assert isinstance(parsed, list)
+
+    def test_single_node_selection_returns_hostname_selector(self):
+        """Test that single node selection uses kubernetes.io/hostname"""
+        nodes = [Node(name="my-node", labels={})]  # No labels forces hostname selection
+        result = select_nodes(nodes)
+        assert result.node_selector == "kubernetes.io/hostname=my-node"
+        assert result.number_of_nodes == 1
+
+    def test_single_node_selection_includes_node_taints(self):
+        """Test that single node selection includes the node's taints"""
+        nodes = [Node(name="node1", labels={}, taints=["NoSchedule:key=val"])]
+        result = select_nodes(nodes)
+        taints = json.loads(result.taints_json)
+        assert "NoSchedule:key=val" in taints
+
+    def test_empty_taints_returns_empty_json_array(self):
+        """Test that empty taints returns '[]'"""
+        nodes = [Node(name="node1", labels={}, taints=[])]
+        result = select_nodes(nodes)
+        assert result.taints_json == "[]"


### PR DESCRIPTION
### **User description**
# Refactor and deduplicate node selection logic in node hog scenarios

## Summary

This PR removes duplicated node label / taint selection logic from node hog scenarios by extracting it into a shared helper module.

Previously, `NodeCPUHogScenario` and `NodeIOHogScenario` each implemented their own (nearly identical) logic for:
- Selecting nodes by hostname or label
- Counting label frequencies
- Collecting and deduplicating taints
- Handling empty node lists (inconsistently)

This refactor centralizes the logic, fixes inconsistent error handling, and significantly improves maintainability and testability.

Fixes: https://github.com/krkn-chaos/krkn-ai/issues/104

---

## Problem

- ~80 lines of duplicated logic across CPU and IO node hog scenarios
- Inconsistent behavior:
  - `NodeIOHogScenario` raised an error when no nodes existed
  - `NodeCPUHogScenario` silently proceeded
- Node selection logic was tightly coupled to scenario classes, making it hard to test and evolve

---

## Solution

### 1. New helper module

Added `krkn_ai/utils/node_selector.py` which provides:
- `select_nodes()` — shared node selection strategy
- `NodeSelectionResult` dataclass:
  - `node_selector`
  - `number_of_nodes`
  - `taints_json`
- Helper utilities for:
  - Label counting
  - Matching nodes by label
  - Deduplicating taints

Behavior:
- Raises `ScenarioParameterInitError` when no nodes are present
- Randomly selects between hostname-based or label-based selection
- Falls back safely when no labels exist
- Deduplicates taints across matching nodes

---

### 2. Scenario refactors

#### NodeCPUHogScenario
- Removed duplicated label / taint logic
- Delegates selection to `select_nodes()`
- Now correctly errors when no nodes are available

#### NodeIOHogScenario
- Simplified `mutate()` implementation
- Uses shared helper for consistent behavior

---

## Steps to Reproduce (Before)

1. Create a cluster with no nodes
2. Initialize `NodeCPUHogScenario`
3. Scenario initializes without error (inconsistent behavior)
4. Node selection logic duplicated across scenarios

---

## Steps to Verify (After)

1. Create a cluster with no nodes
2. Initialize either `NodeCPUHogScenario` or `NodeIOHogScenario`
3. `ScenarioParameterInitError` is raised consistently
4. Node selection behavior is identical across both scenarios
5. All existing and new unit tests pass

---

## Tests Added

- New unit tests for `node_selector` helper module
- Added test ensuring `NodeCPUHogScenario` errors when no nodes exist
- Full test suite passes
<img width="1007" height="348" alt="image" src="https://github.com/user-attachments/assets/94e8f0db-00c5-4a4b-933d-95eda8a7d08a" />


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Extract duplicated node selection logic into reusable `select_nodes()` helper module

- Fix inconsistent error handling: both scenarios now raise error when no nodes exist

- Simplify `NodeCPUHogScenario` and `NodeIOHogScenario` by delegating to shared utility

- Add comprehensive unit tests for node selector helper and CPU hog scenario


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NodeCPUHogScenario<br/>NodeIOHogScenario"] -->|"delegates to"| B["select_nodes()"]
  B -->|"uses"| C["build_label_counter()"]
  B -->|"uses"| D["get_nodes_matching_label()"]
  B -->|"uses"| E["collect_unique_taints()"]
  B -->|"returns"| F["NodeSelectionResult"]
  F -->|"contains"| G["node_selector<br/>number_of_nodes<br/>taints_json"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>node_selector.py</strong><dd><code>New node selector utility module with shared logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/node_selector.py

<ul><li>New utility module providing reusable node selection logic<br> <li> Implements <code>select_nodes()</code> function with 50/50 hostname vs label <br>selection strategy<br> <li> Provides helper functions: <code>build_label_counter()</code>, <br><code>get_nodes_matching_label()</code>, <code>collect_unique_taints()</code><br> <li> Defines <code>NodeSelectionResult</code> dataclass to encapsulate selection results<br> <li> Raises <code>ScenarioParameterInitError</code> when no nodes are available</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/113/files#diff-033d4aece6352fd221c576a2b193f4eb62388d9991fdd72df01b00a5e9701fff">+130/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactor</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>scenario_cpu_hog.py</strong><dd><code>Refactor to use shared node selector helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/models/scenario/scenario_cpu_hog.py

<ul><li>Remove ~60 lines of duplicated node selection and taint handling logic<br> <li> Replace with single call to <code>select_nodes()</code> helper function<br> <li> Simplify <code>mutate()</code> method to delegate node selection to shared utility<br> <li> Now consistently raises error when no nodes exist (previously silent)<br> <li> Remove unused imports: <code>Counter</code>, <code>json</code>, <code>rng</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/113/files#diff-7ba0ab03f856239a3259bf692e1f9dab3190cf62b4242fb8c4f8c56c91193502">+7/-47</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>scenario_io_hog.py</strong><dd><code>Refactor to use shared node selector helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/models/scenario/scenario_io_hog.py

<ul><li>Remove ~55 lines of duplicated node selection and taint handling logic<br> <li> Replace with single call to <code>select_nodes()</code> helper function<br> <li> Simplify <code>mutate()</code> method implementation<br> <li> Remove explicit error handling (now handled by <code>select_nodes()</code>)<br> <li> Remove unused imports: <code>Counter</code>, <code>json</code>, <code>rng</code>, <code>ScenarioParameterInitError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/113/files#diff-3bba9ccc8adbd18e4ea56d84561ebdafef62fa24da24dc7fc5a99a364bf3aef2">+6/-43</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scenario_classes.py</strong><dd><code>Add test for CPU hog scenario error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/models/scenario/test_scenario_classes.py

<ul><li>Add new test <code>test_node_cpu_hog_scenario_raises_error_when_no_nodes()</code> <br>to verify error handling<br> <li> Test ensures <code>NodeCPUHogScenario</code> raises <code>ScenarioParameterInitError</code> when <br>cluster has no nodes<br> <li> Fixes inconsistent behavior where CPU hog scenario previously silently <br>proceeded</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/113/files#diff-30617f331f3a2a6fdbb2e0582003f44045f756d2c24c053c63c13f94f17b4de6">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_node_selector.py</strong><dd><code>Comprehensive unit tests for node selector module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils/test_node_selector.py

<ul><li>New comprehensive test suite for node selector utility module<br> <li> Tests for <code>collect_unique_taints()</code>: deduplication, order preservation, <br>edge cases<br> <li> Tests for <code>build_label_counter()</code>: label counting, empty nodes, missing <br>labels<br> <li> Tests for <code>get_nodes_matching_label()</code>: matching logic, edge cases with <br>equals in values<br> <li> Tests for <code>select_nodes()</code>: error handling, result validation, hostname <br>vs label selection<br> <li> 15 test cases covering all helper functions and selection strategies</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/113/files#diff-093af84a2dc32bc8a1cc9e628f907fb3417b73ed6dd4f3ad36c341f948880c4c">+170/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

