### PR TITLE
capture duration (seconds) for scenario and overall result

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -743,9 +743,6 @@ class GeneticAlgorithm:
         # Convert timestamps to ISO string
         result["start_time"] = (result["start_time"]).isoformat()
         result["end_time"] = (result["end_time"]).isoformat()
-        result["duration"] = (
-            fitness_result.end_time - fitness_result.start_time
-        ).total_seconds()
 
         output_dir = os.path.join(
             self.output_dir, self.format, "generation_%s" % generation_id

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -91,6 +91,7 @@ class KrknRunner:
         logger.info("Running scenario: %s", scenario)
 
         start_time = datetime.datetime.now()
+        mono_start = time.monotonic()
 
         # Generate command krkn executor command
         log, returncode, run_uuid = None, None, None
@@ -133,6 +134,7 @@ class KrknRunner:
                 health_check_watcher.stop()
 
         end_time = datetime.datetime.now()
+        duration_seconds = time.monotonic() - mono_start
 
         # calculate fitness scores
         fitness_result: FitnessResult = FitnessResult()
@@ -205,6 +207,7 @@ class KrknRunner:
             returncode=returncode,
             start_time=start_time,
             end_time=end_time,
+            duration_seconds=duration_seconds,
             fitness_result=fitness_result,
             health_check_results=health_check_results,
             run_uuid=run_uuid,

--- a/krkn_ai/models/app.py
+++ b/krkn_ai/models/app.py
@@ -41,6 +41,7 @@ class CommandRunResult(BaseModel):
     returncode: int  # Return code of Krkn-Hub scenario execution
     start_time: datetime.datetime  # Start date timestamp of the test
     end_time: datetime.datetime  # End date timestamp of the test
+    duration_seconds: float = 0.0  # Monotonic-clock elapsed seconds for the run
     fitness_result: FitnessResult  # Fitness result measured for scenario.
     health_check_results: Dict[str, List[HealthCheckResult]] = {}
     run_uuid: Optional[str] = (

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -99,7 +99,6 @@ class JSONSummaryReporter:
         results_summary: Dict[str, Any] = {
             "run_id": self.run_uuid,
             "seed": self.seed,
-            "duration": duration_seconds,
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "duration_seconds": round(duration_seconds, 2),


### PR DESCRIPTION
## feat/execution-duration: Capture execution duration for scenario and overall result

### Summary
Adds tracking of duration (in seconds) for each scenario and for the overall result.

### Changes
- **krkn_ai/algorithm/genetic.py** – Capture scenario and overall execution duration
- **krkn_ai/reporter/json_summary_reporter.py** – Include duration in JSON summary output

Signed-off-by: Rahul Shetty <rashetty@redhat.com>
