### PR TITLE
# Fix Silent Failure in Composite Scenarios by Evaluating All Scenario Exit Codes

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -533,16 +533,40 @@ class KrknRunner:
             json_str = "\n".join(json_lines)
             chaos_data = json.loads(json_str)
 
-            # Extract exit_status from first scenario
+            # Extract exit_status from all scenarios (for composite scenarios)
+            # Return the worst exit status: misconfiguration errors (!=0,!=2) > SLO failures (2) > success (0)
             scenarios = chaos_data.get("telemetry", {}).get("scenarios", [])
             if scenarios and len(scenarios) > 0:
-                exit_status = scenarios[0].get("exit_status", default_returncode)
                 run_uuid = chaos_data.get("telemetry", {}).get("run_uuid", None)
-                logger.debug("Extracted exit_status: %s", exit_status)
-                logger.debug("Extracted run_uuid: %s", run_uuid)
-                return exit_status, run_uuid
 
-            logger.warning("No exit_status found in telemetry data")
+                worst_exit_status = 0
+                failed_scenarios = []
+
+                for scenario in scenarios:
+                    exit_status = scenario.get("exit_status", 0)
+                    scenario_name = scenario.get("name", "unknown")
+
+                    if exit_status != 0:
+                        failed_scenarios.append((scenario_name, exit_status))
+                        # Prioritize misconfiguration errors over SLO failures
+                        if worst_exit_status == 0:
+                            worst_exit_status = exit_status
+                        elif exit_status != 2 and worst_exit_status == 2:
+                            # Misconfiguration error takes precedence over SLO failure
+                            worst_exit_status = exit_status
+
+                if failed_scenarios:
+                    logger.warning(
+                        "Scenario failures detected in composite run: %s",
+                        failed_scenarios
+                    )
+
+                logger.debug("Extracted worst exit_status: %s from %d scenarios",
+                           worst_exit_status, len(scenarios))
+                logger.debug("Extracted run_uuid: %s", run_uuid)
+                return worst_exit_status, run_uuid
+
+            logger.warning("No scenarios found in telemetry data")
             return default_returncode, None
 
         except Exception as e:


### PR DESCRIPTION
### **User description**
## Summary

This PR fixes a **critical silent failure bug** in Krkn where **composite scenario runs only evaluated the exit status of the first scenario**, ignoring failures in subsequent scenarios.

As a result, chaos runs involving multiple scenarios could be incorrectly marked as **successful**, even when later scenarios failed due to SLO violations or misconfigurations.

This PR ensures that **all scenario exit statuses are evaluated** and the **worst (non-zero) exit status** is returned and logged.

---

## Problem Description

Krkn supports **composite scenarios** via `krknctl graph run`, where multiple chaos scenarios are executed sequentially and reported in telemetry as an array of results.

However, the return code extraction logic only inspected the **first scenario**:

```python
exit_status = scenarios[0].get("exit_status", default_returncode)

## Impacted Test Scenarios

The following test cases demonstrate the impact of this fix and prevent regressions in composite scenario handling.

### 1. Composite Scenario With Partial Failure (Primary Case)

**Input Telemetry**
```json
{
  "telemetry": {
    "scenarios": [
      {"name": "pod_scenario", "exit_status": 0},
      {"name": "network_scenario", "exit_status": 2}
    ]
  }
}



___

### **PR Type**
Bug fix


___

### **Description**
- Fix silent failure in composite scenarios by evaluating all exit codes

- Implement worst-case exit status logic prioritizing misconfiguration errors

- Add detailed logging for failed scenarios in composite runs

- Prevent incorrect success marking when subsequent scenarios fail


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Extract scenarios from telemetry"] --> B["Iterate all scenarios"]
  B --> C["Collect exit statuses"]
  C --> D["Determine worst status"]
  D --> E["Log failures if found"]
  E --> F["Return worst exit status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>krkn_runner.py</strong><dd><code>Evaluate all scenario exit codes in composite runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/krkn_runner.py

<ul><li>Changed exit status extraction from first scenario only to evaluating <br>all scenarios<br> <li> Implemented worst-case exit status logic with prioritization: <br>misconfiguration errors (!=0,!=2) > SLO failures (2) > success (0)<br> <li> Added collection and logging of failed scenarios with their names and <br>exit codes<br> <li> Updated debug logging to reflect worst exit status from all scenarios <br>instead of just first</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/121/files#diff-0cda393c52fddf48cdec219c4a67270901bbdf21e5820c13f650eca73463332f">+29/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

