### PR TITLE
Fix: Mock env_is_truthy in prometheus connection test

### DIFF
--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -113,8 +113,9 @@ class TestPrometheusUtils:
             with pytest.raises(PrometheusConnectionError):
                 create_prometheus_client("/tmp/test-kubeconfig")
 
+    @patch("krkn_ai.utils.prometheus.env_is_truthy", return_value=False)
     @patch("krkn_ai.utils.prometheus.KrknPrometheus")
-    def test_create_client_connection_test_failure(self, mock_prom_class):
+    def test_create_client_connection_test_failure(self, mock_prom_class, _):
         """Should raise connection error if the connection test (process_query) fails."""
         env = {"PROMETHEUS_URL": "http://localhost", "PROMETHEUS_TOKEN": "tok"}
         with patch.dict(os.environ, env):


### PR DESCRIPTION
### **User description**
Fixes #139.


The unit test was failing because the environment check `env_is_truthy('MOCK_FITNESS')` was not mocked, potentially evaluating to True and skipping the connection verification logic.

This change mocks `env_is_truthy` to return `False` within the test, forcing the `process_query` call and ensuring the expected `PrometheusConnectionError` is raised.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Mock `env_is_truthy` function to ensure test executes connection verification

- Force `process_query` call by returning False from environment check

- Ensure `PrometheusConnectionError` is properly raised during test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test: test_create_client_connection_test_failure"] -->|Add mock decorator| B["env_is_truthy returns False"]
  B -->|Forces execution| C["process_query call"]
  C -->|Raises| D["PrometheusConnectionError"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_prometheus.py</strong><dd><code>Mock env_is_truthy in prometheus connection test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils/test_prometheus.py

<ul><li>Added <code>@patch</code> decorator to mock <code>env_is_truthy</code> function with return <br>value <code>False</code><br> <li> Updated method signature to accept the mocked parameter<br> <li> Ensures connection test logic executes and raises expected <br><code>PrometheusConnectionError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/141/files#diff-76890c7bcf5568b11ba46eb75e2151499d53d2f227b6e825697bada9c4874015">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

