### PR TITLE
fix: handle empty Prometheus values in fitness calculation

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -474,8 +474,12 @@ class KrknRunner:
             end_time=timestamp,
             granularity=100,
         )
-        # Find the first series with non-empty values (multi-series responses possible
-        # with unaggregated PromQL queries; aggregation should produce single series)
+        if not result:
+            raise FitnessFunctionCalculationError(
+                f"Prometheus returned no data for query '{query}' at {timestamp} "
+                f"during {context}. This may indicate the metric does not exist "
+                f"in the requested time range or Prometheus has not yet scraped data."
+            )
         for series in result:
             if series.get("values"):
                 return series["values"][-1][1]
@@ -512,7 +516,12 @@ class KrknRunner:
             end_time=end,
             granularity=100,
         )
-        # Find the first series with non-empty values (same logic as point fitness)
+        if not result:
+            raise FitnessFunctionCalculationError(
+                f"Prometheus returned no data for query '{query}' in range "
+                f"[{start}, {end}]. This may indicate the metric does not exist "
+                f"in the requested time range or Prometheus has not yet scraped data."
+            )
         for series in result:
             if series.get("values"):
                 return float(series["values"][-1][1])

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -442,21 +442,48 @@ class KrknRunner:
         Helpful to measure values for counter based metric like restarts.
         """
         logger.debug("Calculating Point Fitness")
-        result_at_beginning = self.prom_client.process_prom_query_in_range(
-            query,
-            start_time=start,
-            end_time=start,
-            granularity=100,
-        )[0]["values"][-1][1]
-
-        result_at_end = self.prom_client.process_prom_query_in_range(
-            query,
-            start_time=end,
-            end_time=end,
-            granularity=100,
-        )[0]["values"][-1][1]
+        result_at_beginning = self._query_prometheus_single_point(
+            query, start, "point fitness (start)"
+        )
+        result_at_end = self._query_prometheus_single_point(
+            query, end, "point fitness (end)"
+        )
 
         return float(result_at_end) - float(result_at_beginning)
+
+    def _query_prometheus_single_point(
+        self, query: str, timestamp: datetime.datetime, context: str
+    ) -> str:
+        """
+        Query Prometheus for a single point at a specific timestamp.
+
+        Args:
+            query: The PromQL query to execute
+            timestamp: The timestamp to query at
+            context: Description of where this is called from (for error messages)
+
+        Returns:
+            The metric value as a string
+
+        Raises:
+            FitnessFunctionCalculationError: If Prometheus returns no data
+        """
+        result = self.prom_client.process_prom_query_in_range(
+            query,
+            start_time=timestamp,
+            end_time=timestamp,
+            granularity=100,
+        )
+        # Find the first series with non-empty values (multi-series responses possible
+        # with unaggregated PromQL queries; aggregation should produce single series)
+        for series in result:
+            if series.get("values"):
+                return series["values"][-1][1]
+        raise FitnessFunctionCalculationError(
+            f"Prometheus returned no data for query '{query}' at {timestamp} "
+            f"during {context}. This may indicate the metric does not exist "
+            f"in the requested time range or Prometheus has not yet scraped data."
+        )
 
     def calculate_range_fitness(self, start, end, query):
         """
@@ -484,9 +511,16 @@ class KrknRunner:
             start_time=start,
             end_time=end,
             granularity=100,
-        )[0]["values"][-1][1]
-
-        return float(result)
+        )
+        # Find the first series with non-empty values (same logic as point fitness)
+        for series in result:
+            if series.get("values"):
+                return float(series["values"][-1][1])
+        raise FitnessFunctionCalculationError(
+            f"Prometheus returned no data for query '{query}' in range "
+            f"[{start}, {end}]. This may indicate the metric does not exist "
+            f"in the requested time range or Prometheus has not yet scraped data."
+        )
 
     def __extract_returncode_from_run(
         self, log: str, default_returncode: int

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -223,7 +223,8 @@ class TestCalculatePointFitness:
     def test_calculate_point_fitness_success(self, minimal_config, temp_output_dir):
         """Test point fitness calculation with valid Prometheus response"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
@@ -232,7 +233,10 @@ class TestCalculatePointFitness:
             [{"values": [[2000, "10"]]}],  # end query
         ]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -243,21 +247,31 @@ class TestCalculatePointFitness:
             start = datetime.datetime(2024, 1, 1, 12, 0, 0)
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
-            score = runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+            score = runner.calculate_point_fitness(
+                start, end, "sum(kube_pod_container_status_restarts_total)"
+            )
 
             assert score == 5.0  # 10 - 5
             assert mock_prom_client.process_prom_query_in_range.call_count == 2
 
-    def test_calculate_point_fitness_empty_values_raises_error(self, minimal_config, temp_output_dir):
+    def test_calculate_point_fitness_empty_values_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test point fitness raises FitnessFunctionCalculationError when Prometheus returns empty values"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
-        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]  # Empty values
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": []}
+        ]  # Empty values
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -269,21 +283,29 @@ class TestCalculatePointFitness:
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
             with pytest.raises(FitnessFunctionCalculationError) as exc_info:
-                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+                runner.calculate_point_fitness(
+                    start, end, "sum(kube_pod_container_status_restarts_total)"
+                )
 
             assert "Prometheus returned no data" in str(exc_info.value)
             assert "point fitness (start)" in str(exc_info.value)
 
-    def test_calculate_point_fitness_none_result_raises_error(self, minimal_config, temp_output_dir):
+    def test_calculate_point_fitness_none_result_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test point fitness raises error when Prometheus returns None result"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
         mock_prom_client.process_prom_query_in_range.return_value = None
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -295,20 +317,28 @@ class TestCalculatePointFitness:
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
             with pytest.raises(FitnessFunctionCalculationError) as exc_info:
-                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+                runner.calculate_point_fitness(
+                    start, end, "sum(kube_pod_container_status_restarts_total)"
+                )
 
             assert "Prometheus returned no data" in str(exc_info.value)
 
-    def test_calculate_point_fitness_empty_list_result_raises_error(self, minimal_config, temp_output_dir):
+    def test_calculate_point_fitness_empty_list_result_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test point fitness raises error when Prometheus returns empty list"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
         mock_prom_client.process_prom_query_in_range.return_value = []
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -320,11 +350,15 @@ class TestCalculatePointFitness:
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
             with pytest.raises(FitnessFunctionCalculationError) as exc_info:
-                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+                runner.calculate_point_fitness(
+                    start, end, "sum(kube_pod_container_status_restarts_total)"
+                )
 
             assert "Prometheus returned no data" in str(exc_info.value)
 
-    def test_query_prometheus_single_point_context_in_error(self, minimal_config, temp_output_dir):
+    def test_query_prometheus_single_point_context_in_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test that context string appears in error message"""
         minimal_config.fitness_function = FitnessFunction(
             query="up", type=FitnessFunctionType.point
@@ -333,7 +367,10 @@ class TestCalculatePointFitness:
         mock_prom_client = Mock()
         mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -357,7 +394,8 @@ class TestCalculateRangeFitness:
     def test_calculate_range_fitness_success(self, minimal_config, temp_output_dir):
         """Test range fitness calculation with valid Prometheus response"""
         minimal_config.fitness_function = FitnessFunction(
-            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+            query="max(kube_pod_container_status_restarts_total{$range$})",
+            type=FitnessFunctionType.range,
         )
 
         mock_prom_client = Mock()
@@ -365,7 +403,10 @@ class TestCalculateRangeFitness:
             {"values": [[1000, "15.5"]]}
         ]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -385,16 +426,22 @@ class TestCalculateRangeFitness:
             assert "10m" in call_str
             assert score == 15.5
 
-    def test_calculate_range_fitness_empty_values_raises_error(self, minimal_config, temp_output_dir):
+    def test_calculate_range_fitness_empty_values_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test range fitness raises FitnessFunctionCalculationError when Prometheus returns empty values"""
         minimal_config.fitness_function = FitnessFunction(
-            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+            query="max(kube_pod_container_status_restarts_total{$range$})",
+            type=FitnessFunctionType.range,
         )
 
         mock_prom_client = Mock()
         mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -415,16 +462,22 @@ class TestCalculateRangeFitness:
             assert "2024-01-01 12:00:00" in str(exc_info.value)
             assert "2024-01-01 12:05:00" in str(exc_info.value)
 
-    def test_calculate_range_fitness_none_result_raises_error(self, minimal_config, temp_output_dir):
+    def test_calculate_range_fitness_none_result_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
         """Test range fitness raises error when Prometheus returns None result"""
         minimal_config.fitness_function = FitnessFunction(
-            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+            query="max(kube_pod_container_status_restarts_total{$range$})",
+            type=FitnessFunctionType.range,
         )
 
         mock_prom_client = Mock()
         mock_prom_client.process_prom_query_in_range.return_value = None
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -448,10 +501,13 @@ class TestCalculateFitnessValueRetries:
 
     @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
     @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
-    def test_calculate_fitness_value_retries_on_empty_data(self, mock_env, mock_sleep, minimal_config, temp_output_dir):
+    def test_calculate_fitness_value_retries_on_empty_data(
+        self, mock_env, mock_sleep, minimal_config, temp_output_dir
+    ):
         """Test that calculate_fitness_value retries when Prometheus returns empty data"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
@@ -463,7 +519,10 @@ class TestCalculateFitnessValueRetries:
             [{"values": [[2000, "10"]]}],
         ]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -475,23 +534,34 @@ class TestCalculateFitnessValueRetries:
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
             # Should not raise since eventually succeeds
-            score = runner.calculate_fitness_value(start, end, "sum(kube_pod_container_status_restarts_total)", FitnessFunctionType.point)
+            score = runner.calculate_fitness_value(
+                start,
+                end,
+                "sum(kube_pod_container_status_restarts_total)",
+                FitnessFunctionType.point,
+            )
             assert score == 5.0
             assert mock_prom_client.process_prom_query_in_range.call_count == 4
 
     @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
     @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
-    def test_calculate_fitness_value_raises_after_retries_exhausted(self, mock_env, mock_sleep, minimal_config, temp_output_dir):
+    def test_calculate_fitness_value_raises_after_retries_exhausted(
+        self, mock_env, mock_sleep, minimal_config, temp_output_dir
+    ):
         """Test that calculate_fitness_value raises after 3 retries when Prometheus keeps returning empty data"""
         minimal_config.fitness_function = FitnessFunction(
-            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
         )
 
         mock_prom_client = Mock()
         # All calls return empty
         mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,
@@ -503,7 +573,12 @@ class TestCalculateFitnessValueRetries:
             end = datetime.datetime(2024, 1, 1, 12, 5, 0)
 
             with pytest.raises(FitnessFunctionCalculationError) as exc_info:
-                runner.calculate_fitness_value(start, end, "sum(kube_pod_container_status_restarts_total)", FitnessFunctionType.point)
+                runner.calculate_fitness_value(
+                    start,
+                    end,
+                    "sum(kube_pod_container_status_restarts_total)",
+                    FitnessFunctionType.point,
+                )
 
             # After retries exhausted, calculate_fitness_value raises its own error
             assert "failed after 3 retries" in str(exc_info.value)

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -14,6 +14,7 @@ from krkn_ai.models.config import (
     FitnessFunctionType,
     HealthCheckConfig,
 )
+from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
 from krkn_ai.models.cluster_components import ClusterComponents
@@ -214,3 +215,298 @@ class TestKrknRunnerCommandGeneration:
             assert os.path.exists(graph_dir)
             json_files = [f for f in os.listdir(graph_dir) if f.endswith(".json")]
             assert len(json_files) > 0
+
+
+class TestCalculatePointFitness:
+    """Test calculate_point_fitness and _query_prometheus_single_point"""
+
+    def test_calculate_point_fitness_success(self, minimal_config, temp_output_dir):
+        """Test point fitness calculation with valid Prometheus response"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.side_effect = [
+            [{"values": [[1000, "5"]]}],  # start query
+            [{"values": [[2000, "10"]]}],  # end query
+        ]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            score = runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+
+            assert score == 5.0  # 10 - 5
+            assert mock_prom_client.process_prom_query_in_range.call_count == 2
+
+    def test_calculate_point_fitness_empty_values_raises_error(self, minimal_config, temp_output_dir):
+        """Test point fitness raises FitnessFunctionCalculationError when Prometheus returns empty values"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]  # Empty values
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+
+            assert "Prometheus returned no data" in str(exc_info.value)
+            assert "point fitness (start)" in str(exc_info.value)
+
+    def test_calculate_point_fitness_none_result_raises_error(self, minimal_config, temp_output_dir):
+        """Test point fitness raises error when Prometheus returns None result"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = None
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+
+            assert "Prometheus returned no data" in str(exc_info.value)
+
+    def test_calculate_point_fitness_empty_list_result_raises_error(self, minimal_config, temp_output_dir):
+        """Test point fitness raises error when Prometheus returns empty list"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = []
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_point_fitness(start, end, "sum(kube_pod_container_status_restarts_total)")
+
+            assert "Prometheus returned no data" in str(exc_info.value)
+
+    def test_query_prometheus_single_point_context_in_error(self, minimal_config, temp_output_dir):
+        """Test that context string appears in error message"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="up", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            ts = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner._query_prometheus_single_point("up", ts, "my custom context")
+
+            assert "my custom context" in str(exc_info.value)
+            assert "up" in str(exc_info.value)
+            assert "2024-01-01 12:00:00" in str(exc_info.value)
+
+
+class TestCalculateRangeFitness:
+    """Test calculate_range_fitness"""
+
+    def test_calculate_range_fitness_success(self, minimal_config, temp_output_dir):
+        """Test range fitness calculation with valid Prometheus response"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "15.5"]]}
+        ]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 10, 0)
+
+            score = runner.calculate_range_fitness(
+                start, end, "max(kube_pod_container_status_restarts_total{$range$})"
+            )
+
+            # Query should have $range$ replaced with "10m"
+            call_str = str(mock_prom_client.process_prom_query_in_range.call_args)
+            assert "10m" in call_str
+            assert score == 15.5
+
+    def test_calculate_range_fitness_empty_values_raises_error(self, minimal_config, temp_output_dir):
+        """Test range fitness raises FitnessFunctionCalculationError when Prometheus returns empty values"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_range_fitness(
+                    start, end, "max(kube_pod_container_status_restarts_total{$range$})"
+                )
+
+            assert "Prometheus returned no data" in str(exc_info.value)
+            assert "range" in str(exc_info.value)
+            assert "2024-01-01 12:00:00" in str(exc_info.value)
+            assert "2024-01-01 12:05:00" in str(exc_info.value)
+
+    def test_calculate_range_fitness_none_result_raises_error(self, minimal_config, temp_output_dir):
+        """Test range fitness raises error when Prometheus returns None result"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max(kube_pod_container_status_restarts_total{$range$})", type=FitnessFunctionType.range
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = None
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_range_fitness(
+                    start, end, "max(kube_pod_container_status_restarts_total{$range$})"
+                )
+
+            assert "Prometheus returned no data" in str(exc_info.value)
+
+
+class TestCalculateFitnessValueRetries:
+    """Test calculate_fitness_value retry behavior with empty Prometheus data"""
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    def test_calculate_fitness_value_retries_on_empty_data(self, mock_env, mock_sleep, minimal_config, temp_output_dir):
+        """Test that calculate_fitness_value retries when Prometheus returns empty data"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        # First two calls return empty, third call succeeds
+        mock_prom_client.process_prom_query_in_range.side_effect = [
+            [{"values": []}],
+            [{"values": []}],
+            [{"values": [[1000, "5"]]}],
+            [{"values": [[2000, "10"]]}],
+        ]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            # Should not raise since eventually succeeds
+            score = runner.calculate_fitness_value(start, end, "sum(kube_pod_container_status_restarts_total)", FitnessFunctionType.point)
+            assert score == 5.0
+            assert mock_prom_client.process_prom_query_in_range.call_count == 4
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    def test_calculate_fitness_value_raises_after_retries_exhausted(self, mock_env, mock_sleep, minimal_config, temp_output_dir):
+        """Test that calculate_fitness_value raises after 3 retries when Prometheus keeps returning empty data"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)", type=FitnessFunctionType.point
+        )
+
+        mock_prom_client = Mock()
+        # All calls return empty
+        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
+
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client", return_value=mock_prom_client):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_fitness_value(start, end, "sum(kube_pod_container_status_restarts_total)", FitnessFunctionType.point)
+
+            # After retries exhausted, calculate_fitness_value raises its own error
+            assert "failed after 3 retries" in str(exc_info.value)
+            # Each retry calls calculate_point_fitness which calls _query_prometheus_single_point
+            # for the start point. The guard fails immediately, so 1 Prometheus call per retry = 3 total.
+            assert mock_prom_client.process_prom_query_in_range.call_count == 3


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Prometheus queries in `calculate_point_fitness()` and `calculate_range_fitness()` accessed `result[0]["values"][-1][1]` without validating that `values` was non-empty. When Prometheus returned no data for a query, this caused a cryptic `IndexError` that was caught only after 3 retries with a generic error message, obscuring the real cause (missing metrics, 
unsupported time range, or Prometheus not yet scraping data).

This PR:

- Extracts a `_query_prometheus_single_point()` helper that validates Prometheus response data before accessing it, raising a descriptive `FitnessFunctionCalculationError` that includes the query, timestamp, and a hint about possible causes
- Refactors `calculate_point_fitness()` to use the helper for both start and end queries
- Fixes `calculate_range_fitness()` with the same guard pattern
- Adds comprehensive unit tests covering success paths, empty `values`, `None` result, empty list result, and retry behavior

# Documentation
- [ ] Is documentation needed for this update?

# Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Unit tests added with >80% coverage on changed code
- [x] Changes are consistent with the project's code style (PEP 8, ruff)
- [x] All existing tests pass

# Testing performed

```bash
# Run the specific test file
python3 -m pytest tests/unit/chaos_engines/test_krkn_runner.py -v
```
<img width="1470" height="690" alt="Screenshot 2026-04-11 at 6 36 56 PM" src="https://github.com/user-attachments/assets/0d030abd-9224-41a6-a27a-7a8615a2f9b4" />