### PR TITLE
docs: add documentation for reproducible runs using seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,31 @@ Options:
 
 > **Note:** You can also run Krkn-AI as a container with Podman or on Kubernetes. See [container instructions](./containers/README.md).
 
+### 🔁 Reproducible Runs with Seed
+
+Krkn-AI supports reproducible chaos experiment runs using a configurable random seed.
+When a seed is provided, all random operations such as initial population generation,
+mutation, and crossover follow a deterministic execution path.
+
+This is useful for debugging, testing, and comparing experiment behavior across runs.
+
+#### Using Seed from CLI
+
+The seed can be overridden from the command line using the `--seed` flag:
+
+```bash
+uv run krkn_ai run \
+  -c ./tmp/krkn-ai.yaml \
+  -o ./tmp/results/ \
+  --seed 42
+```
+If both the configuration file and CLI specify a seed, the CLI value takes precedence.
+
+### Seed in Output Artifacts
+For traceability and reproducibility, the seed used for a run is logged and persisted
+in the generated output configuration. This allows users to re-run experiments with
+the same parameters and execution behavior.
+
 ### Understanding Results
 
 Krkn-AI saves results in the specified output directory:


### PR DESCRIPTION
### **User description**
### Summary

This PR adds documentation explaining how to use the configurable random seed
feature in Krkn-AI to enable reproducible chaos experiment runs.

### What’s included

- Description of deterministic behavior when a seed is provided
- Instructions for overriding the seed using the `--seed` CLI flag
- Clarification that CLI seed takes precedence over config file
- Explanation of how the seed is logged and persisted in output artifacts

### Why this is useful

Documenting the seed functionality helps users:
- Debug and compare experiment behavior across runs
- Reproduce results reliably
- Understand how randomness is controlled in Krkn-AI

This change does not modify runtime behavior and is documentation-only.


___

### **PR Type**
Documentation


___

### **Description**
- Adds comprehensive documentation for reproducible runs using seed

- Explains deterministic behavior when seed is provided

- Documents CLI `--seed` flag usage with example command

- Clarifies CLI seed precedence over config file values

- Describes seed logging and persistence in output artifacts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Seed Configuration"] --> B["CLI --seed Flag"]
  A --> C["Config File"]
  B --> D["Deterministic Execution"]
  C --> D
  D --> E["Output Artifacts"]
  E --> F["Reproducible Runs"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document seed feature for reproducible experiments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added new section "Reproducible Runs with Seed" explaining seed <br>functionality<br> <li> Documented deterministic behavior for random operations with seed<br> <li> Provided CLI example using <code>--seed 42</code> flag<br> <li> Clarified CLI seed takes precedence over config file<br> <li> Explained seed logging and persistence in output configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/138/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

