### PR TITLE
fix(cli): Resolve --output crash and clean up CLI defaults

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -34,7 +34,7 @@ def main():
     default=os.getenv("KUBECONFIG", None),
 )
 @click.option("--config", "-c", help="Path to krkn-ai config file.")
-@click.option("--output", "-o", help="Directory to save results.")
+@click.option("--output", "-o", help="Directory to save results.", default="./")
 @click.option(
     "--format",
     "-f",

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -31,7 +31,7 @@ def main():
     "--kubeconfig",
     "-k",
     help="Path to cluster kubeconfig file. Setting this will override value in config file.",
-    default=os.getenv("KUBECONFIG", None),
+    envvar="KUBECONFIG",
 )
 @click.option("--config", "-c", help="Path to krkn-ai config file.")
 @click.option("--output", "-o", help="Directory to save results.", default="./")
@@ -195,7 +195,7 @@ def monitor(ctx, output: str, port: int):
     "--kubeconfig",
     "-k",
     help="Path to cluster kubeconfig file.",
-    default=os.getenv("KUBECONFIG", None),
+    envvar="KUBECONFIG",
 )
 @click.option(
     "--output", "-o", help="Path to save config file.", default="./krkn-ai.yaml"

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -83,7 +83,7 @@ def run(
     output: str = "./",
     format: str = "yaml",
     runner_type: str = None,
-    param: list[str] = None,
+    param: tuple[str, ...] = (),
     seed: int = None,
     verbose: int = 0,  # Default to INFO level
     monitoring: bool = False,

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -54,7 +54,6 @@ def main():
     "-p",
     multiple=True,
     help="Additional parameters for config file in key=value format.",
-    default=[],
 )
 @click.option(
     "--seed",

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -231,8 +231,8 @@ def monitor(ctx, output: str, port: int):
 def discover(
     ctx,
     kubeconfig: str,
-    output: str = "./",
-    namespace: str = "*",
+    output: str = "./krkn-ai.yaml",
+    namespace: str = ".*",
     pod_label: str = ".*",
     node_label: str = ".*",
     verbose: int = 0,

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -21,7 +21,9 @@ def preprocess_param_string(data: str, params: dict) -> str:
 
 
 def read_config_from_file(
-    file_path: str, param: Sequence[str] | None = None, kubeconfig: str | None = None
+    file_path: str,
+    param: Union[Sequence[str], None] = None,
+    kubeconfig: Union[str, None] = None,
 ) -> ConfigFile:
     """Read config file from local
     Args:

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -1,6 +1,7 @@
 import json
 import os
 import yaml
+from collections.abc import Sequence
 from typing import Union, List, Dict
 
 from krkn_ai.models.config import ConfigFile
@@ -20,7 +21,7 @@ def preprocess_param_string(data: str, params: dict) -> str:
 
 
 def read_config_from_file(
-    file_path: str, param: list[str] = None, kubeconfig: str = None
+    file_path: str, param: Sequence[str] | None = None, kubeconfig: str | None = None
 ) -> ConfigFile:
     """Read config file from local
     Args:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.11
+python_version = 3.9
 ignore_missing_imports = True
 follow_imports = skip
 no_implicit_optional = False

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.11
 ignore_missing_imports = True
 follow_imports = skip
 no_implicit_optional = False

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -69,6 +69,49 @@ class TestRunCommand:
         finally:
             os.unlink(config_path)
 
+    def test_run_uses_default_output_when_flag_is_omitted(self, minimal_config):
+    """Test command uses default output directory when --output is omitted"""
+    runner = CliRunner()
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        import yaml
+
+        config_dict = {
+            "kubeconfig_file_path": minimal_config.kubeconfig_file_path,
+            "generations": minimal_config.generations,
+            "population_size": minimal_config.population_size,
+            "fitness_function": {
+                "query": minimal_config.fitness_function.query,
+                "type": minimal_config.fitness_function.type.value,
+            },
+            "scenario": {"pod_scenarios": {"enable": True}},
+        }
+        yaml.dump(config_dict, f)
+        config_path = f.name
+
+    try:
+        with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
+            with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
+                mock_read.return_value = minimal_config
+                mock_ga = Mock()
+                mock_ga_class.return_value = mock_ga
+
+                with runner.isolated_filesystem():
+                    result = runner.invoke(
+                        main,
+                        [
+                            "run",
+                            "--config",
+                            config_path,
+                        ],
+                    )
+
+                assert result.exit_code == 0
+                mock_ga.simulate.assert_called_once()
+                mock_ga.save.assert_called_once()
+    finally:
+        os.unlink(config_path)
+        
     def test_run_fails_when_config_missing_or_invalid(self, temp_output_dir):
         """Test command fails when config file is missing or invalid"""
         runner = CliRunner()

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -70,48 +70,48 @@ class TestRunCommand:
             os.unlink(config_path)
 
     def test_run_uses_default_output_when_flag_is_omitted(self, minimal_config):
-    """Test command uses default output directory when --output is omitted"""
-    runner = CliRunner()
+        """Test command uses default output directory when --output is omitted"""
+        runner = CliRunner()
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-        import yaml
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            import yaml
 
-        config_dict = {
-            "kubeconfig_file_path": minimal_config.kubeconfig_file_path,
-            "generations": minimal_config.generations,
-            "population_size": minimal_config.population_size,
-            "fitness_function": {
-                "query": minimal_config.fitness_function.query,
-                "type": minimal_config.fitness_function.type.value,
-            },
-            "scenario": {"pod_scenarios": {"enable": True}},
-        }
-        yaml.dump(config_dict, f)
-        config_path = f.name
+            config_dict = {
+                "kubeconfig_file_path": minimal_config.kubeconfig_file_path,
+                "generations": minimal_config.generations,
+                "population_size": minimal_config.population_size,
+                "fitness_function": {
+                    "query": minimal_config.fitness_function.query,
+                    "type": minimal_config.fitness_function.type.value,
+                },
+                "scenario": {"pod_scenarios": {"enable": True}},
+            }
+            yaml.dump(config_dict, f)
+            config_path = f.name
 
-    try:
-        with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
-            with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
-                mock_read.return_value = minimal_config
-                mock_ga = Mock()
-                mock_ga_class.return_value = mock_ga
+        try:
+            with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
+                with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
+                    mock_read.return_value = minimal_config
+                    mock_ga = Mock()
+                    mock_ga_class.return_value = mock_ga
 
-                with runner.isolated_filesystem():
-                    result = runner.invoke(
-                        main,
-                        [
-                            "run",
-                            "--config",
-                            config_path,
-                        ],
-                    )
+                    with runner.isolated_filesystem():
+                        result = runner.invoke(
+                            main,
+                            [
+                                "run",
+                                "--config",
+                                config_path,
+                            ],
+                        )
 
-                assert result.exit_code == 0
-                mock_ga.simulate.assert_called_once()
-                mock_ga.save.assert_called_once()
-    finally:
-        os.unlink(config_path)
-        
+                    assert result.exit_code == 0, result.exception
+                    mock_ga.simulate.assert_called_once()
+                    mock_ga.save.assert_called_once()
+        finally:
+            os.unlink(config_path)
+
     def test_run_fails_when_config_missing_or_invalid(self, temp_output_dir):
         """Test command fails when config file is missing or invalid"""
         runner = CliRunner()


### PR DESCRIPTION
## Description
While testing the `run` command locally with a basic execution `krkn_ai run -c config.yaml` , the CLI crashed immediately before even reaching config validation.
The traceback output was:
```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```
The traceback pointed to:
```
new_output_path = os.path.join(output, run_uuid)
```
The root cause was that the `--output` option did not define a Click-level default. Although the Python callback signature had output: `str = "./",` Click explicitly passed None when the option was omitted. That caused the command to evaluate:
```
os.path.join(None, run_uuid)
```

## Changes Made
1. Added `default="./"` to the run `--output`Click option.
2. Added a regression test for running `krkn_ai run` without `--output`.
3. Replaced `default=os.getenv("KUBECONFIG", None)` with Click’s `envvar="KUBECONFIG"` for `--kubeconfig` in both `run` and `discover`.
4. Aligned `discover` callback defaults with the corresponding Click option defaults.
5. Removed the unnecessary `default=[]` from the `multiple=True` `--param` option and updated the callback type/default to use an empty tuple.

## Tests
```
conda run -n krkn-ai python -m pytest tests/unit/cli/test_cmd.py -q
```
Output:
```
8 passed in 0.07s
```
All tests passed.



