### PR TITLE
fix(templates): use context manager and explicit encoding when reading template

### DIFF
--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -17,7 +17,8 @@ def create_krkn_ai_template(
     current_dir = os.path.dirname(__file__)
     template_path = os.path.join(current_dir, "krkn-ai.yaml.j2")
 
-    template_str = open(template_path).read()
+    with open(template_path, encoding="utf-8") as f:
+        template_str = f.read()
     template = environment.from_string(template_str)
 
     # Convert cluster_components to properly indented YAML string


### PR DESCRIPTION
# FIX: #195
 
## Description
 
`krkn_ai/templates/generator.py:20` reads the Jinja2 template with a bare `open().read()` — no context manager, no explicit `encoding=`. This is the only `open()` in the entire `krkn_ai` package not wrapped in a `with` block, and the only `ruff SIM115` violation in the repo.
 
```diff
- template_str = open(template_path).read()
+ with open(template_path, encoding="utf-8") as f:
+     template_str = f.read()
```
 
One file, +2 / -1 lines.
 
| Edit | Reason |
|---|---|
| Wrap in `with` | Deterministic file-handle close across CPython, PyPy, etc. Resolves `ruff SIM115`. Matches every other `open()` in `krkn_ai/`. |
| Add `encoding="utf-8"` | Without it, `open()` falls back to `locale.getpreferredencoding()` — `cp1252` on Windows — which will `UnicodeDecodeError` on any non-ASCII character in the template. |
 
---
 
## Type of Change
 
- [x] Bug fix (non-breaking)
---
 
## Testing
 
```bash
# SIM115 violation resolved
$ ruff check --select=SIM115 .
All checks passed!
 
# Full test suite
$ pytest tests/ -q
210 passed in 13.74s
 
# Pre-commit suite
$ pre-commit run --all-files
All checks passed!
```
 
---
 
## Checklist
 
- [x] Code follows project style guidelines (`ruff`, `ruff format`, `mypy` clean)
- [x] All existing tests pass (210 passed)
- [x] No new warnings or errors
- [ ] New tests added — the function has no direct unit test today; happy to add one in a follow-up if requested.
 