### PR TITLE
fix: correct scenario name mapping in composite graphs (#159)

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -64,18 +64,31 @@ class KrknRunner:
         # Check if krknctl is available
         krknctl_available = True
         podman_available = True
-        _, returncode = run_shell("krknctl --version", do_not_log=True)
-        if returncode != 0:
+        try:
+            _, returncode = run_shell("krknctl --version", do_not_log=True)
+            if returncode != 0:
+                krknctl_available = False
+                logger.warning("krknctl is not available.")
+        except Exception:
             krknctl_available = False
             logger.warning("krknctl is not available.")
 
         # Check if podman is available
-        _, returncode = run_shell("podman --version", do_not_log=True)
-        if returncode != 0:
+        try:
+            _, returncode = run_shell("podman --version", do_not_log=True)
+            if returncode != 0:
+                podman_available = False
+                logger.warning("podman is not available.")
+        except Exception:
             podman_available = False
             logger.warning("podman is not available.")
 
         if krknctl_available is False and podman_available is False:
+            if env_is_truthy("MOCK_RUN"):
+                logger.warning(
+                    "krknctl and podman are not available, but MOCK_RUN is enabled. Using CLI_RUNNER for mock run."
+                )
+                return KrknRunnerType.CLI_RUNNER
             raise Exception(
                 "krknctl and podman are not available. Please install krknctl and podman."
             )
@@ -378,7 +391,7 @@ class KrknRunner:
         }
         result = {
             "image": scenario.krknhub_image,
-            "name": scenario.name,
+            "name": scenario.krknctl_name,
             "env": env,
         }
         if depends_on is not None:

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -47,9 +47,10 @@ class TestKrknRunnerInitialization:
             runner = KrknRunner(config=minimal_config, output_dir=temp_output_dir)
             assert runner.runner_type == KrknRunnerType.CLI_RUNNER
 
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
     @patch("krkn_ai.chaos_engines.krkn_runner.run_shell")
     def test_init_raises_when_no_runner_available(
-        self, mock_run_shell, minimal_config, temp_output_dir
+        self, mock_run_shell, mock_env, minimal_config, temp_output_dir
     ):
         """Test raises exception when neither krknctl nor podman is available"""
         mock_run_shell.side_effect = [
@@ -214,3 +215,19 @@ class TestKrknRunnerCommandGeneration:
             assert os.path.exists(graph_dir)
             json_files = [f for f in os.listdir(graph_dir) if f.endswith(".json")]
             assert len(json_files) > 0
+
+    def test_generate_scenario_json_uses_krknctl_name(self, minimal_config, temp_output_dir, mock_cluster_components):
+        """Test __generate_scenario_json uses krknctl_name for the name field (Issue #159)"""
+        from krkn_ai.models.scenario.scenario_dns_outage import DnsOutageScenario
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client"):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            scenario = DnsOutageScenario(cluster_components=mock_cluster_components)
+            # Access private method for testing
+            result = runner._KrknRunner__generate_scenario_json(scenario)
+            assert result["name"] == "pod-network-filter"
+            assert result["name"] != "dns-outage"


### PR DESCRIPTION
### Description
Fixes #159. When generating composite scenarios (graphs), the runner was incorrectly using the internal scenario name (e.g., `dns-outage`) instead of the CLI-compatible name (`pod-network-filter`). This led to validation failures in [krknctl](cci:1://file:///e:/opensource/krkn_ai/tests/unit/chaos_engines/test_krkn_runner.py:217:4-231:49) during execution.

I also updated [KrknRunner](cci:2://file:///e:/opensource/krkn_ai/krkn_ai/chaos_engines/krkn_runner.py:46:0-570:43) to gracefully handle cases where [krknctl](cci:1://file:///e:/opensource/krkn_ai/tests/unit/chaos_engines/test_krkn_runner.py:217:4-231:49) or `podman` are missing from the system path during mock runs, preventing unexpected `FileNotFoundError` crashes.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing
- Added a targeted regression test in [tests/unit/chaos_engines/test_krkn_runner.py](cci:7://file:///e:/opensource/krkn_ai/tests/unit/chaos_engines/test_krkn_runner.py:0:0-0:0) to verify that [DnsOutageScenario](cci:2://file:///e:/opensource/krkn_ai/krkn_ai/models/scenario/scenario_dns_outage.py:14:0-54:43) maps correctly in the generated JSON.
- Verified locally using a `MOCK_RUN` that the generated graph JSON now uses the correct CLI names for composite nodes.

### Checklist
- [x] I have read the [CONTRIBUTING] guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

### Additional Notes
None.
