### PR TITLE
Fix thread leak in HealthCheckWatcher on exception

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -39,7 +39,9 @@ class HealthCheckWatcher:
             f"Starting health check watcher for {len(self.config.applications)} applications"
         )
         for health_check in self.config.applications:
-            t = threading.Thread(target=self.run_health_check, args=(health_check,))
+            t = threading.Thread(
+                target=self.run_health_check, args=(health_check,), daemon=True
+            )
             t.start()
             self._threads.append(t)
 

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -115,17 +115,19 @@ class KrknRunner:
             # Start watching application urls for health checks
             health_check_watcher.run()
 
-            # Run command (show logs when verbose mode is enabled)
-            log, returncode = run_shell(
-                self.process_es_env_string(command, True), do_not_log=not is_verbose()
-            )
+            try:
+                # Run command (show logs when verbose mode is enabled)
+                log, returncode = run_shell(
+                    self.process_es_env_string(command, True), do_not_log=not is_verbose()
+                )
 
-            # Extract return code from run log which is part of telemetry data present in the log
-            returncode, run_uuid = self.__extract_returncode_from_run(log, returncode)
-            logger.info("Krkn scenario return code: %d", returncode)
-
-            # Stop watching application urls for health checks
-            health_check_watcher.stop()
+                # Extract return code from run log which is part of telemetry data present in the log
+                returncode, run_uuid = self.__extract_returncode_from_run(log, returncode)
+                logger.info("Krkn scenario return code: %d", returncode)
+            finally:
+                # Stop watching application urls for health checks
+                # Must be in finally block to prevent thread leak on exceptions
+                health_check_watcher.stop()
 
         end_time = datetime.datetime.now()
 


### PR DESCRIPTION
### **User description**
# Fix health check watcher thread leak on krkn runner failures

## Summary

This PR fixes a critical issue in `krkn-ai` where background health check watcher threads were not cleaned up if an exception occurred during chaos execution.

When the krkn runner failed (for example due to subprocess errors or infrastructure instability), health check threads continued running indefinitely. Because these threads were non-daemon and never stopped, the krkn-ai process would hang and fail to exit cleanly.

This change guarantees proper cleanup of health check threads on **all execution paths**.

---

## Problem Description

### Affected Component
- **File:** `krkn_ai/chaos_engines/krkn_runner.py`
- **Function:** `KrknRunner.run()`

### What was happening

During chaos execution, health check monitoring is started before running the chaos command:

```python
health_check_watcher.run()
log, returncode = run_shell(...)
health_check_watcher.stop()


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent health check watcher thread leak on exceptions

- Wrap chaos command execution in try-finally block

- Mark health check threads as daemon threads

- Guarantee cleanup of health check threads on all paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Health Check Watcher Started"] --> B["Try: Run Chaos Command"]
  B --> C["Extract Return Code"]
  B --> D["Exception Occurs"]
  C --> E["Finally: Stop Watcher"]
  D --> E
  E --> F["Daemon Threads Cleaned Up"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_check_watcher.py</strong><dd><code>Mark health check threads as daemon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/health_check_watcher.py

<ul><li>Mark health check worker threads as daemon threads<br> <li> Prevents process hang when main thread exits<br> <li> Ensures threads are cleaned up automatically by Python runtime</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/120/files#diff-7bc26c6651e54020598e15513a8a7cc0141ee4c00a235cff7f7e73dc3d361b00">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>krkn_runner.py</strong><dd><code>Ensure health check watcher cleanup on exceptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/krkn_runner.py

<ul><li>Wrap chaos command execution in try-finally block<br> <li> Move health check watcher stop call to finally block<br> <li> Guarantees cleanup even if exceptions occur during command execution<br> <li> Prevents thread leak on subprocess errors or infrastructure failures</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/120/files#diff-0cda393c52fddf48cdec219c4a67270901bbdf21e5820c13f650eca73463332f">+12/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

