### PR TITLE
feat:added a zone-outage scenario

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -47,6 +47,10 @@ class KubevirtScenarioConfig(BaseModel):
     enable: bool = False
 
 
+class ZoneOutageScenarioConfig(BaseModel):
+    enable: bool = False
+
+
 class ScenarioConfig(BaseModel):
     application_outages: Optional[AppOutageScenarioConfig] = Field(
         alias="application-outages", default=None
@@ -81,6 +85,9 @@ class ScenarioConfig(BaseModel):
     )
     kubevirt_scenarios: Optional[KubevirtScenarioConfig] = Field(
         alias="kubevirt-scenarios", default=None
+    )
+    zone_outages: Optional[ZoneOutageScenarioConfig] = Field(
+        alias="zone-outages", default=None
     )
 
 

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -24,6 +24,7 @@ from krkn_ai.models.scenario.scenario_syn_flood import SynFloodScenario
 from krkn_ai.models.scenario.scenario_io_hog import NodeIOHogScenario
 from krkn_ai.models.scenario.scenario_pvc import PVCScenario
 from krkn_ai.models.scenario.scenario_kubevirt import KubevirtDisruptionScenario
+from krkn_ai.models.scenario.scenario_zone_outage import ZoneOutageScenario
 
 logger = get_logger(__name__)
 
@@ -40,6 +41,7 @@ scenario_specs = [
     ("syn_flood", SynFloodScenario),
     ("pvc_scenarios", PVCScenario),
     ("kubevirt_scenarios", KubevirtDisruptionScenario),
+    ("zone_outages", ZoneOutageScenario),
 ]
 
 

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -513,3 +513,39 @@ class KillCountParameter(BaseParameter):
     krknhub_name: str = "KILL_COUNT"
     krknctl_name: str = "kill-count"
     value: int = 1
+
+
+class CloudTypeParameter(BaseParameter):
+    krknhub_name: str = "CLOUD_TYPE"
+    krknctl_name: str = "cloud-type"
+    value: str = "aws"
+
+    def mutate(self):
+        self.value = rng.choice(["aws", "gcp"])
+
+
+class VpcIdParameter(BaseParameter):
+    krknhub_name: str = "VPC_ID"
+    krknctl_name: str = "vpc-id"
+    value: str = ""
+
+
+class SubnetIdParameter(BaseParameter):
+    krknhub_name: str = "SUBNET_ID"
+    krknctl_name: str = "subnet-id"
+    value: list = []
+
+
+class ZoneParameter(BaseParameter):
+    krknhub_name: str = "ZONE"
+    krknctl_name: str = "zone"
+    value: str = ""
+
+
+class KubeCheckParameter(BaseParameter):
+    krknhub_name: str = "KUBE_CHECK"
+    krknctl_name: str = "kube-check"
+    value: bool = True
+
+    def mutate(self):
+        self.value = rng.choice([True, False])

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -1,4 +1,5 @@
 import math
+from typing import List
 from pydantic import BaseModel, Field
 from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import BaseParameter
@@ -533,7 +534,7 @@ class VpcIdParameter(BaseParameter):
 class SubnetIdParameter(BaseParameter):
     krknhub_name: str = "SUBNET_ID"
     krknctl_name: str = "subnet-id"
-    value: list = []
+    value: List[str] = Field(default_factory=list)
 
 
 class ZoneParameter(BaseParameter):

--- a/krkn_ai/models/scenario/scenario_zone_outage.py
+++ b/krkn_ai/models/scenario/scenario_zone_outage.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 from krkn_ai.models.scenario.base import Scenario
 from krkn_ai.models.scenario.parameters import (
     CloudTypeParameter,
@@ -57,9 +57,12 @@ class ZoneOutageScenario(Scenario):
             self.subnet_id.value = []
 
         elif self.cloud_type.value == "aws":
-            self.vpc_id.value = "vpc-xxxxxx"  # Placeholder for real VPC
-            self.subnet_id.value = ["subnet-xxxxxx"]  # Placeholder for subnets
-            self.zone.value = ""
+            vpc_id, subnets = self._get_aws_ids()
+            self.vpc_id.value = vpc_id
+            self.subnet_id.value = subnets
+            self.zone.value = (
+                self._get_zones_from_nodes()[0] if self._get_zones_from_nodes() else ""
+            )
             self.kube_check.value = True
 
     def _detect_cloud_type(self) -> str:
@@ -81,3 +84,7 @@ class ZoneOutageScenario(Scenario):
                 if label in node.labels:
                     zones.add(node.labels[label])
         return list(zones)
+
+    def _get_aws_ids(self) -> Tuple[str, List[str]]:
+        """Placeholder for getting AWS VPC and Subnet IDs."""
+        return "vpc-xxxxxx", ["subnet-xxxxxx"]

--- a/krkn_ai/models/scenario/scenario_zone_outage.py
+++ b/krkn_ai/models/scenario/scenario_zone_outage.py
@@ -1,0 +1,83 @@
+from typing import List
+from krkn_ai.models.scenario.base import Scenario
+from krkn_ai.models.scenario.parameters import (
+    CloudTypeParameter,
+    DurationParameter,
+    VpcIdParameter,
+    SubnetIdParameter,
+    ZoneParameter,
+    KubeCheckParameter,
+)
+from krkn_ai.utils.rng import rng
+
+
+class ZoneOutageScenario(Scenario):
+    """Scenario for simulating zone outages in cloud environments like AWS or GCP."""
+
+    name: str = "zone_outages"
+    krknctl_name: str = "zone-outages"
+    krknhub_image: str = "quay.io/krkn-chaos/krkn-hub:zone-outages"
+
+    cloud_type: CloudTypeParameter = CloudTypeParameter()
+    duration: DurationParameter = DurationParameter()
+    vpc_id: VpcIdParameter = VpcIdParameter()
+    subnet_id: SubnetIdParameter = SubnetIdParameter()
+    zone: ZoneParameter = ZoneParameter()
+    kube_check: KubeCheckParameter = KubeCheckParameter()
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.mutate()
+
+    @property
+    def parameters(self):
+        return [
+            self.cloud_type,
+            self.duration,
+            self.vpc_id,
+            self.subnet_id,
+            self.zone,
+            self.kube_check,
+        ]
+
+    def mutate(self):
+        # Randomly select cloud type initially
+        self.cloud_type.mutate()
+
+        # Try to detect actual cloud from node labels
+        detected_cloud = self._detect_cloud_type()
+        if detected_cloud:
+            self.cloud_type.value = detected_cloud
+
+        # Configure parameters based on cloud type
+        if self.cloud_type.value == "gcp":
+            zones = self._get_zones_from_nodes()
+            self.zone.value = rng.choice(zones) if zones else "us-west1-a"
+            self.vpc_id.value = ""
+            self.subnet_id.value = []
+
+        elif self.cloud_type.value == "aws":
+            self.vpc_id.value = "vpc-xxxxxx"  # Placeholder for real VPC
+            self.subnet_id.value = ["subnet-xxxxxx"]  # Placeholder for subnets
+            self.zone.value = ""
+            self.kube_check.value = True
+
+    def _detect_cloud_type(self) -> str:
+        """Infer cloud provider from node labels."""
+        for node in self._cluster_components.nodes:
+            labels = node.labels
+            if any(k.startswith("cloud.google.com/") for k in labels.keys()):
+                return "gcp"
+        return ""
+
+    def _get_zones_from_nodes(self) -> List[str]:
+        """Extract unique zones from node labels."""
+        zones = set()
+        for node in self._cluster_components.nodes:
+            for label in [
+                "failure-domain.beta.kubernetes.io/zone",
+                "topology.kubernetes.io/zone",
+            ]:
+                if label in node.labels:
+                    zones.add(node.labels[label])
+        return list(zones)


### PR DESCRIPTION
Reference : https://krkn-chaos.dev/docs/scenarios/zone-outage-scenarios/
Part of #13 
### **PR Type**
Enhancement, Tests


___

### **Description**
- Added ZoneOutageScenario class for simulating cloud zone outages

- Introduced new parameters for zone outage configuration (CloudType, VpcId, SubnetId, Zone, KubeCheck)

- Registered ZoneOutageScenario in scenario factory for automatic discovery

- Added comprehensive unit tests for ZoneOutageScenario initialization and cloud provider detection


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New ZoneOutageScenario Class"] --> B["Factory Registration"]
  A --> C["New Parameters"]
  C --> D["CloudType, VpcId, SubnetId, Zone, KubeCheck"]
  A --> E["Unit Tests"]
  E --> F["Initialization & GCP Detection Tests"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>factory.py</strong><dd><code>Register ZoneOutageScenario in factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/models/scenario/factory.py

<ul><li>Added import for <code>ZoneOutageScenario</code> class<br> <li> Registered zone outage scenario in <code>scenario_specs</code> list with key <br><code>zone_outages</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/130/files#diff-5d7bf543d3ed53391cfcf82eaea51910319b3489d8a45d4df99057351a3ce2ac">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parameters.py</strong><dd><code>Add zone outage scenario parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/models/scenario/parameters.py

<ul><li>Added <code>CloudTypeParameter</code> with mutation support for AWS and GCP <br>selection<br> <li> Added <code>VpcIdParameter</code> for AWS VPC identification<br> <li> Added <code>SubnetIdParameter</code> for subnet configuration<br> <li> Added <code>ZoneParameter</code> for cloud zone specification<br> <li> Added <code>KubeCheckParameter</code> with boolean mutation support</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/130/files#diff-bf7d3b288357c3d83968a8c89db114bc217ec2e510d1fb67edb425752f5b626d">+36/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_scenario_classes.py</strong><dd><code>Add ZoneOutageScenario unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/models/scenario/test_scenario_classes.py

<ul><li>Added import for <code>ZoneOutageScenario</code> class<br> <li> Added <code>TestZoneOutageScenario</code> test class with initialization tests<br> <li> Added test for default parameter initialization and cloud type <br>validation<br> <li> Added test for GCP detection from node labels and zone extraction</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/130/files#diff-30617f331f3a2a6fdbb2e0582003f44045f756d2c24c053c63c13f94f17b4de6">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

