### PR TITLE
fix(containers): correct node-label condition and remove eval in entrypoint

### DIFF
--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -93,7 +93,7 @@ case "$MODE_LOWER" in
             exit 1
         fi
 
-        # Build the command
+        # Build the command array
         CMD=(krkn_ai run --config "$CONFIG_FILE" --output "$OUTPUT_DIR" --kubeconfig "$KUBECONFIG")
 
         # Add optional parameters

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -61,7 +61,7 @@ case "$MODE_LOWER" in
         if [ -n "$POD_LABEL" ]; then
             CMD+=(--pod-label "$POD_LABEL")
         fi
-        if [ -n "$POD_LABEL" ]; then
+        if [ -n "$NODE_LABEL" ]; then
             CMD+=(--node-label "$NODE_LABEL")
         fi
         if [ -n "$SKIP_POD_NAME" ]; then
@@ -94,34 +94,34 @@ case "$MODE_LOWER" in
         fi
 
         # Build the command
-        CMD="krkn_ai run --config $CONFIG_FILE --output $OUTPUT_DIR --kubeconfig $KUBECONFIG"
+        CMD=(krkn_ai run --config "$CONFIG_FILE" --output "$OUTPUT_DIR" --kubeconfig "$KUBECONFIG")
 
         # Add optional parameters
         if [ -n "$FORMAT" ]; then
-            CMD="$CMD --format $FORMAT"
+            CMD+=(--format "$FORMAT")
         fi
 
         if [ -n "$RUNNER_TYPE" ]; then
-            CMD="$CMD --runner-type $RUNNER_TYPE"
+            CMD+=(--runner-type "$RUNNER_TYPE")
         fi
 
         # Add extra parameters (comma-separated key=value pairs)
         if [ -n "$EXTRA_PARAMS" ]; then
             IFS=',' read -ra PARAMS <<< "$EXTRA_PARAMS"
             for param in "${PARAMS[@]}"; do
-                CMD="$CMD --param $param"
+                CMD+=(--param "$param")
             done
         fi
 
         # Add verbosity flags
         if [ "$VERBOSE" -ge 1 ]; then
             for ((i=0; i<$VERBOSE; i++)); do
-                CMD="$CMD -v"
+                CMD+=(-v)
             done
         fi
 
-        echo "Executing: $CMD"
-        eval $CMD
+        echo "Executing: ${CMD[*]}"
+        "${CMD[@]}"
         ;;
 
     *)


### PR DESCRIPTION
## Description

This PR addresses two bugs found in `containers/entrypoint.sh` during a codebase audit:

1. **Incorrect Variable Check:** In the `discover` mode block, `--node-label` was incorrectly guarded by `if [ -n "$POD_LABEL" ]`. This caused the script to attach `--node-label` only when `$POD_LABEL` was present, ignoring `$NODE_LABEL` entirely. It has been corrected to check `$NODE_LABEL`.

2. **Shell Injection Risk:** In the `run` mode block, the execution command was constructed as a plain string and executed via `eval $CMD`. If any parameters (like `EXTRA_PARAMS`) contained shell metacharacters, they would be blindly evaluated by the shell, creating a potential shell injection risk in multi-tenant environments. The execution flow has been refactored to use a safer Bash array (`"${CMD[@]}"`), matching the secure pattern already used in `discover` mode.

## Changes Made

- Changed the conditional check from `$POD_LABEL` to `$NODE_LABEL` on line 64.
- Refactored `CMD` from a string concatenation to a Bash array in the `run` mode block.
- Replaced the unsafe `eval $CMD` execution with `"${CMD[@]}"`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security fix (non-breaking change which addresses a security vulnerability)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Fixes #192 

## Dry-Run Output

Verified the fixes by simulating the container entrypoint execution:

### DISCOVER Mode (Node Label Fix)
Input: `MODE=discover NODE_LABEL=my-node-label`
```bash
Running in DISCOVER mode...
Executing: krkn_ai discover --kubeconfig kube.config --output /tmp/krkn-ai.yaml --node-label my-node-label
```

### RUN Mode (Array Execution & Param Parsing)
Input: `MODE=run EXTRA_PARAMS="key1=val1,key2=val2"`
```bash
Running in RUN mode...
Executing: krkn_ai run --config config.yaml --output /tmp --kubeconfig kube.config --param key1=val1 --param key2=val2
```
