### PR TITLE
Prevent indefinite hang during chaos execution when Kubernetes API is unreachable

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -116,8 +116,12 @@ class KrknRunner:
             health_check_watcher.run()
 
             # Run command (show logs when verbose mode is enabled)
+            # Timeout = wait_duration + 120 seconds buffer for initialization/teardown
+            execution_timeout = self.config.wait_duration + 120
             log, returncode = run_shell(
-                self.process_es_env_string(command, True), do_not_log=not is_verbose()
+                self.process_es_env_string(command, True),
+                do_not_log=not is_verbose(),
+                timeout=execution_timeout,
             )
 
             # Extract return code from run log which is part of telemetry data present in the log
@@ -136,14 +140,22 @@ class KrknRunner:
 
         # Check if krkn scenario failed due to misconfiguration (non-zero and not status code 2)
         # Status code 2 means that SLOs not met per Krkn test (valid failure)
+        # Return code -1 indicates execution timeout
         # Other non-zero status codes indicate misconfiguration errors
         if returncode != 0 and returncode != 2:
-            # Misconfiguration failure - skip fitness calculation and set failure marker
-            logger.warning(
-                "Krkn scenario failed with return code %d (misconfiguration). "
-                "Skipping fitness calculation to avoid data pollution.",
-                returncode,
-            )
+            # Misconfiguration or timeout failure - skip fitness calculation and set failure marker
+            if returncode == -1:
+                logger.error(
+                    "Krkn scenario execution timed out. "
+                    "This may indicate Kubernetes API unreachability or network issues. "
+                    "Skipping fitness calculation to avoid data pollution."
+                )
+            else:
+                logger.warning(
+                    "Krkn scenario failed with return code %d (misconfiguration). "
+                    "Skipping fitness calculation to avoid data pollution.",
+                    returncode,
+                )
             if self.config.fitness_function.include_krkn_failure:
                 fitness_result.krkn_failure_score = -1.0
             fitness_result.fitness_score = -1.0

--- a/krkn_ai/utils/__init__.py
+++ b/krkn_ai/utils/__init__.py
@@ -1,6 +1,7 @@
 import shlex
 import subprocess
-from typing import Iterator
+import threading
+from typing import Iterator, Optional
 
 from krkn_ai.utils.logger import get_logger
 
@@ -14,21 +15,62 @@ def id_generator() -> Iterator[int]:
         i += 1
 
 
-def run_shell(command, do_not_log=False):
+def run_shell(command, do_not_log=False, timeout: Optional[int] = None):
     """
     Run shell command and get logs and statuscode in output.
+
+    Args:
+        command: Shell command to execute
+        do_not_log: If True, suppress debug logging of command output
+        timeout: Maximum execution time in seconds. If None, no timeout is applied.
+                 If the timeout expires, the process is terminated and return code -1 is returned.
+
+    Returns:
+        Tuple of (logs, returncode). On timeout, returncode is -1.
     """
     logs = ""
-    command = shlex.split(command)
+    command_list = shlex.split(command)
     # Let's show the command name being executed
-    logger.debug("Running command: %s", command[0])
+    logger.debug("Running command: %s", command_list[0])
+
     process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        command_list, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
     )
-    for line in process.stdout:
-        if not do_not_log:
-            logger.debug("%s", line.rstrip())
-        logs += line
-    process.wait()
+
+    # Use a timer to enforce timeout since we're reading stdout line-by-line
+    timed_out = threading.Event()
+
+    def kill_on_timeout():
+        timed_out.set()
+        logger.error(
+            "Command timed out after %d seconds, terminating: %s", timeout, command_list[0]
+        )
+        process.terminate()
+        # Give process time to terminate gracefully, then force kill
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            logger.warning("Process did not terminate gracefully, sending SIGKILL")
+            process.kill()
+
+    timer = None
+    if timeout is not None:
+        timer = threading.Timer(timeout, kill_on_timeout)
+        timer.start()
+
+    try:
+        for line in process.stdout:
+            if not do_not_log:
+                logger.debug("%s", line.rstrip())
+            logs += line
+        process.wait()
+    finally:
+        if timer is not None:
+            timer.cancel()
+
+    if timed_out.is_set():
+        logger.error("Command execution timed out")
+        return logs, -1
+
     logger.debug("Run Status: %d", process.returncode)
     return logs, process.returncode

--- a/tests/unit/utils/test_run_shell.py
+++ b/tests/unit/utils/test_run_shell.py
@@ -1,0 +1,118 @@
+"""
+Tests for the run_shell function in krkn_ai.utils
+"""
+
+import pytest
+import time
+from krkn_ai.utils import run_shell
+
+
+class TestRunShellBasic:
+    """Test basic run_shell functionality"""
+
+    def test_successful_command(self):
+        """Test that a successful command returns output and exit code 0"""
+        logs, returncode = run_shell("echo 'hello world'")
+        assert returncode == 0
+        assert "hello world" in logs
+
+    def test_failed_command(self):
+        """Test that a failed command returns non-zero exit code"""
+        logs, returncode = run_shell("ls /nonexistent_directory_12345")
+        assert returncode != 0
+
+    def test_multiline_output(self):
+        """Test that multiline output is captured correctly"""
+        logs, returncode = run_shell("echo -e 'line1\\nline2\\nline3'")
+        assert returncode == 0
+        assert "line1" in logs
+        assert "line2" in logs
+        assert "line3" in logs
+
+
+class TestRunShellTimeout:
+    """Test run_shell timeout functionality"""
+
+    def test_command_completes_before_timeout(self):
+        """Test that a fast command completes normally with timeout set"""
+        logs, returncode = run_shell("echo 'fast'", timeout=10)
+        assert returncode == 0
+        assert "fast" in logs
+
+    def test_command_times_out(self):
+        """Test that a slow command is terminated when timeout expires"""
+        start_time = time.time()
+        logs, returncode = run_shell("sleep 30", timeout=2)
+        elapsed = time.time() - start_time
+
+        # Should return -1 on timeout
+        assert returncode == -1
+        # Should complete in roughly 2 seconds (with some buffer for termination)
+        assert elapsed < 10, f"Command took {elapsed} seconds, expected ~2 seconds"
+
+    def test_timeout_none_allows_completion(self):
+        """Test that timeout=None allows command to complete normally"""
+        logs, returncode = run_shell("sleep 1", timeout=None)
+        assert returncode == 0
+
+    def test_partial_output_on_timeout(self):
+        """Test that partial output is captured even on timeout"""
+        # Command that continuously outputs then gets killed
+        # Using a bash script that outputs before sleeping
+        logs, returncode = run_shell(
+            "bash -c 'for i in 1 2 3; do echo line$i; done; sleep 30'", timeout=2
+        )
+        assert returncode == -1
+        assert "line1" in logs
+
+    def test_zero_timeout_immediately_kills(self):
+        """Test that timeout=0 immediately kills the process"""
+        # Note: timeout=0 means no timeout in the current implementation
+        # This test documents the behavior
+        start_time = time.time()
+        logs, returncode = run_shell("sleep 5", timeout=1)
+        elapsed = time.time() - start_time
+
+        assert returncode == -1
+        assert elapsed < 5
+
+
+class TestRunShellLogging:
+    """Test run_shell logging behavior"""
+
+    def test_do_not_log_suppresses_output(self):
+        """Test that do_not_log=True suppresses debug logging"""
+        # This test mainly verifies the parameter is accepted
+        logs, returncode = run_shell("echo 'test'", do_not_log=True)
+        assert returncode == 0
+        assert "test" in logs
+
+    def test_do_not_log_false_allows_output(self):
+        """Test that do_not_log=False allows debug logging"""
+        logs, returncode = run_shell("echo 'test'", do_not_log=False)
+        assert returncode == 0
+        assert "test" in logs
+
+
+class TestRunShellEdgeCases:
+    """Test edge cases for run_shell"""
+
+    def test_empty_output_command(self):
+        """Test command that produces no output"""
+        logs, returncode = run_shell("true")
+        assert returncode == 0
+        assert logs == ""
+
+    def test_special_characters_in_output(self):
+        """Test that special characters are handled correctly"""
+        logs, returncode = run_shell("echo 'special: $HOME \"quotes\" `backticks`'")
+        assert returncode == 0
+        assert "special:" in logs
+
+    def test_large_output(self):
+        """Test that large output is captured correctly"""
+        # Generate 1000 lines of output
+        logs, returncode = run_shell("seq 1 1000")
+        assert returncode == 0
+        assert "1" in logs
+        assert "1000" in logs


### PR DESCRIPTION
### **User description**
# Fix: Prevent indefinite hang during chaos execution when Kubernetes API is unreachable

## Summary

This PR fixes a critical issue where `krkn-ai` could hang indefinitely while executing chaos scenarios if the Kubernetes API becomes slow or unreachable.

The root cause was an unbounded subprocess execution in `run_shell()` that waited forever for command output or process exit. Under real Kubernetes failure conditions, `krknctl` may never return, causing `krkn-ai` to block permanently with no recovery.

This change introduces a bounded timeout for chaos execution and ensures failures are handled gracefully.

---

## Problem

`run_shell()` executed `krknctl` / `podman` using `subprocess.Popen()` with:

- No timeout
- Blocking reads on `stdout`
- A blocking `process.wait()`

If the Kubernetes API is unreachable or the target resources are deleted mid-execution, `krknctl` can hang indefinitely, causing `krkn-ai` to stall forever.

This occurs during exactly the kinds of instability chaos testing is designed to introduce.

---

## Why This Is Critical

**Impact before fix**
- Chaos runs hang indefinitely
- CI/CD pipelines stall until externally killed
- No cleanup of chaos artifacts
- No fitness results returned (silent failure)

**Affected users**
- SREs running chaos in CI pipelines
- Reliability engineers using continuous chaos testing
- Any user running chaos during cluster instability

---

## Root Cause

`run_shell()` assumed subprocesses would always complete in bounded time.

This assumption breaks when:
- Kubernetes API is slow or unreachable
- Network partitions occur
- Target nodes or namespaces are deleted mid-execution

`krknctl --wait-duration` does not cover the initial API connection phase, so it does not prevent this hang.

---

## Fix

### 1. Add timeout support to `run_shell()`
- Introduced an optional `timeout` parameter
- Subprocess is terminated if it exceeds the timeout
- Returns `-1` on timeout with partial logs preserved

### 2. Bound chaos execution time
- `krkn_runner` now passes:


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add timeout parameter to `run_shell()` to prevent indefinite hangs

- Implement threading-based timeout with graceful termination and SIGKILL fallback

- Return exit code -1 on timeout for proper error handling

- Pass execution timeout from `krkn_runner` with 120-second buffer

- Add comprehensive unit tests for timeout and edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run_shell function"] -->|"add timeout parameter"| B["Threading Timer"]
  B -->|"timeout expires"| C["Terminate process"]
  C -->|"graceful fail"| D["Return -1"]
  C -->|"force kill"| D
  E["krkn_runner"] -->|"calculate timeout"| F["wait_duration + 120s"]
  F -->|"pass to run_shell"| A
  G["Unit tests"] -->|"verify timeout behavior"| H["Test suite"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>krkn_runner.py</strong><dd><code>Add timeout parameter to chaos execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/krkn_runner.py

<ul><li>Calculate execution timeout as <code>wait_duration + 120</code> seconds buffer<br> <li> Pass <code>timeout</code> parameter to <code>run_shell()</code> call<br> <li> Handle return code -1 separately for timeout vs misconfiguration<br> <li> Log timeout errors distinctly from misconfiguration failures</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/124/files#diff-0cda393c52fddf48cdec219c4a67270901bbdf21e5820c13f650eca73463332f">+19/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Implement timeout mechanism in run_shell function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/__init__.py

<ul><li>Add optional <code>timeout</code> parameter to <code>run_shell()</code> function<br> <li> Implement threading.Timer to enforce timeout on subprocess execution<br> <li> Gracefully terminate process on timeout, then force kill if needed<br> <li> Return exit code -1 when timeout occurs<br> <li> Preserve partial logs even when timeout is triggered<br> <li> Add comprehensive docstring with parameter descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/124/files#diff-04f3245e59645d703654646cf6c2ae7140d220f2cd36289616663fa26c049028">+52/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_run_shell.py</strong><dd><code>Add comprehensive unit tests for run_shell timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils/test_run_shell.py

<ul><li>Add 118 lines of comprehensive unit tests for <code>run_shell()</code> function<br> <li> Test basic functionality: successful commands, failures, multiline <br>output<br> <li> Test timeout behavior: fast completion, timeout expiration, partial <br>output<br> <li> Test logging suppression with <code>do_not_log</code> parameter<br> <li> Test edge cases: empty output, special characters, large output</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/124/files#diff-b1641e6528785688ac3d1b802a983c2e34529ff9eba763bdba1f352862f0cbea">+118/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

