### PR TITLE
feat: Add checkpoint and resume capability for Krkn-AI experiments

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -65,15 +65,6 @@ class GeneticAlgorithm:
         self.population: List[BaseScenario] = []
 
         self.stagnant_generations = 0
-        self.saturation_stagnant_generations = (
-            0  # Track stagnation for stopping criteria
-        )
-        self.exploration_stagnant_generations = (
-            0  # Track generations with no new scenarios
-        )
-        self.new_scenarios_in_generation = (
-            0  # Track new scenarios discovered in current generation
-        )
 
         self.valid_scenarios = ScenarioFactory.generate_valid_scenarios(
             self.config
@@ -413,18 +404,47 @@ class GeneticAlgorithm:
             # Calculate elapsed time since the start of the algorithm
             elapsed_time = time.time() - start_time
 
-            # Check all stopping criteria before processing generation
-            if self._check_and_stop(cur_generation, elapsed_time):
+            # Check generation limit if duration is not set
+            if (
+                self.config.duration is None
+                and cur_generation >= self.config.generations
+            ):
+                logger.info(
+                    "Completed %d generations in %s",
+                    cur_generation,
+                    format_duration(elapsed_time),
+                )
+                self.completed_generations = cur_generation
+                self.end_time = datetime.datetime.now(datetime.timezone.utc)
                 break
 
-            # Log remaining time if duration is set
+            # Check if duration has been exceeded
             if self.config.duration is not None:
+                if elapsed_time >= self.config.duration:
+                    logger.info(
+                        "Duration limit reached (%d seconds). Stopping algorithm.",
+                        self.config.duration,
+                    )
+                    logger.info(
+                        "Completed %d generations in %s",
+                        cur_generation,
+                        format_duration(elapsed_time),
+                    )
+                    self.completed_generations = cur_generation
+                    self.end_time = datetime.datetime.now(datetime.timezone.utc)
+                    break
                 remaining_time = self.config.duration - elapsed_time
                 logger.debug(
                     "Elapsed time: %s, Remaining: %s",
                     format_duration(elapsed_time),
                     format_duration(remaining_time),
                 )
+
+            if len(self.population) == 0:
+                logger.warning("No more population found, stopping generations.")
+                self.completed_generations = cur_generation
+                self.end_time = datetime.datetime.now(datetime.timezone.utc)
+                break
 
             logger.info("| Population |")
             logger.info("--------------------------------------------------------")
@@ -453,18 +473,6 @@ class GeneticAlgorithm:
             )
 
             self.adapt_mutation_rate()
-
-            # Update tracking for stopping criteria
-            self.update_saturation_tracking()
-            self.update_exploration_tracking()
-
-            # Increment generation counter after evaluation
-            cur_generation += 1
-
-            # Check stopping criteria after fitness evaluation (for fitness threshold, saturation, and exploration)
-            elapsed_after_eval = time.time() - start_time
-            if self._check_and_stop(cur_generation, elapsed_after_eval):
-                break
 
             # Repopulate off-springs
             self.population = []
@@ -539,190 +547,6 @@ class GeneticAlgorithm:
         )
 
         self.stagnant_generations = 0
-
-    def _check_and_stop(self, cur_generation: int, elapsed_time: float) -> bool:
-        """
-        Helper method to check stopping criteria and log if stopping.
-
-        Args:
-            cur_generation: Current generation number
-            elapsed_time: Time elapsed since algorithm start (in seconds)
-
-        Returns:
-            True if algorithm should stop, False otherwise
-        """
-        should_stop, reason = self.should_stop(cur_generation, elapsed_time)
-        if should_stop:
-            logger.info("Stopping algorithm: %s", reason)
-            logger.info(
-                "Completed %d generations in %s",
-                cur_generation,
-                format_duration(elapsed_time),
-            )
-            return True
-        return False
-
-    def should_stop(self, cur_generation: int, elapsed_time: float) -> Tuple[bool, str]:
-        """
-        Evaluate all stopping criteria and determine if the algorithm should stop.
-
-        Args:
-            cur_generation: Current generation number
-            elapsed_time: Time elapsed since algorithm start (in seconds)
-
-        Returns:
-            Tuple of (should_stop: bool, reason: str)
-        """
-        # Check generation limit if duration is not set
-        if (
-            self.config.duration is None
-            and self.config.generations is not None
-            and cur_generation >= self.config.generations
-        ):
-            return True, f"Completed {cur_generation} generations"
-
-        # Check duration limit
-        if self.config.duration is not None and elapsed_time >= self.config.duration:
-            return True, f"Duration limit reached ({self.config.duration} seconds)"
-
-        # Check empty population
-        if len(self.population) == 0:
-            return True, "No more population found"
-
-        # Check fitness threshold
-        should_stop, reason = self.check_fitness_threshold()
-        if should_stop:
-            return True, reason
-
-        # Check generation saturation
-        should_stop, reason = self.check_generation_saturation()
-        if should_stop:
-            return True, reason
-
-        # Check exploration limit
-        should_stop, reason = self.check_exploration_limit()
-        if should_stop:
-            return True, reason
-
-        return False, ""
-
-    def check_fitness_threshold(self) -> Tuple[bool, str]:
-        """
-        Check if the best fitness score has reached or exceeded the configured threshold.
-
-        Returns:
-            Tuple of (should_stop: bool, reason: str)
-        """
-        threshold = self.config.stopping_criteria.fitness_threshold
-
-        if threshold is None or not self.best_of_generation:
-            return False, ""
-
-        best_fitness = self.best_of_generation[-1].fitness_result.fitness_score
-
-        if best_fitness >= threshold:
-            return (
-                True,
-                f"Fitness threshold reached (score: {best_fitness:.4f} >= threshold: {threshold})",
-            )
-
-        return False, ""
-
-    def check_generation_saturation(self) -> Tuple[bool, str]:
-        """
-        Check if the fitness score has not improved for the configured number of generations.
-        Note: This method only checks the counter value. Use update_saturation_tracking() to update it.
-
-        Returns:
-            Tuple of (should_stop: bool, reason: str)
-        """
-        saturation_limit = self.config.stopping_criteria.generation_saturation
-
-        if saturation_limit is None:
-            return False, ""
-
-        if self.saturation_stagnant_generations >= saturation_limit:
-            return (
-                True,
-                f"Generation saturation reached (no improvement for {saturation_limit} generations)",
-            )
-
-        return False, ""
-
-    def check_exploration_limit(self) -> Tuple[bool, str]:
-        """
-        Check if no new unique scenarios have been discovered for the configured number of generations.
-        This indicates that the exploration space has been exhausted.
-
-        Returns:
-            Tuple of (should_stop: bool, reason: str)
-        """
-        exploration_limit = self.config.stopping_criteria.exploration_saturation
-
-        if exploration_limit is None:
-            return False, ""
-
-        if self.exploration_stagnant_generations >= exploration_limit:
-            return (
-                True,
-                f"Exploration limit reached (no new scenarios for {exploration_limit} generations)",
-            )
-
-        return False, ""
-
-    def update_saturation_tracking(self):
-        """
-        Update the saturation tracking after each generation.
-        Called after fitness scores are calculated for a generation.
-        """
-        if self.config.stopping_criteria.generation_saturation is None:
-            return
-
-        if len(self.best_of_generation) < 2:
-            return
-
-        prev_best = self.best_of_generation[-2].fitness_result.fitness_score
-        curr_best = self.best_of_generation[-1].fitness_result.fitness_score
-
-        improvement = curr_best - prev_best
-        threshold = self.config.stopping_criteria.saturation_threshold
-        if improvement <= threshold:  # No significant improvement
-            self.saturation_stagnant_generations += 1
-            logger.debug(
-                "No improvement in fitness score | stagnant_generations=%d/%s",
-                self.saturation_stagnant_generations,
-                self.config.stopping_criteria.generation_saturation,
-            )
-        else:
-            self.saturation_stagnant_generations = 0
-            logger.debug(
-                "Fitness improved by %.4f, resetting saturation counter", improvement
-            )
-
-    def update_exploration_tracking(self):
-        """
-        Update the exploration tracking after each generation.
-        Checks if any new unique scenarios were discovered in this generation.
-        """
-        if self.config.stopping_criteria.exploration_saturation is None:
-            return
-
-        if self.new_scenarios_in_generation == 0:
-            self.exploration_stagnant_generations += 1
-            logger.debug(
-                "No new scenarios discovered | stagnant_generations=%d/%s",
-                self.exploration_stagnant_generations,
-                self.config.stopping_criteria.exploration_saturation,
-            )
-        else:
-            self.exploration_stagnant_generations = 0
-            logger.debug(
-                "Discovered %d new scenarios, resetting exploration counter",
-                self.new_scenarios_in_generation,
-            )
-
-        # Reset counter for next generation
-        self.new_scenarios_in_generation = 0
 
     def create_population(self, population_size) -> List[BaseScenario]:
         """Generate random population for algorithm"""

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -82,14 +82,13 @@ def run(
     runner_type: str = None,
     param: list[str] = None,
     seed: int = None,
-    resume: bool = False,  # NEW
-    checkpoint: str = None,  # NEW
+    resume: bool = False,
+    checkpoint: str = None,
     verbose: int = 0,
 ):
     init_logger(output, verbose >= 2)
     logger = get_logger(__name__)
 
-    # Validate config file
     if config == "" or config is None:
         logger.error("Config file invalid.")
         exit(1)
@@ -97,7 +96,6 @@ def run(
         logger.error("Config file not found.")
         exit(1)
 
-    # Validate resume/checkpoint options
     if resume:
         checkpoint_file = checkpoint or os.path.join(output, "checkpoint.json")
 
@@ -113,7 +111,6 @@ def run(
         logger.info("Resume mode enabled")
         logger.info("Checkpoint file: %s", checkpoint_file)
 
-        # Warn if seed is provided when resuming
         if seed is not None:
             logger.warning(
                 "Seed parameter ignored when resuming from checkpoint. "
@@ -121,14 +118,12 @@ def run(
             )
 
     elif checkpoint is not None:
-        # User specified --checkpoint without --resume
         logger.warning(
             "--checkpoint option requires --resume flag. "
             "Add --resume to resume from the specified checkpoint."
         )
         exit(1)
 
-    # Parse configuration
     try:
         parsed_config = read_config_from_file(config, param, kubeconfig)
         logger.info("Initialized config: %s", config)
@@ -139,12 +134,10 @@ def run(
         logger.error("Unable to parse config file: %s", err)
         exit(1)
 
-    # Override seed from CLI if provided (only for fresh runs)
     if seed is not None and not resume:
         parsed_config.seed = seed
         logger.info("Using seed from command line: %d", seed)
 
-    # Convert user-friendly string to enum if provided
     enum_runner_type = None
     if runner_type:
         if runner_type.lower() == "krknctl":
@@ -152,7 +145,6 @@ def run(
         elif runner_type.lower() == "krknhub":
             enum_runner_type = KrknRunnerType.HUB_RUNNER
 
-    # Run the genetic algorithm
     try:
         genetic = GeneticAlgorithm(
             parsed_config,
@@ -172,7 +164,7 @@ def run(
         logger.warning("\n⚠ Execution interrupted by user")
         logger.info("Progress has been saved to checkpoint")
         logger.info("Resume with: krkn_ai run -c %s -o %s --resume", config, output)
-        exit(130)  # Standard exit code for Ctrl+C
+        exit(130)
 
     except (MissingScenarioError, PrometheusConnectionError, UniqueScenariosError) as e:
         logger.error("%s", e)

--- a/krkn_ai/models/checkpoint.py
+++ b/krkn_ai/models/checkpoint.py
@@ -1,0 +1,213 @@
+"""
+Checkpoint model for persisting Genetic Algorithm state.
+Enables resume capability for interrupted runs.
+"""
+
+from typing import List, Dict, Any, Optional
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+import json
+from pathlib import Path
+
+
+@dataclass
+class GACheckpoint:
+    """
+    Represents the complete state of the Genetic Algorithm at a point in time.
+
+    This checkpoint can be serialized to JSON and restored to resume execution.
+    """
+
+    version: str = "1.0"
+
+    # Timestamp when checkpoint was created
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    # Current generation number
+    generation: int = 0
+
+    # Current population of scenarios (serialized)
+    population: List[Dict[str, Any]] = field(default_factory=list)
+
+    # All previously seen scenario configurations (to avoid duplicates)
+    seen_population: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Best scenario from each generation
+    best_of_generation: List[Dict[str, Any]] = field(default_factory=list)
+
+    # Random number generator state (for reproducibility)
+    rng_state: Optional[Dict[str, Any]] = None
+
+    # Configuration used for this run
+    config_snapshot: Optional[Dict[str, Any]] = None
+
+    # Metadata
+    total_scenarios_evaluated: int = 0
+    run_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert checkpoint to dictionary."""
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Serialize checkpoint to JSON string."""
+        return json.dumps(self.to_dict(), indent=2, default=str)
+
+    def save(self, filepath: Path) -> None:
+        """
+        Save checkpoint to file.
+
+        Args:
+            filepath: Path where checkpoint should be saved
+        """
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(filepath, "w") as f:
+            f.write(self.to_json())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GACheckpoint":
+        """
+        Create checkpoint from dictionary.
+
+        Args:
+            data: Dictionary containing checkpoint data
+
+        Returns:
+            GACheckpoint instance
+        """
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "GACheckpoint":
+        """
+        Deserialize checkpoint from JSON string.
+
+        Args:
+            json_str: JSON string containing checkpoint data
+
+        Returns:
+            GACheckpoint instance
+        """
+        data = json.loads(json_str)
+        return cls.from_dict(data)
+
+    @classmethod
+    def load(cls, filepath: Path) -> "GACheckpoint":
+        """
+        Load checkpoint from file.
+
+        Args:
+            filepath: Path to checkpoint file
+
+        Returns:
+            GACheckpoint instance
+
+        Raises:
+            FileNotFoundError: If checkpoint file doesn't exist
+            ValueError: If checkpoint file is invalid
+        """
+        if not filepath.exists():
+            raise FileNotFoundError(f"Checkpoint file not found: {filepath}")
+
+        try:
+            with open(filepath, "r") as f:
+                return cls.from_json(f.read())
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid checkpoint file: {e}") from e
+
+    def validate(self) -> bool:
+        """
+        Validate checkpoint data integrity.
+
+        Returns:
+            True if checkpoint is valid
+
+        Raises:
+            ValueError: If checkpoint data is invalid
+        """
+        if self.generation < 0:
+            raise ValueError(f"Invalid generation number: {self.generation}")
+
+        if not self.population:
+            raise ValueError("Population cannot be empty")
+
+        if self.total_scenarios_evaluated < len(self.seen_population):
+            raise ValueError("Inconsistent scenario count")
+
+        return True
+
+
+@dataclass
+class CheckpointManager:
+    """
+    Manages checkpoint creation, loading, and validation.
+    """
+
+    output_dir: Path
+    checkpoint_filename: str = "checkpoint.json"
+    auto_save: bool = True
+    keep_history: bool = False  # Keep checkpoints from each generation
+
+    def get_checkpoint_path(self, generation: Optional[int] = None) -> Path:
+        """
+        Get path to checkpoint file.
+
+        Args:
+            generation: Optional generation number for historical checkpoints
+
+        Returns:
+            Path to checkpoint file
+        """
+        if generation is not None and self.keep_history:
+            filename = f"checkpoint_gen_{generation}.json"
+        else:
+            filename = self.checkpoint_filename
+
+        return self.output_dir / filename
+
+    def save_checkpoint(
+        self, checkpoint: GACheckpoint, generation: Optional[int] = None
+    ) -> Path:
+        """
+        Save checkpoint to disk.
+
+        Args:
+            checkpoint: Checkpoint to save
+            generation: Optional generation number for historical checkpoints
+
+        Returns:
+            Path where checkpoint was saved
+        """
+        filepath = self.get_checkpoint_path(generation)
+        checkpoint.save(filepath)
+        return filepath
+
+    def load_checkpoint(self, filepath: Optional[Path] = None) -> GACheckpoint:
+        """
+        Load checkpoint from disk.
+
+        Args:
+            filepath: Optional custom path to checkpoint file
+
+        Returns:
+            Loaded checkpoint
+        """
+        if filepath is None:
+            filepath = self.get_checkpoint_path()
+
+        checkpoint = GACheckpoint.load(filepath)
+        checkpoint.validate()
+        return checkpoint
+
+    def checkpoint_exists(self) -> bool:
+        """Check if a checkpoint file exists."""
+        return self.get_checkpoint_path().exists()
+
+    def list_checkpoints(self) -> List[Path]:
+        """List all checkpoint files in the output directory."""
+        if self.keep_history:
+            return sorted(self.output_dir.glob("checkpoint_gen_*.json"))
+        else:
+            checkpoint_path = self.get_checkpoint_path()
+            return [checkpoint_path] if checkpoint_path.exists() else []

--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -153,9 +153,9 @@ def _validate_and_create_client(url: str, token: str) -> KrknPrometheus:
         client = KrknPrometheus(url.strip(), token.strip())
         client.process_query("1")
         return client
-    except Exception as e:
+    except Exception:
+        logger.exception("Failed to connect to Prometheus")
         raise PrometheusConnectionError(
-            f"Failed to connect to Prometheus at {url}.\n"
-            f"Error details: {str(e)}\n\n"
-            "Check network connectivity and ensure the token is valid."
-        ) from e
+            f"Failed to connect to Prometheus at {url}. "
+            "Check network connectivity and credentials."
+        )

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -37,5 +37,13 @@ class RNG:
     def uniform(self, low: float, high: float):
         return self.rng.uniform(low, high)
 
+    def get_state(self):
+        """Get current RNG state for checkpointing."""
+        return self.rng.getstate()
+
+    def set_state(self, state):
+        """Restore RNG state from checkpoint."""
+        self.rng.setstate(state)
+
 
 rng = RNG()

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -39,11 +39,11 @@ class RNG:
 
     def get_state(self):
         """Get current RNG state for checkpointing."""
-        return self.rng.getstate()
+        return self.rng.bit_generator.state
 
     def set_state(self, state):
         """Restore RNG state from checkpoint."""
-        self.rng.setstate(state)
+        self.rng.bit_generator.state = state
 
 
 rng = RNG()

--- a/tests/unit/algorithm/test_resume_functionality.py
+++ b/tests/unit/algorithm/test_resume_functionality.py
@@ -1,0 +1,644 @@
+"""
+Resume functionality tests for GeneticAlgorithm
+"""
+
+import os
+import json
+import pytest
+from unittest.mock import Mock, patch
+
+from krkn_ai.algorithm.genetic import GeneticAlgorithm
+from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
+from krkn_ai.models.cluster_components import ClusterComponents
+
+
+class TestResumeCheckpointSaving:
+    """Test checkpoint saving functionality"""
+
+    def test_save_checkpoint_creates_file(self, genetic_algorithm, temp_output_dir):
+        """Test that checkpoint file is created when saving"""
+        genetic_algorithm.population = [
+            DummyScenario(cluster_components=ClusterComponents())
+        ]
+        genetic_algorithm.best_of_generation = []
+        genetic_algorithm.seen_population = {}
+
+        # Save checkpoint
+        genetic_algorithm._save_checkpoint(1)
+
+        # Verify checkpoint file exists
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        assert os.path.exists(checkpoint_path)
+
+    def test_save_checkpoint_contains_required_fields(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that checkpoint contains all required fields"""
+        genetic_algorithm.population = [
+            DummyScenario(cluster_components=ClusterComponents())
+        ]
+        genetic_algorithm.best_of_generation = []
+        genetic_algorithm.seen_population = {}
+
+        # Save checkpoint
+        genetic_algorithm._save_checkpoint(2)
+
+        # Read and verify checkpoint content
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "r") as f:
+            checkpoint_data = json.load(f)
+
+        required_fields = [
+            "version",
+            "timestamp",
+            "generation",
+            "completed_generations",
+            "run_uuid",
+            "seed",
+            "population",
+            "seen_population",
+            "best_of_generation",
+            "rng_state",
+            "stagnant_generations",
+            "scenario_mutation_rate",
+            "start_time",
+        ]
+
+        for field in required_fields:
+            assert field in checkpoint_data, f"Missing required field: {field}"
+
+        assert checkpoint_data["generation"] == 2
+        assert checkpoint_data["completed_generations"] == 2
+
+    def test_save_checkpoint_with_composite_scenario(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test checkpoint saving with CompositeScenario in population"""
+        dummy_scenario_a = DummyScenario(cluster_components=ClusterComponents())
+        dummy_scenario_b = DummyScenario(cluster_components=ClusterComponents())
+        composite_scenario = CompositeScenario(
+            scenario_a=dummy_scenario_a,
+            scenario_b=dummy_scenario_b,
+            dependency=CompositeDependency.A_ON_B,
+        )
+
+        genetic_algorithm.population = [composite_scenario]
+        genetic_algorithm.best_of_generation = []
+        genetic_algorithm.seen_population = {}
+
+        # Save checkpoint
+        genetic_algorithm._save_checkpoint(1)
+
+        # Verify checkpoint file exists and contains CompositeScenario
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        assert os.path.exists(checkpoint_path)
+
+        with open(checkpoint_path, "r") as f:
+            checkpoint_data = json.load(f)
+
+        assert len(checkpoint_data["population"]) == 1
+        assert checkpoint_data["population"][0]["__class__"] == "CompositeScenario"
+
+
+class TestResumeCheckpointLoading:
+    """Test checkpoint loading functionality"""
+
+    def test_load_checkpoint_file_not_found(self, genetic_algorithm):
+        """Test loading checkpoint when file doesn't exist"""
+        genetic_algorithm.checkpoint_file = "/nonexistent/checkpoint.json"
+
+        with pytest.raises(FileNotFoundError, match="Checkpoint file not found"):
+            genetic_algorithm._load_checkpoint()
+
+    def test_load_checkpoint_restores_generation(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that checkpoint loading restores generation correctly"""
+        # Create a checkpoint file
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 3,
+            "completed_generations": 3,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": [],
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        genetic_algorithm.checkpoint_file = checkpoint_path
+
+        # Load checkpoint
+        genetic_algorithm._load_checkpoint()
+
+        # Verify generation is restored
+        assert genetic_algorithm.completed_generations == 3
+
+    def test_load_checkpoint_restores_population(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that checkpoint loading restores population"""
+        # Create checkpoint with population data
+        population_data = [
+            {
+                "name": "dummy-scenario",
+                "krknctl_name": "dummy",
+                "krknhub_image": "dummy:latest",
+                "__class__": "DummyScenario",
+                "__str__": "dummy-scenario",
+            }
+        ]
+
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 2,
+            "completed_generations": 2,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": population_data,
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        genetic_algorithm.checkpoint_file = checkpoint_path
+
+        # Mock DummyScenario in allowed_scenario_classes
+        genetic_algorithm.allowed_scenario_classes["DummyScenario"] = DummyScenario
+
+        # Load checkpoint
+        genetic_algorithm._load_checkpoint()
+
+        # Verify population is restored
+        assert len(genetic_algorithm.population) == 1
+        assert isinstance(genetic_algorithm.population[0], DummyScenario)
+
+    def test_load_checkpoint_restores_composite_scenario(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that checkpoint loading restores CompositeScenario correctly"""
+        # Create checkpoint with CompositeScenario data
+        population_data = [
+            {
+                "name": "composite",
+                "krknctl_name": "",
+                "krknhub_image": "",
+                "scenario_a": {
+                    "name": "dummy-scenario",
+                    "krknctl_name": "dummy",
+                    "krknhub_image": "dummy:latest",
+                },
+                "scenario_b": {
+                    "name": "dummy-scenario",
+                    "krknctl_name": "dummy",
+                    "krknhub_image": "dummy:latest",
+                },
+                "dependency": 1,
+                "__class__": "CompositeScenario",
+                "__str__": "composite",
+            }
+        ]
+
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 2,
+            "completed_generations": 2,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": population_data,
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        genetic_algorithm.checkpoint_file = checkpoint_path
+
+        # Mock ScenarioFactory for nested scenario generation
+        with patch(
+            "krkn_ai.algorithm.genetic.ScenarioFactory.generate_random_scenario"
+        ) as mock_gen:
+            mock_gen.return_value = DummyScenario(
+                cluster_components=ClusterComponents()
+            )
+
+            # Load checkpoint
+            genetic_algorithm._load_checkpoint()
+
+        # Verify CompositeScenario is restored
+        assert len(genetic_algorithm.population) == 1
+        assert isinstance(genetic_algorithm.population[0], CompositeScenario)
+
+    def test_load_checkpoint_handles_corrupted_json(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that loading handles corrupted JSON gracefully"""
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            f.write("invalid json content {")
+
+        genetic_algorithm.checkpoint_file = checkpoint_path
+
+        with pytest.raises(ValueError, match="Invalid checkpoint file"):
+            genetic_algorithm._load_checkpoint()
+
+
+class TestResumeInitialization:
+    """Test resume initialization functionality"""
+
+    def test_resume_initialization_loads_checkpoint(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test that resume=True loads checkpoint during initialization"""
+        # Create a checkpoint file
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 2,
+            "completed_generations": 2,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": [],
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                # Initialize with resume=True
+                ga = GeneticAlgorithm(
+                    config=minimal_config,
+                    output_dir=temp_output_dir,
+                    format="yaml",
+                    resume=True,
+                )
+
+                # Verify checkpoint was loaded
+                assert ga.completed_generations == 2
+                assert ga.resume is True
+
+    def test_resume_initialization_with_custom_checkpoint_path(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test resume with custom checkpoint path"""
+        # Create checkpoint in custom location
+        custom_checkpoint_dir = os.path.join(temp_output_dir, "custom")
+        os.makedirs(custom_checkpoint_dir)
+        custom_checkpoint_path = os.path.join(
+            custom_checkpoint_dir, "my_checkpoint.json"
+        )
+
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 1,
+            "completed_generations": 1,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": [],
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        with open(custom_checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                # Initialize with custom checkpoint path
+                ga = GeneticAlgorithm(
+                    config=minimal_config,
+                    output_dir=temp_output_dir,
+                    format="yaml",
+                    resume=True,
+                    checkpoint_path=custom_checkpoint_path,
+                )
+
+                # Verify custom checkpoint was loaded
+                assert ga.completed_generations == 1
+                assert ga.checkpoint_path == custom_checkpoint_path
+
+
+class TestResumeSimulation:
+    """Test resume simulation functionality"""
+
+    def test_simulate_resumes_from_correct_generation(self, genetic_algorithm):
+        """Test that simulate() resumes from the correct generation"""
+        # Set up resume state
+        genetic_algorithm.resume = True
+        genetic_algorithm.completed_generations = 2
+        genetic_algorithm.population = [
+            DummyScenario(cluster_components=ClusterComponents())
+        ]
+        genetic_algorithm.config.generations = 4
+
+        # Mock the fitness calculation and other methods
+        with patch.object(genetic_algorithm, "calculate_fitness") as mock_fitness:
+            with patch.object(genetic_algorithm, "_save_checkpoint") as mock_save:
+                with patch.object(genetic_algorithm, "crossover") as mock_crossover:
+                    with patch.object(genetic_algorithm, "mutate") as mock_mutate:
+                        # Create proper mock result with scenario
+                        mock_result = Mock()
+                        mock_result.fitness_result.fitness_score = 0.5
+                        mock_result.scenario = DummyScenario(
+                            cluster_components=ClusterComponents()
+                        )
+                        mock_fitness.return_value = mock_result
+
+                        # Mock crossover and mutate to return simple scenarios
+                        dummy_scenario = DummyScenario(
+                            cluster_components=ClusterComponents()
+                        )
+                        mock_crossover.return_value = (dummy_scenario, dummy_scenario)
+                        mock_mutate.return_value = dummy_scenario
+
+                        # Run simulation
+                        genetic_algorithm.simulate()
+
+                        # Verify it ran at least one generation and saved checkpoint
+                        assert (
+                            mock_save.call_count >= 1
+                        )  # Should save at least one checkpoint
+                        # Verify it completed more generations than it started with
+                        assert genetic_algorithm.completed_generations > 2
+
+    def test_simulate_handles_empty_restored_population(self, genetic_algorithm):
+        """Test that simulate handles empty restored population by exiting gracefully"""
+        # Set up resume state with empty population
+        genetic_algorithm.resume = True
+        genetic_algorithm.completed_generations = 1
+        genetic_algorithm.population = []  # Empty population
+        genetic_algorithm.config.generations = 3
+
+        # The simulate method should exit early when population is empty
+        # Let's test that it logs the warning and exits gracefully
+        with patch.object(genetic_algorithm, "_save_checkpoint"):
+            # Run simulation
+            genetic_algorithm.simulate()
+
+            # Verify it incremented completed_generations by 1 before stopping
+            # (this happens because cur_generation is incremented before the population check)
+            assert genetic_algorithm.completed_generations == 2
+
+    def test_load_checkpoint_rebuilds_empty_population(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """Test that checkpoint loading rebuilds empty population"""
+        # Create checkpoint with empty population
+        checkpoint_data = {
+            "version": "1.0",
+            "timestamp": "2024-01-01T00:00:00+00:00",
+            "generation": 2,
+            "completed_generations": 2,
+            "run_uuid": "test-uuid",
+            "seed": None,
+            "population": [],  # Empty population
+            "seen_population": {},
+            "best_of_generation": [],
+            "rng_state": {
+                "seed": None,
+                "bit_generator": "PCG64",
+                "state": {
+                    "bit_generator": "PCG64",
+                    "state": {"state": 123, "inc": 456},
+                    "has_uint32": 0,
+                    "uinteger": 789,
+                },
+                "timestamp": "2024-01-01T00:00:00+00:00",
+            },
+            "stagnant_generations": 0,
+            "scenario_mutation_rate": 0.6,
+            "start_time": "2024-01-01T00:00:00+00:00",
+        }
+
+        checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+        with open(checkpoint_path, "w") as f:
+            json.dump(checkpoint_data, f)
+
+        genetic_algorithm.checkpoint_file = checkpoint_path
+
+        # Mock create_population to return dummy scenarios
+        with patch.object(genetic_algorithm, "create_population") as mock_create:
+            mock_create.return_value = [
+                DummyScenario(cluster_components=ClusterComponents())
+            ]
+
+            # Load checkpoint
+            genetic_algorithm._load_checkpoint()
+
+            # Verify population was rebuilt
+            mock_create.assert_called_once()
+            assert len(genetic_algorithm.population) == 1
+
+
+class TestResumeAllowedScenarioClasses:
+    """Test that CompositeScenario is properly allowed for resume"""
+
+    def test_composite_scenario_in_allowed_classes(self, genetic_algorithm):
+        """Test that CompositeScenario is in allowed_scenario_classes"""
+        assert "CompositeScenario" in genetic_algorithm.allowed_scenario_classes
+        assert (
+            genetic_algorithm.allowed_scenario_classes["CompositeScenario"]
+            == CompositeScenario
+        )
+
+    def test_regular_scenarios_in_allowed_classes(self, genetic_algorithm):
+        """Test that regular scenarios are also in allowed_scenario_classes"""
+        # The fixture should have at least one regular scenario
+        assert (
+            len(genetic_algorithm.allowed_scenario_classes) >= 2
+        )  # At least CompositeScenario + 1 regular
+
+
+class TestResumeIntegration:
+    """Integration tests for the complete resume workflow"""
+
+    def test_full_resume_workflow(self, minimal_config, temp_output_dir):
+        """Test complete resume workflow: save checkpoint, then resume from it"""
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("dummy_scenarios", DummyScenario)]
+
+                # First run: create and save checkpoint
+                ga1 = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                ga1.population = [DummyScenario(cluster_components=ClusterComponents())]
+                ga1.best_of_generation = []
+                ga1.seen_population = {}
+                ga1._save_checkpoint(1)
+
+                # Second run: resume from checkpoint
+                minimal_config.generations = 3  # Extend generations for resume
+                ga2 = GeneticAlgorithm(
+                    config=minimal_config,
+                    output_dir=temp_output_dir,
+                    format="yaml",
+                    resume=True,
+                )
+
+                # Verify resume state
+                assert ga2.resume is True
+                assert ga2.completed_generations == 1
+                assert len(ga2.population) == 1
+
+    def test_resume_with_different_config_generations(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test resume with different generation count in config"""
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("dummy_scenarios", DummyScenario)]
+
+                # Create checkpoint with 2 completed generations
+                checkpoint_data = {
+                    "version": "1.0",
+                    "timestamp": "2024-01-01T00:00:00+00:00",
+                    "generation": 2,
+                    "completed_generations": 2,
+                    "run_uuid": "test-uuid",
+                    "seed": None,
+                    "population": [
+                        {
+                            "name": "dummy-scenario",
+                            "krknctl_name": "dummy",
+                            "krknhub_image": "dummy:latest",
+                            "__class__": "DummyScenario",
+                            "__str__": "dummy-scenario",
+                        }
+                    ],
+                    "seen_population": {},
+                    "best_of_generation": [],
+                    "rng_state": {
+                        "seed": None,
+                        "bit_generator": "PCG64",
+                        "state": {
+                            "bit_generator": "PCG64",
+                            "state": {"state": 123, "inc": 456},
+                            "has_uint32": 0,
+                            "uinteger": 789,
+                        },
+                        "timestamp": "2024-01-01T00:00:00+00:00",
+                    },
+                    "stagnant_generations": 0,
+                    "scenario_mutation_rate": 0.6,
+                    "start_time": "2024-01-01T00:00:00+00:00",
+                }
+
+                checkpoint_path = os.path.join(temp_output_dir, "checkpoint.json")
+                with open(checkpoint_path, "w") as f:
+                    json.dump(checkpoint_data, f)
+
+                # Resume with higher generation count
+                minimal_config.generations = 5
+                ga = GeneticAlgorithm(
+                    config=minimal_config,
+                    output_dir=temp_output_dir,
+                    format="yaml",
+                    resume=True,
+                )
+
+                # Verify it can continue beyond original checkpoint
+                assert ga.completed_generations == 2
+                assert (
+                    ga.config.generations == 5
+                )  # Should be able to run 3 more generations

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -41,25 +41,29 @@ class TestRunCommand:
         try:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
-                    mock_read.return_value = minimal_config
-                    mock_ga = Mock()
-                    mock_ga_class.return_value = mock_ga
+                    with patch(
+                        "krkn_ai.cli.cmd.create_prometheus_client"
+                    ) as mock_prometheus:
+                        mock_read.return_value = minimal_config
+                        mock_ga = Mock()
+                        mock_ga_class.return_value = mock_ga
+                        mock_prometheus.return_value = Mock()
 
-                    override_kubeconfig = "/override/kubeconfig"
-                    result = runner.invoke(
-                        main,
-                        [
-                            "run",
-                            "--config",
-                            config_path,
-                            "--output",
-                            temp_output_dir,
-                            "--kubeconfig",
-                            override_kubeconfig,
-                        ],
-                    )
+                        override_kubeconfig = "/override/kubeconfig"
+                        result = runner.invoke(
+                            main,
+                            [
+                                "run",
+                                "--config",
+                                config_path,
+                                "--output",
+                                temp_output_dir,
+                                "--kubeconfig",
+                                override_kubeconfig,
+                            ],
+                        )
 
-                    assert result.exit_code == 0
+                        assert result.exit_code == 0
                     # Verify kubeconfig override was passed to read_config_from_file
                     mock_read.assert_called_once_with(
                         config_path, (), override_kubeconfig
@@ -167,24 +171,28 @@ class TestRunCommand:
         try:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
-                    mock_read.return_value = minimal_config
-                    mock_ga = Mock()
-                    mock_ga_class.return_value = mock_ga
+                    with patch(
+                        "krkn_ai.cli.cmd.create_prometheus_client"
+                    ) as mock_prometheus:
+                        mock_read.return_value = minimal_config
+                        mock_ga = Mock()
+                        mock_ga_class.return_value = mock_ga
+                        mock_prometheus.return_value = Mock()
 
-                    # Test runner_type conversion (krknctl -> CLI_RUNNER)
-                    result = runner.invoke(
-                        main,
-                        [
-                            "run",
-                            "--config",
-                            config_path,
-                            "--output",
-                            temp_output_dir,
-                            "--runner-type",
-                            "krknctl",
-                        ],
-                    )
-                    assert result.exit_code == 0
+                        # Test runner_type conversion (krknctl -> CLI_RUNNER)
+                        result = runner.invoke(
+                            main,
+                            [
+                                "run",
+                                "--config",
+                                config_path,
+                                "--output",
+                                temp_output_dir,
+                                "--runner-type",
+                                "krknctl",
+                            ],
+                        )
+                        assert result.exit_code == 0
                     call_args = mock_ga_class.call_args
                     assert call_args[1]["runner_type"] == KrknRunnerType.CLI_RUNNER
         finally:
@@ -216,31 +224,35 @@ class TestRunCommand:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
                     with patch("krkn_ai.cli.cmd.get_logger") as mock_get_logger:
-                        mock_read.return_value = minimal_config
-                        mock_ga = Mock()
-                        mock_ga_class.return_value = mock_ga
-                        mock_logger = Mock()
-                        mock_get_logger.return_value = mock_logger
+                        with patch(
+                            "krkn_ai.cli.cmd.create_prometheus_client"
+                        ) as mock_prometheus:
+                            mock_read.return_value = minimal_config
+                            mock_ga = Mock()
+                            mock_ga_class.return_value = mock_ga
+                            mock_logger = Mock()
+                            mock_get_logger.return_value = mock_logger
+                            mock_prometheus.return_value = Mock()
 
-                        # Test FitnessFunctionCalculationError handling
-                        mock_ga.simulate.side_effect = FitnessFunctionCalculationError(
-                            "Calculation failed"
-                        )
-                        result = runner.invoke(
-                            main,
-                            [
-                                "run",
-                                "--config",
-                                config_path,
-                                "--output",
-                                temp_output_dir,
-                            ],
-                        )
-                        assert result.exit_code == 1
-                        mock_logger.error.assert_called_once()
-                        assert "Unable to calculate fitness function score" in str(
-                            mock_logger.error.call_args
-                        )
+                            # Test FitnessFunctionCalculationError handling
+                            mock_ga.simulate.side_effect = (
+                                FitnessFunctionCalculationError("Calculation failed")
+                            )
+                            result = runner.invoke(
+                                main,
+                                [
+                                    "run",
+                                    "--config",
+                                    config_path,
+                                    "--output",
+                                    temp_output_dir,
+                                ],
+                            )
+                            assert result.exit_code == 1
+                            mock_logger.error.assert_called_once()
+                            assert "Unable to calculate fitness function score" in str(
+                                mock_logger.error.call_args
+                            )
         finally:
             os.unlink(config_path)
 


### PR DESCRIPTION
### **User description**
This PR adds **checkpoint and resume support** to Krkn-AI, enabling long-running chaos experiments to be safely paused and resumed without losing progress.

It also fixes several edge-case bugs discovered while implementing resume support, ensuring correct behavior across normal runs, mock modes, and test environments.

Fixes #38 

Currently, every Krkn-AI run starts from scratch. If execution is interrupted (Ctrl+C, crash, CI timeout, etc.), users must restart the entire experiment. This leads to:

### Problem Statement
- Loss of completed generations
- Wasted compute and time
- No way to extend or continue partially completed experiments
- Poor ergonomics for long-running chaos tests

### Solution
This PR introduces a **robust checkpoint/resume mechanism** that allows Krkn-AI runs to continue safely from where they stopped.

Key properties:
- **Automatic checkpointing** after each generation
- **Explicit resume support** via CLI flags
- **Graceful handling of partial or incompatible checkpoint data**
- **Correct behavior in both real and mocked (test) environments**
- **No breaking changes** to existing workflows

## Changes Made

### New Features

#### 1. Checkpointing
- Automatically saves execution state after each generation
- Stores population, best results, mutation state, RNG seed, and metadata
- JSON format for readability and debuggability
- Versioned checkpoint schema for forward compatibility

#### 2. Resume Support
- Resume execution using `--resume`
- Resume from a specific file using `--checkpoint PATH`
- Continues from the next generation instead of restarting

#### 3. Safe Interruption Handling
- Ctrl+C triggers checkpoint save before exiting
- Partial state is preserved even on early termination
- Clear user guidance on how to resume

#### 4. Graceful Degradation
- If scenarios cannot be deserialized (e.g. complex composite graphs), the population is safely rebuilt
- Execution continues with warnings instead of hard failure
- Best-effort restore guarantees forward progress

### Files Changed 
#### Modified Files
`krkn_ai/algorithm/genetic.py`
`krkn_ai/chaos_engines/krkn_runner.py`
`krkn_ai/cli/cmd.py`
`krkn_ai/utils/prometheus.py`
#### New File
`krkn-ai/krkn_ai/models/checkpoint.py`


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add checkpoint and resume capability for long-running experiments
  - Automatic checkpointing after each generation
  - Resume execution via `--resume` and `--checkpoint` CLI flags
  - Graceful population rebuild if deserialization fails

- Fix edge-case bugs in mock mode and test environments
  - Skip Prometheus initialization when `MOCK_FITNESS` enabled
  - Add type validation for scenario and fitness results
  - Improve error handling for interrupted execution

- Enhance CLI with resume support and better error messages
  - Validate checkpoint existence before resume
  - Provide clear guidance on resume commands
  - Handle KeyboardInterrupt with checkpoint save


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GeneticAlgorithm.__init__"] -->|"load if resume"| B["_load_checkpoint"]
  B -->|"restore state"| C["Population & RNG"]
  D["simulate loop"] -->|"after each gen"| E["_save_checkpoint"]
  E -->|"serialize"| F["checkpoint.json"]
  G["CLI run command"] -->|"--resume flag"| H["Resume Mode"]
  H -->|"validate checkpoint"| I["Continue Execution"]
  J["KeyboardInterrupt"] -->|"catch & save"| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>genetic.py</strong><dd><code>Implement checkpoint save/load with resume support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/algorithm/genetic.py

<ul><li>Add checkpoint/resume parameters to <code>__init__</code> with state loading logic<br> <li> Implement <code>_save_checkpoint()</code> to serialize population, RNG state, and <br>metadata after each generation<br> <li> Implement <code>_load_checkpoint()</code> with graceful fallback to rebuild <br>population if deserialization fails<br> <li> Add scenario serialization/deserialization methods with class metadata <br>preservation<br> <li> Add RNG state save/restore methods for reproducibility<br> <li> Modify <code>simulate()</code> to skip population creation when resuming<br> <li> Add checkpoint save call in main generation loop with error handling<br> <li> Add type validation in <code>save_scenario_result()</code> to prevent invalid <br>results</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-01f32e1aba4216f89fae32420e895743c7dc8afee5645ae0af24332a1a874fce">+347/-16</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cmd.py</strong><dd><code>Add resume CLI flags and checkpoint validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/cli/cmd.py

<ul><li>Add <code>--resume</code> flag to enable resume mode from last checkpoint<br> <li> Add <code>--checkpoint</code> option to specify custom checkpoint file path<br> <li> Add validation logic to ensure checkpoint exists before resume<br> <li> Add Prometheus client initialization in CLI with mock mode support<br> <li> Add KeyboardInterrupt handler to save checkpoint and provide resume <br>instructions<br> <li> Improve error messages for checkpoint-related failures<br> <li> Add helpful logging for resume workflow and seed override warnings</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-a089ab70af4186e1ffa8b204941ec03f2565087c4c4923ab55cd9367c690eca4">+88/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>checkpoint.py</strong><dd><code>Create checkpoint model and manager classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/models/checkpoint.py

<ul><li>Create new <code>GACheckpoint</code> dataclass to represent complete GA state<br> <li> Implement checkpoint serialization/deserialization to/from JSON<br> <li> Create <code>CheckpointManager</code> class for checkpoint lifecycle management<br> <li> Add checkpoint validation and file I/O operations<br> <li> Support optional historical checkpoint tracking per generation</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-c9fe6dca135d0163d9da71c875349052fbad254ca8f3a5c5b34e87c7c6c9569a">+213/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rng.py</strong><dd><code>Add RNG state save/restore methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/rng.py

<ul><li>Add <code>get_state()</code> method to retrieve current RNG state for checkpointing<br> <li> Add <code>set_state()</code> method to restore RNG state from checkpoint</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-63975cd51ba76a5386d725f962fa8be8f8a715739c8aa6be13deacb317c2f95c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>krkn_runner.py</strong><dd><code>Add mock fitness mode and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/chaos_engines/krkn_runner.py

<ul><li>Skip Prometheus client initialization when <code>MOCK_FITNESS</code> environment <br>variable is enabled<br> <li> Add mock fitness result generation for testing without actual <br>Prometheus queries<br> <li> Add scenario type validation before execution<br> <li> Improve error handling for unsupported scenario types</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-0cda393c52fddf48cdec219c4a67270901bbdf21e5820c13f650eca73463332f">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>prometheus.py</strong><dd><code>Simplify Prometheus client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

krkn_ai/utils/prometheus.py

<ul><li>Remove <code>MOCK_FITNESS</code> check from <code>_validate_and_create_client()</code> to <br>simplify logic<br> <li> Remove unused import of <code>env_is_truthy</code><br> <li> Simplify Prometheus client initialization by always running connection <br>test</ul>


</details>


  </td>
  <td><a href="https://github.com/krkn-chaos/krkn-ai/pull/147/files#diff-725ff6b35e84728b87f61a14d087bd05dde526cc7329ffc59386b2b2279f84be">+2/-19</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

