### PR TITLE
fix: stale pod names

### DIFF
--- a/krkn_ai/models/cluster_components.py
+++ b/krkn_ai/models/cluster_components.py
@@ -7,10 +7,16 @@ class Container(BaseModel):
     disabled: bool = False
 
 
+class OwnerReference(BaseModel):
+    kind: str
+    name: str
+
+
 class Pod(BaseModel):
     name: str
     labels: Dict[str, str] = {}
     containers: List[Container] = []
+    owner: Optional[OwnerReference] = None
     disabled: bool = False
 
 

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -1,5 +1,6 @@
 import math
-from pydantic import BaseModel, Field
+from typing import Optional
+from pydantic import BaseModel, Field, PrivateAttr
 from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import BaseParameter
 
@@ -327,6 +328,29 @@ class PodNameParameter(BaseParameter):
     krknhub_name: str = "POD_NAME"
     krknctl_name: str = "pod-name"
     value: str = ""
+    _namespace: str = PrivateAttr(default="")
+    _owner_kind: Optional[str] = PrivateAttr(default=None)
+    _owner_name: Optional[str] = PrivateAttr(default=None)
+
+    def set_pod(self, namespace, pod):
+        """Store pod identity for lazy resolution at execution time."""
+        self.value = pod.name
+        self._namespace = namespace
+        if pod.owner:
+            self._owner_kind = pod.owner.kind
+            self._owner_name = pod.owner.name
+        else:
+            self._owner_kind = None
+            self._owner_name = None
+
+    def get_value(self):
+        if self._namespace and self._owner_kind and self._owner_name:
+            from krkn_ai.utils.pvc_utils import resolve_pod_name
+
+            return resolve_pod_name(
+                self._namespace, self.value, self._owner_kind, self._owner_name
+            )
+        return self.value
 
 
 class IngressParameter(BaseParameter):

--- a/krkn_ai/models/scenario/scenario_dns_outage.py
+++ b/krkn_ai/models/scenario/scenario_dns_outage.py
@@ -52,4 +52,4 @@ class DnsOutageScenario(Scenario):
         # Select a random pod from all pods in the cluster
         ns, pod = rng.choice(pods)
         self.namespace.value = ns.name
-        self.pod_name.value = pod.name
+        self.pod_name.set_pod(ns.name, pod)

--- a/krkn_ai/models/scenario/scenario_pvc.py
+++ b/krkn_ai/models/scenario/scenario_pvc.py
@@ -79,7 +79,7 @@ class PVCScenario(Scenario):
         else:
             namespace, pod = rng.choice(namespace_pod_tuple)
             self.namespace.value = namespace.name
-            self.pod_name.value = pod.name
+            self.pod_name.set_pod(namespace.name, pod)
             self.pvc_name.value = ""  # Leave empty when using pod-name
             selected_pvc_name = None
 

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -10,6 +10,7 @@ from krkn_ai.models.cluster_components import (
     Container,
     Namespace,
     Node,
+    OwnerReference,
     Pod,
     PVC,
     Service,
@@ -165,8 +166,14 @@ class ClusterManager:
                 )
                 continue
 
+            owner = None
+            if pod.metadata.owner_references:
+                ref = pod.metadata.owner_references[0]
+                owner = OwnerReference(name=ref.name, kind=ref.kind)
+
             pod_component = Pod(
                 name=pod.metadata.name,
+                owner=owner,
             )
             # Filter label keys by patterns
             labels = {}

--- a/krkn_ai/utils/pvc_utils.py
+++ b/krkn_ai/utils/pvc_utils.py
@@ -1,5 +1,5 @@
 """
-Utilities for working with PVCs, including getting real-time usage percentage.
+Kubernetes resource utilities: PVC usage lookups and pod name resolution.
 """
 
 from typing import Optional, Dict, Tuple
@@ -22,14 +22,88 @@ _logged_pvcs: set = set()
 
 def initialize_kubeconfig(kubeconfig_path: str):
     """
-    Initialize the kubeconfig path for PVC utilities.
-    This should be called once at the start of the application.
+    Initialize the global kubeconfig path.
+    Called once at startup by ScenarioFactory.
 
     Args:
         kubeconfig_path: Path to kubeconfig file
     """
     global _kubeconfig_path
     _kubeconfig_path = kubeconfig_path
+
+
+def resolve_pod_name(
+    namespace: str,
+    pod_name: str,
+    owner_kind: Optional[str] = None,
+    owner_name: Optional[str] = None,
+    kubeconfig: Optional[str] = None,
+) -> str:
+    """
+    Resolve a potentially stale pod name to the current running pod name
+    using the pod's owner reference.
+
+    Pods managed by controllers (Deployments, StatefulSets, etc.) get new
+    names when recreated after chaos scenarios. This uses the owner reference
+    stored during discovery to find the current running pod.
+
+    Falls back to the stored pod name if no kubeconfig is available (unit
+    tests), the pod has no owner reference (bare pod), or resolution fails.
+
+    Args:
+        namespace: Namespace where the pod lives
+        pod_name: Pod name from cluster_components config
+        owner_kind: Controller kind (e.g. "ReplicaSet", "StatefulSet")
+        owner_name: Controller name (e.g. "cart-655b74fb49")
+        kubeconfig: Optional explicit kubeconfig path
+
+    Returns:
+        Current pod name, or the stored name as fallback
+    """
+    kubeconfig_path = kubeconfig or _kubeconfig_path
+    if not kubeconfig_path:
+        return pod_name
+
+    if not owner_kind or not owner_name:
+        return pod_name
+
+    try:
+        krkn_k8s = KrknKubernetes(kubeconfig_path=kubeconfig_path)
+        live_pods = krkn_k8s.cli.list_namespaced_pod(
+            namespace=namespace,
+            field_selector="status.phase=Running",
+        ).items
+
+        for live_pod in live_pods:
+            if not live_pod.metadata.owner_references:
+                continue
+            ref = live_pod.metadata.owner_references[0]
+            if ref.kind == owner_kind and ref.name == owner_name:
+                logger.debug(
+                    "Resolved pod %s -> %s (owner: %s/%s)",
+                    pod_name,
+                    live_pod.metadata.name,
+                    owner_kind,
+                    owner_name,
+                )
+                return live_pod.metadata.name
+
+        logger.debug(
+            "No running pod found for owner %s/%s in %s, using stored name %s",
+            owner_kind,
+            owner_name,
+            namespace,
+            pod_name,
+        )
+        return pod_name
+    except Exception as e:
+        logger.debug(
+            "Failed to resolve pod name for %s in %s: %s",
+            pod_name,
+            namespace,
+            str(e),
+        )
+        return pod_name
 
 
 def get_pvc_usage_percentage(

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -54,6 +54,10 @@ class TestClusterManager:
         mock_pod = Mock()
         mock_pod.metadata.name = "test-pod"
         mock_pod.metadata.labels = {"app": "test"}
+        mock_owner_ref = Mock()
+        mock_owner_ref.kind = "ReplicaSet"
+        mock_owner_ref.name = "test-pod-abc123"
+        mock_pod.metadata.owner_references = [mock_owner_ref]
         mock_container = Mock()
         mock_container.name = "test-container"
         mock_pod.spec = Mock()
@@ -108,6 +112,9 @@ class TestClusterManager:
         assert components.namespaces[0].name == "default"
         assert len(components.namespaces[0].pods) == 1
         assert components.namespaces[0].pods[0].name == "test-pod"
+        assert components.namespaces[0].pods[0].owner is not None
+        assert components.namespaces[0].pods[0].owner.kind == "ReplicaSet"
+        assert components.namespaces[0].pods[0].owner.name == "test-pod-abc123"
         assert len(components.nodes) == 1
         assert components.nodes[0].name == "test-node"
 
@@ -287,6 +294,7 @@ class TestClusterManager:
         mock_pod1 = Mock()
         mock_pod1.metadata.name = "app-pod"
         mock_pod1.metadata.labels = {"app": "myapp", "env": "prod"}
+        mock_pod1.metadata.owner_references = None
         mock_container1 = Mock()
         mock_container1.name = "container1"
         mock_pod1.spec = Mock()
@@ -295,6 +303,7 @@ class TestClusterManager:
         mock_pod2 = Mock()
         mock_pod2.metadata.name = "skip-me"
         mock_pod2.metadata.labels = {"app": "myapp"}
+        mock_pod2.metadata.owner_references = None
         mock_container2 = Mock()
         mock_container2.name = "container2"
         mock_pod2.spec = Mock()

--- a/tests/unit/utils/test_resource_resolver.py
+++ b/tests/unit/utils/test_resource_resolver.py
@@ -1,0 +1,107 @@
+"""
+Tests for resolve_pod_name in pvc_utils
+"""
+
+from unittest.mock import Mock, patch
+from krkn_ai.utils import pvc_utils
+from krkn_ai.utils.pvc_utils import resolve_pod_name
+
+
+class TestResolvePodName:
+    """Test resolve_pod_name function"""
+
+    def setup_method(self):
+        pvc_utils._kubeconfig_path = None
+
+    def test_returns_stored_name_when_no_kubeconfig(self):
+        assert (
+            resolve_pod_name("test-ns", "cart-old", "ReplicaSet", "cart-abc")
+            == "cart-old"
+        )
+
+    def test_returns_stored_name_when_no_owner(self):
+        pvc_utils._kubeconfig_path = "/tmp/kubeconfig"
+        assert resolve_pod_name("test-ns", "bare-pod") == "bare-pod"
+
+    @patch("krkn_ai.utils.pvc_utils.KrknKubernetes")
+    def test_resolves_to_new_pod_name_via_owner_reference(self, mock_krkn_cls):
+        pvc_utils._kubeconfig_path = "/tmp/kubeconfig"
+
+        mock_ref = Mock()
+        mock_ref.kind = "ReplicaSet"
+        mock_ref.name = "cart-abc"
+
+        live_pod = Mock()
+        live_pod.metadata.name = "cart-new-xyz"
+        live_pod.metadata.owner_references = [mock_ref]
+
+        mock_krkn_cls.return_value.cli.list_namespaced_pod.return_value.items = [
+            live_pod
+        ]
+
+        result = resolve_pod_name(
+            "robot-shop", "cart-old-def", "ReplicaSet", "cart-abc"
+        )
+        assert result == "cart-new-xyz"
+
+    @patch("krkn_ai.utils.pvc_utils.KrknKubernetes")
+    def test_falls_back_when_no_matching_live_pod(self, mock_krkn_cls):
+        pvc_utils._kubeconfig_path = "/tmp/kubeconfig"
+
+        mock_ref = Mock()
+        mock_ref.kind = "ReplicaSet"
+        mock_ref.name = "other-rs"
+
+        unrelated_pod = Mock()
+        unrelated_pod.metadata.name = "other-pod"
+        unrelated_pod.metadata.owner_references = [mock_ref]
+
+        mock_krkn_cls.return_value.cli.list_namespaced_pod.return_value.items = [
+            unrelated_pod
+        ]
+
+        result = resolve_pod_name(
+            "robot-shop", "cart-old-def", "ReplicaSet", "cart-abc"
+        )
+        assert result == "cart-old-def"
+
+    @patch("krkn_ai.utils.pvc_utils.KrknKubernetes")
+    def test_falls_back_on_api_exception(self, mock_krkn_cls):
+        pvc_utils._kubeconfig_path = "/tmp/kubeconfig"
+
+        mock_krkn_cls.return_value.cli.list_namespaced_pod.side_effect = Exception(
+            "connection refused"
+        )
+
+        result = resolve_pod_name("robot-shop", "cart-old", "ReplicaSet", "cart-abc")
+        assert result == "cart-old"
+
+    @patch("krkn_ai.utils.pvc_utils.KrknKubernetes")
+    def test_distinguishes_pods_from_different_owners(self, mock_krkn_cls):
+        pvc_utils._kubeconfig_path = "/tmp/kubeconfig"
+
+        wrong_ref = Mock()
+        wrong_ref.kind = "ReplicaSet"
+        wrong_ref.name = "cart-v2-abc"
+
+        wrong_owner_pod = Mock()
+        wrong_owner_pod.metadata.name = "cart-v2-new"
+        wrong_owner_pod.metadata.owner_references = [wrong_ref]
+
+        correct_ref = Mock()
+        correct_ref.kind = "ReplicaSet"
+        correct_ref.name = "cart-v1-abc"
+
+        correct_owner_pod = Mock()
+        correct_owner_pod.metadata.name = "cart-v1-new"
+        correct_owner_pod.metadata.owner_references = [correct_ref]
+
+        mock_krkn_cls.return_value.cli.list_namespaced_pod.return_value.items = [
+            wrong_owner_pod,
+            correct_owner_pod,
+        ]
+
+        result = resolve_pod_name(
+            "robot-shop", "cart-v1-old", "ReplicaSet", "cart-v1-abc"
+        )
+        assert result == "cart-v1-new"


### PR DESCRIPTION
Resolves https://github.com/krkn-chaos/krkn-ai/issues/56

## Issue
When we run certain scenarios in sequence (e.g: pod_scenario -> dns_outage) targeting same pod, then we used to observe that pod_scenario would disrupt the pod in creating a new pod. Krkn-AI would be relying on the `cluster_components` identified during discovery which would make some of the pod named deleted due to certain scenarios obsolete.

## Fix
Each pod is now associated with its immediate owner reference and that is used to do a look up. `PodNameParameter` now has overided `get_value()` method that resolves the new pod name using owner matching at runtime.