### PR TITLE
Updating python3.11 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An intelligent chaos engineering framework that uses genetic algorithms to optim
 ### Prerequisites
 
 - [krknctl](https://github.com/krkn-chaos/krknctl)
-- Python 3.9+
+- Python 3.11+
 - `uv` package manager (recommended) or `pip`
 - [podman](https://podman.io/)
 - [helm](https://helm.sh/docs/intro/install/)
@@ -36,7 +36,7 @@ An intelligent chaos engineering framework that uses genetic algorithms to optim
 pip install uv
 
 # Create and activate virtual environment
-uv venv --python 3.9
+uv venv --python 3.11
 source .venv/bin/activate
 
 # Install Krkn-AI in development mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "krkn_ai"
 version = "0.0.3"
 description = "Krkn-AI"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11,<4.0"
 license = { text = "Apache-2.0" }
 authors = [ { name = "krkn-chaos" } ]
 


### PR DESCRIPTION
When trying to use python3.9 as the docs state getting this error with installing krkn-lib

```
% uv run krkn_ai --help
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.11,<4.0 and krkn-lib==0.0.0 depends on Python>=3.11,<4.0, we can conclude that krkn-lib==0.0.0 cannot be used.
      And because only krkn-lib==0.0.0 is available, we can conclude that all versions of krkn-lib cannot be used.
      And because your project depends on krkn-lib and your project requires krkn-ai[dev], we can conclude that your project's requirements are unsatisfiable.

      hint: The `requires-python` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., krkn-lib==0.0.0 only supports >=3.11, <4.0). Consider using a more
      restrictive `requires-python` value (like >=3.11, <4.0).
```