### PR TITLE
feat: auth token support for health check URLs

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 import threading
 import time
 import requests
-from typing import List, Dict, Tuple
+from typing import Dict, List, Optional, Tuple
 import numpy as np
 
 from krkn_ai.utils.logger import get_logger
@@ -28,7 +28,11 @@ logger = get_logger(__name__)
 
 
 class HealthCheckWatcher:
-    def __init__(self, config: HealthCheckConfig, params: Dict[str, ParameterValue] = None):
+    def __init__(
+        self,
+        config: HealthCheckConfig,
+        params: Optional[Dict[str, ParameterValue]] = None,
+    ):
         self.config = config
         self._params = {k: v.value for k, v in (params or {}).items()}
         self._stop_event = threading.Event()
@@ -58,12 +62,14 @@ class HealthCheckWatcher:
         thread_results: List[HealthCheckResult] = []
         self._thread_results[thread_id] = (health_check.url, thread_results)
 
+        resolved_headers = self._resolve_headers(health_check)
+
         # Simple polling loop, stops when stop() is called
         while not self._stop_event.is_set():
             try:
                 resp = requests.get(
                     health_check.url,
-                    headers=self._resolve_headers(health_check),
+                    headers=resolved_headers,
                     timeout=health_check.timeout,
                 )
                 status = resp.status_code

--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -16,18 +16,21 @@ from typing import List, Dict, Tuple
 import numpy as np
 
 from krkn_ai.utils.logger import get_logger
+from krkn_ai.utils.fs import preprocess_param_string
 from krkn_ai.models.config import (
     HealthCheckApplicationConfig,
     HealthCheckConfig,
     HealthCheckResult,
+    ParameterValue,
 )
 
 logger = get_logger(__name__)
 
 
 class HealthCheckWatcher:
-    def __init__(self, config: HealthCheckConfig):
+    def __init__(self, config: HealthCheckConfig, params: Dict[str, ParameterValue] = None):
         self.config = config
+        self._params = {k: v.value for k, v in (params or {}).items()}
         self._stop_event = threading.Event()
         self._threads: List[threading.Thread] = []
         # Each thread stores results in its own list - ZERO contention!
@@ -43,6 +46,10 @@ class HealthCheckWatcher:
             t.start()
             self._threads.append(t)
 
+    def _resolve_headers(self, app: HealthCheckApplicationConfig) -> dict:
+        merged = {**(self.config.headers or {}), **(app.headers or {})}
+        return {k: preprocess_param_string(v, self._params) for k, v in merged.items()}
+
     def run_health_check(self, health_check: HealthCheckApplicationConfig):
         # Each thread gets its own private results list
         thread_id = threading.current_thread().ident
@@ -54,7 +61,11 @@ class HealthCheckWatcher:
         # Simple polling loop, stops when stop() is called
         while not self._stop_event.is_set():
             try:
-                resp = requests.get(health_check.url, timeout=health_check.timeout)
+                resp = requests.get(
+                    health_check.url,
+                    headers=self._resolve_headers(health_check),
+                    timeout=health_check.timeout,
+                )
                 status = resp.status_code
                 success = status == health_check.status_code
                 error = None

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -103,7 +103,9 @@ class KrknRunner:
         else:
             raise NotImplementedError("Scenario unable to run")
 
-        health_check_watcher = HealthCheckWatcher(self.config.health_checks, self.config.parameters)
+        health_check_watcher = HealthCheckWatcher(
+            self.config.health_checks, self.config.parameters
+        )
 
         # Run command and fetch result
         if env_is_truthy("MOCK_RUN"):
@@ -111,10 +113,10 @@ class KrknRunner:
             time.sleep(rng.randint(1, 3))
             log, returncode = "", 0
         else:
-            # Start watching application urls for health checks
-            health_check_watcher.run()
-
             try:
+                # Start watching application urls for health checks
+                health_check_watcher.run()
+
                 # Run command (show logs when verbose mode is enabled)
                 log, returncode = run_shell(
                     self.process_es_env_string(command, True),

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -103,7 +103,7 @@ class KrknRunner:
         else:
             raise NotImplementedError("Scenario unable to run")
 
-        health_check_watcher = HealthCheckWatcher(self.config.health_checks)
+        health_check_watcher = HealthCheckWatcher(self.config.health_checks, self.config.parameters)
 
         # Run command and fetch result
         if env_is_truthy("MOCK_RUN"):

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -140,11 +140,13 @@ class HealthCheckApplicationConfig(BaseModel):
     status_code: int = 200  # Expected status code
     timeout: int = 4  # in seconds
     interval: int = 2  # in seconds
+    headers: Optional[Dict[str, str]] = None
 
 
 class HealthCheckConfig(BaseModel):
     stop_watcher_on_failure: bool = False
     applications: List[HealthCheckApplicationConfig] = []
+    headers: Optional[Dict[str, str]] = None
 
 
 class OutputConfig(BaseModel):

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -1,7 +1,13 @@
 import datetime
 from enum import Enum
 from typing import Dict, List, Optional, Union
-from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 import krkn_ai.constants as const
 from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.utils import id_generator

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -1,10 +1,23 @@
 import datetime
 from enum import Enum
 from typing import Dict, List, Optional, Union
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_serializer, model_validator
 import krkn_ai.constants as const
 from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.utils import id_generator
+
+
+class ParameterValue(BaseModel):
+    value: str
+    is_private: bool = False
+
+    @model_serializer
+    def serialize(self) -> str:
+        return "***" if self.is_private else self.value
+
+    @classmethod
+    def from_cli(cls, key: str, raw: str) -> "ParameterValue":
+        return cls(value=raw, is_private=key.startswith("__"))
 
 
 class PodScenarioConfig(BaseModel):
@@ -237,7 +250,7 @@ class StoppingCriteria(BaseModel):
 
 class ConfigFile(BaseModel):
     kubeconfig_file_path: str  # Path to kubeconfig
-    parameters: Dict[str, str] = {}
+    parameters: Dict[str, ParameterValue] = {}
 
     seed: Optional[int] = None  # Optional: Random seed for reproducible runs
 

--- a/krkn_ai/reporter/generations_reporter.py
+++ b/krkn_ai/reporter/generations_reporter.py
@@ -4,6 +4,9 @@ from typing import List
 
 import yaml
 
+import matplotlib
+
+matplotlib.use("Agg")
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MaxNLocator

--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -1,6 +1,9 @@
 import os
 import pandas as pd
 
+import matplotlib
+
+matplotlib.use("Agg")
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -3,7 +3,7 @@ import os
 import yaml
 from typing import Union, List, Dict
 
-from krkn_ai.models.config import ConfigFile
+from krkn_ai.models.config import ConfigFile, ParameterValue
 from krkn_ai.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -42,43 +42,39 @@ def read_config_from_file(
                 key, value = p.split("=", 1)
             else:
                 key, value = p, ""
-            params[str(key)] = str(value)
+            params[str(key)] = ParameterValue.from_cli(str(key), str(value))
+
+        raw = {k: v.value for k, v in params.items()}
 
         # Replace parameter in health check url string
-        if "health_checks" in config and "applications" in config["health_checks"]:
-            for health_check in config["health_checks"]["applications"]:
-                health_check["url"] = preprocess_param_string(
-                    health_check["url"], params
-                )
+        for app in config.get("health_checks", {}).get("applications", []):
+            app["url"] = preprocess_param_string(app["url"], raw)
 
         # Replace parameter in elastic configuration
         if "elastic" in config and "server" in config["elastic"]:
             config["elastic"]["enable"] = is_truthy(
-                preprocess_param_string(config["elastic"]["enable"], params)
+                preprocess_param_string(config["elastic"]["enable"], raw)
             )
             config["elastic"]["verify_certs"] = is_truthy(
-                preprocess_param_string(config["elastic"]["verify_certs"], params)
+                preprocess_param_string(config["elastic"]["verify_certs"], raw)
             )
             config["elastic"]["server"] = preprocess_param_string(
-                config["elastic"]["server"], params
+                config["elastic"]["server"], raw
             )
             config["elastic"]["port"] = preprocess_param_string(
-                config["elastic"]["port"], params
+                config["elastic"]["port"], raw
             )
             config["elastic"]["username"] = preprocess_param_string(
-                config["elastic"]["username"], params
+                config["elastic"]["username"], raw
             )
             config["elastic"]["password"] = preprocess_param_string(
-                config["elastic"]["password"], params
+                config["elastic"]["password"], raw
             )
             config["elastic"]["index"] = preprocess_param_string(
-                config["elastic"]["index"], params
+                config["elastic"]["index"], raw
             )
 
-        # Remove private parameters from config (starts with double __underscore)
-        config["parameters"] = {
-            k: v for k, v in params.items() if not k.startswith("__")
-        }
+        config["parameters"] = params
 
     return ConfigFile(**config)
 

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -284,7 +284,9 @@ class TestHealthCheckWatcherHeaders:
         watcher.run()
         watcher.stop()
 
-        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer endpoint"
+        assert (
+            mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer endpoint"
+        )
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_global_and_endpoint_headers_merged(self, mock_get):
@@ -336,7 +338,10 @@ class TestHealthCheckWatcherHeaders:
         watcher.run()
         watcher.stop()
 
-        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer resolved-token"
+        assert (
+            mock_get.call_args.kwargs["headers"]["Authorization"]
+            == "Bearer resolved-token"
+        )
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_missing_param_leaves_template_unchanged(self, mock_get):
@@ -360,4 +365,6 @@ class TestHealthCheckWatcherHeaders:
         watcher.run()
         watcher.stop()
 
-        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer $MISSING"
+        assert (
+            mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer $MISSING"
+        )

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -10,6 +10,7 @@ from krkn_ai.models.config import (
     HealthCheckConfig,
     HealthCheckApplicationConfig,
     HealthCheckResult,
+    ParameterValue,
 )
 
 
@@ -233,3 +234,130 @@ class TestHealthCheckWatcherResults:
                 assert result.success is False
                 assert result.status_code == -1
                 assert result.error is not None
+
+
+class TestHealthCheckWatcherHeaders:
+    """Test header merging and env-var resolution"""
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_global_headers_sent_when_no_endpoint_headers(self, mock_get):
+        """Global headers are passed to requests.get when endpoint has none"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_get.return_value = mock_response
+
+        config = HealthCheckConfig(
+            headers={"X-Global": "global-value"},
+            applications=[
+                HealthCheckApplicationConfig(
+                    name="api", url="http://localhost/health", interval=1
+                )
+            ],
+        )
+        watcher = HealthCheckWatcher(config)
+        watcher.run()
+        watcher.stop()
+
+        assert mock_get.call_args.kwargs["headers"]["X-Global"] == "global-value"
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_endpoint_headers_override_global(self, mock_get):
+        """Per-endpoint header wins over global for the same key"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_get.return_value = mock_response
+
+        config = HealthCheckConfig(
+            headers={"Authorization": "Bearer global"},
+            applications=[
+                HealthCheckApplicationConfig(
+                    name="api",
+                    url="http://localhost/health",
+                    headers={"Authorization": "Bearer endpoint"},
+                    interval=1,
+                )
+            ],
+        )
+        watcher = HealthCheckWatcher(config)
+        watcher.run()
+        watcher.stop()
+
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer endpoint"
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_global_and_endpoint_headers_merged(self, mock_get):
+        """Both global and endpoint headers are present when keys differ"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_get.return_value = mock_response
+
+        config = HealthCheckConfig(
+            headers={"X-Global": "g"},
+            applications=[
+                HealthCheckApplicationConfig(
+                    name="api",
+                    url="http://localhost/health",
+                    headers={"X-Endpoint": "e"},
+                    interval=1,
+                )
+            ],
+        )
+        watcher = HealthCheckWatcher(config)
+        watcher.run()
+        watcher.stop()
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["headers"]["X-Global"] == "g"
+        assert kwargs["headers"]["X-Endpoint"] == "e"
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_param_in_header_value_is_resolved(self, mock_get):
+        """$PARAM in a header value is resolved from the params dict passed to the watcher"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_get.return_value = mock_response
+
+        config = HealthCheckConfig(
+            applications=[
+                HealthCheckApplicationConfig(
+                    name="api",
+                    url="http://localhost/health",
+                    headers={"Authorization": "Bearer $__TOKEN"},
+                    interval=1,
+                )
+            ],
+        )
+        params = {"__TOKEN": ParameterValue(value="resolved-token", is_private=True)}
+        watcher = HealthCheckWatcher(config, params=params)
+        watcher.run()
+        watcher.stop()
+
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer resolved-token"
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_missing_param_leaves_template_unchanged(self, mock_get):
+        """$PARAM with no matching entry in params dict is passed through as-is"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.elapsed.total_seconds.return_value = 0.1
+        mock_get.return_value = mock_response
+
+        config = HealthCheckConfig(
+            applications=[
+                HealthCheckApplicationConfig(
+                    name="api",
+                    url="http://localhost/health",
+                    headers={"Authorization": "Bearer $MISSING"},
+                    interval=1,
+                )
+            ],
+        )
+        watcher = HealthCheckWatcher(config, params={})
+        watcher.run()
+        watcher.stop()
+
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer $MISSING"

--- a/tests/unit/chaos_engines/test_krkn_runner_leak.py
+++ b/tests/unit/chaos_engines/test_krkn_runner_leak.py
@@ -28,6 +28,7 @@ class TestKrknRunnerThreadLeak(unittest.TestCase):
         config.health_checks = MagicMock(spec=HealthCheckConfig)
         config.elastic = None
         config.wait_duration = 10
+        config.parameters = {}  # Pydantic v2 fields aren't in MagicMock spec; set explicitly
 
         from krkn_ai.models.scenario.base import Scenario
 

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -168,6 +168,27 @@ class TestHealthCheckConfig:
         assert app.timeout == 4
         assert app.interval == 2
 
+    def test_health_check_config_headers(self):
+        """Test optional headers field on both health check config models"""
+        # HealthCheckConfig global headers
+        config = HealthCheckConfig(headers={"Authorization": "Bearer ${TOKEN}"})
+        assert config.headers == {"Authorization": "Bearer ${TOKEN}"}
+
+        assert HealthCheckConfig().headers is None
+
+        # HealthCheckApplicationConfig per-endpoint headers
+        app = HealthCheckApplicationConfig(
+            name="api",
+            url="http://localhost:8080/health",
+            headers={"X-Custom": "value"},
+        )
+        assert app.headers == {"X-Custom": "value"}
+
+        app_no_headers = HealthCheckApplicationConfig(
+            name="api", url="http://localhost:8080/health"
+        )
+        assert app_no_headers.headers is None
+
 
 class TestOutputConfig:
     """Test OutputConfig model"""

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -10,6 +10,7 @@ from krkn_ai.models.config import (
     FitnessFunction,
     FitnessFunctionType,
     FitnessFunctionItem,
+    ParameterValue,
     ScenarioConfig,
     HealthCheckConfig,
     HealthCheckApplicationConfig,
@@ -18,6 +19,30 @@ from krkn_ai.models.config import (
     StoppingCriteria,
 )
 from krkn_ai.models.cluster_components import Namespace, Node
+
+
+class TestParameterValue:
+    def test_public_param(self):
+        param = ParameterValue(value="hello")
+        assert param.value == "hello"
+        assert param.is_private is False
+
+    def test_private_param_from_cli(self):
+        param = ParameterValue.from_cli("__SECRET", "token")
+        assert param.value == "token"
+        assert param.is_private is True
+
+    def test_public_param_from_cli(self):
+        param = ParameterValue.from_cli("HOST", "example.com")
+        assert param.is_private is False
+
+    def test_private_serializes_to_redacted(self):
+        param = ParameterValue.from_cli("__TOKEN", "real-secret")
+        assert param.model_dump() == "***"
+
+    def test_public_serializes_to_value(self):
+        param = ParameterValue.from_cli("HOST", "example.com")
+        assert param.model_dump() == "example.com"
 
 
 class TestConfigFile:
@@ -54,7 +79,7 @@ class TestConfigFile:
         scenario_config = ScenarioConfig(**{"pod-scenarios": {"enable": True}})
         config = ConfigFile(
             kubeconfig_file_path="/path/to/kubeconfig",
-            parameters={"key1": "value1"},
+            parameters={"key1": ParameterValue(value="value1")},
             generations=50,
             population_size=20,
             fitness_function=fitness,
@@ -72,7 +97,7 @@ class TestConfigFile:
         )
         assert config.generations == 50
         assert config.population_size == 20
-        assert config.parameters["key1"] == "value1"
+        assert config.parameters["key1"].value == "value1"
         assert config.scenario.pod_scenarios.enable is True
         assert len(config.health_checks.applications) == 1
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -2,7 +2,6 @@
 
 import yaml
 
-from krkn_ai.models.config import ParameterValue
 from krkn_ai.utils.fs import read_config_from_file
 
 
@@ -37,26 +36,6 @@ class TestParamParsing:
             key, value = p, ""
         assert key == "JUST_A_KEY"
         assert value == ""
-
-
-class TestParameterValue:
-    def test_public_param_from_cli(self):
-        param = ParameterValue.from_cli("MY_KEY", "my-value")
-        assert param.value == "my-value"
-        assert param.is_private is False
-
-    def test_private_param_from_cli(self):
-        param = ParameterValue.from_cli("__SECRET", "token123")
-        assert param.value == "token123"
-        assert param.is_private is True
-
-    def test_private_param_serializes_to_redacted(self):
-        param = ParameterValue.from_cli("__TOKEN", "real-secret")
-        assert param.model_dump() == "***"
-
-    def test_public_param_serializes_to_value(self):
-        param = ParameterValue.from_cli("HOST", "example.com")
-        assert param.model_dump() == "example.com"
 
 
 class TestReadConfigFromFileHeaders:

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,5 +1,10 @@
 """Tests for utils/fs.py"""
 
+import yaml
+
+from krkn_ai.models.config import ParameterValue
+from krkn_ai.utils.fs import read_config_from_file
+
 
 class TestParamParsing:
     def test_param_with_base64_value_does_not_crash(self):
@@ -32,3 +37,95 @@ class TestParamParsing:
             key, value = p, ""
         assert key == "JUST_A_KEY"
         assert value == ""
+
+
+class TestParameterValue:
+    def test_public_param_from_cli(self):
+        param = ParameterValue.from_cli("MY_KEY", "my-value")
+        assert param.value == "my-value"
+        assert param.is_private is False
+
+    def test_private_param_from_cli(self):
+        param = ParameterValue.from_cli("__SECRET", "token123")
+        assert param.value == "token123"
+        assert param.is_private is True
+
+    def test_private_param_serializes_to_redacted(self):
+        param = ParameterValue.from_cli("__TOKEN", "real-secret")
+        assert param.model_dump() == "***"
+
+    def test_public_param_serializes_to_value(self):
+        param = ParameterValue.from_cli("HOST", "example.com")
+        assert param.model_dump() == "example.com"
+
+
+class TestReadConfigFromFileHeaders:
+    def _write_config(self, path):
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "health_checks": {
+                "headers": {"Authorization": "Bearer $GLOBAL_TOKEN"},
+                "applications": [
+                    {
+                        "name": "api",
+                        "url": "http://localhost/health",
+                        "headers": {"X-Tenant": "$TENANT_ID"},
+                    }
+                ],
+            },
+        }
+        with open(path, "w") as f:
+            yaml.dump(config, f)
+
+    def test_headers_stay_as_templates_at_load_time(self, tmp_path):
+        """Header values are not substituted at load — resolution happens at request time"""
+        config_file = str(tmp_path / "config.yaml")
+        self._write_config(config_file)
+        config = read_config_from_file(
+            config_file, param=["GLOBAL_TOKEN=mytoken", "TENANT_ID=acme"]
+        )
+        assert config.health_checks.headers["Authorization"] == "Bearer $GLOBAL_TOKEN"
+
+    def test_endpoint_headers_stay_as_templates_at_load_time(self, tmp_path):
+        """Per-endpoint header values are not substituted at load"""
+        config_file = str(tmp_path / "config.yaml")
+        self._write_config(config_file)
+        config = read_config_from_file(
+            config_file, param=["GLOBAL_TOKEN=mytoken", "TENANT_ID=acme"]
+        )
+        assert config.health_checks.applications[0].headers["X-Tenant"] == "$TENANT_ID"
+
+    def test_url_param_substitution_applied_at_load_time(self, tmp_path):
+        """URL $PARAM substitution happens at load time via -p flag"""
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "health_checks": {
+                "applications": [{"name": "api", "url": "http://$HOST/health"}]
+            },
+        }
+        config_file = str(tmp_path / "config.yaml")
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+        result = read_config_from_file(config_file, param=["HOST=myhost.com"])
+        assert result.health_checks.applications[0].url == "http://myhost.com/health"
+
+    def test_no_crash_when_headers_absent(self, tmp_path):
+        """Test config without headers loads fine — guards on absent keys don't raise"""
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "health_checks": {
+                "applications": [{"name": "api", "url": "http://localhost/health"}]
+            },
+        }
+        config_file = str(tmp_path / "config.yaml")
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+        result = read_config_from_file(config_file, param=["KEY=value"])
+        assert result.health_checks.headers is None
+        assert result.health_checks.applications[0].headers is None


### PR DESCRIPTION
## Description

Health check URLs behind authenticated endpoints had no way to pass auth headers - requests would fail with 401s. This adds optional `headers` support at both the global (`health_checks`) and per-endpoint (`applications`) level, with per-endpoint taking priority over global on key conflicts.

Header values support `${ENV_VAR}` substitution so tokens don't get hardcoded into the config. Variables are resolved at request time, so the auto-generated output config only ever contains the placeholder strings, not the actual secrets.

Example config:
```yaml
health_checks:
  headers:
    X-Tenant-ID: "my-tenant"
    Authorization: "Bearer ${GLOBAL_TOKEN}"
  applications:
    - name: api
      url: https://my-api/health
      headers:
        Authorization: "Bearer ${API_TOKEN}"  # overrides global
```

Closes #187

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

## Testing

```
python -m pytest tests/unit/utils/test_fs.py tests/unit/chaos_engines/test_health_check_watcher.py tests/unit/models/test_config.py -v
```

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Additional Notes

`$PARAM` style substitution (via `-p` CLI flag) also works in header values, consistent with how it already works for health check URLs.