### PR TITLE
set MOCK_FITNESS false for prometheus connection failure unit test

### DIFF
--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -116,7 +116,11 @@ class TestPrometheusUtils:
     @patch("krkn_ai.utils.prometheus.KrknPrometheus")
     def test_create_client_connection_test_failure(self, mock_prom_class):
         """Should raise connection error if the connection test (process_query) fails."""
-        env = {"PROMETHEUS_URL": "http://localhost", "PROMETHEUS_TOKEN": "tok"}
+        env = {
+            "PROMETHEUS_URL": "http://localhost",
+            "PROMETHEUS_TOKEN": "tok",
+            "MOCK_FITNESS": "false",
+        }
         with patch.dict(os.environ, env):
             mock_client = Mock()
             mock_client.process_query.side_effect = Exception("Auth failed")


### PR DESCRIPTION
### **User description**
Closes https://github.com/krkn-chaos/krkn-ai/issues/139


___

### **PR Type**
Tests


___

### **Description**
- Add MOCK_FITNESS environment variable to Prometheus connection failure test

- Set MOCK_FITNESS to "false" for proper test isolation

- Ensures connection test failure scenario is properly validated


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["test_create_client_connection_test_failure"] -->|adds MOCK_FITNESS| B["Environment variables"]
  B -->|includes| C["PROMETHEUS_URL"]
  B -->|includes| D["PROMETHEUS_TOKEN"]
  B -->|includes| E["MOCK_FITNESS: false"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_prometheus.py</strong><dd><code>Add MOCK_FITNESS environment variable to connection test</code>&nbsp; </dd></summary>
<hr>

tests/unit/utils/test_prometheus.py

<ul><li>Added <code>MOCK_FITNESS</code> environment variable set to "false" in <br><code>test_create_client_connection_test_failure</code> test<br> <li> Reformatted environment dictionary for better readability with <br>multi-line formatting<br> <li> Ensures test properly validates Prometheus connection failure without <br>mock fitness mode</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/146/files#diff-76890c7bcf5568b11ba46eb75e2151499d53d2f227b6e825697bada9c4874015">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

