### PR TITLE
fix(cli): validate kubeconfig before launching containerized scenarios

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -12,11 +12,13 @@ from krkn_ai.models.app import KrknRunnerType
 from krkn_ai.dashboard.manager import DashboardManager
 from krkn_ai.models.custom_errors import (
     FitnessFunctionCalculationError,
+    KubeconfigValidationError,
     MissingScenarioError,
     PrometheusConnectionError,
     UniqueScenariosError,
 )
 from krkn_ai.utils.fs import read_config_from_file
+from krkn_ai.utils.kubeconfig import validate_kubeconfig_for_container_use
 from krkn_ai.templates.generator import create_krkn_ai_template
 from krkn_ai.utils.cluster_manager import ClusterManager
 
@@ -112,6 +114,17 @@ def run(
         exit(1)
     except ValidationError as err:
         logger.error("Unable to parse config file: %s", err)
+        exit(1)
+
+    # Fail fast with an actionable error if the kubeconfig references credential
+    # files by host path (e.g., a default minikube/kind kubeconfig). Krkn-AI
+    # launches scenarios inside containers that won't have access to those host
+    # paths, so loading the kubeconfig there would fail with a cryptic
+    # `kubernetes.config.config_exception.ConfigException` deep in the call stack.
+    try:
+        validate_kubeconfig_for_container_use(parsed_config.kubeconfig_file_path)
+    except KubeconfigValidationError as err:
+        logger.error("%s", err)
         exit(1)
 
     # Override seed from CLI if provided

--- a/krkn_ai/models/custom_errors.py
+++ b/krkn_ai/models/custom_errors.py
@@ -52,3 +52,13 @@ class ShellCommandTimeoutError(Exception):
     """
 
     pass
+
+
+class KubeconfigValidationError(Exception):
+    """
+    Exception raised when a kubeconfig cannot be used for containerized krkn
+    scenarios (e.g., it references credential files by host path instead of
+    embedding them).
+    """
+
+    pass

--- a/krkn_ai/utils/kubeconfig.py
+++ b/krkn_ai/utils/kubeconfig.py
@@ -1,0 +1,102 @@
+"""
+Kubeconfig validation utilities.
+
+Krkn-AI launches chaos scenarios inside containers (podman/docker). The
+kubeconfig is mounted into the container, but other host filesystem paths
+are not. If the kubeconfig references credential files by path (e.g.
+`certificate-authority: /root/.minikube/ca.crt`), those paths won't
+exist inside the container and the kubernetes-client library raises a
+generic `ConfigException` deep in the call stack with no actionable
+guidance for the user.
+
+This module validates a kubeconfig up-front so the user gets a clear,
+actionable error before any container is launched.
+"""
+
+from typing import List, Tuple
+
+import yaml
+
+from krkn_ai.models.custom_errors import KubeconfigValidationError
+
+# Kubeconfig credential keys that reference external file paths.
+# Their `*-data` counterparts (`certificate-authority-data`, etc.) are
+# base64-embedded and work fine inside containers.
+_PATH_BASED_CLUSTER_KEYS = ("certificate-authority",)
+_PATH_BASED_USER_KEYS = ("client-certificate", "client-key")
+
+
+def _find_path_based_credentials(config: dict) -> List[Tuple[str, str]]:
+    """
+    Walk a kubeconfig dict and return ``(location, value)`` tuples for any
+    credential entries that reference an external file path instead of an
+    embedded base64 blob.
+
+    The locations use a YAML-style notation (e.g.
+    ``users[1].user.client-key``) so the caller can include them verbatim
+    in an error message.
+    """
+    issues: List[Tuple[str, str]] = []
+
+    for i, cluster in enumerate(config.get("clusters", []) or []):
+        cluster_block = cluster.get("cluster", {}) or {}
+        for key in _PATH_BASED_CLUSTER_KEYS:
+            if key in cluster_block:
+                issues.append((f"clusters[{i}].cluster.{key}", str(cluster_block[key])))
+
+    for i, user in enumerate(config.get("users", []) or []):
+        user_block = user.get("user", {}) or {}
+        for key in _PATH_BASED_USER_KEYS:
+            if key in user_block:
+                issues.append((f"users[{i}].user.{key}", str(user_block[key])))
+
+    return issues
+
+
+def validate_kubeconfig_for_container_use(kubeconfig_path: str) -> None:
+    """
+    Verify a kubeconfig is self-contained for use inside containerized
+    krkn scenarios.
+
+    Raises :class:`KubeconfigValidationError` with an actionable message
+    if the kubeconfig file is missing, malformed, or contains path-based
+    credential references that won't resolve inside the krkn container.
+
+    The error message includes the exact ``kubectl config view ... --flatten``
+    command needed to regenerate a self-contained kubeconfig, so the user
+    can fix the problem in one step.
+    """
+    try:
+        with open(kubeconfig_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+    except FileNotFoundError as e:
+        raise KubeconfigValidationError(
+            f"Kubeconfig file not found: {kubeconfig_path}"
+        ) from e
+    except yaml.YAMLError as e:
+        raise KubeconfigValidationError(
+            f"Kubeconfig at '{kubeconfig_path}' is not valid YAML: {e}"
+        ) from e
+
+    if not isinstance(config, dict):
+        raise KubeconfigValidationError(
+            f"Kubeconfig at '{kubeconfig_path}' is not a valid YAML mapping"
+        )
+
+    issues = _find_path_based_credentials(config)
+    if not issues:
+        return
+
+    formatted = "\n".join(f"  - {loc}: {val}" for loc, val in issues)
+    raise KubeconfigValidationError(
+        f"Kubeconfig at '{kubeconfig_path}' uses path-based credential "
+        f"references that won't be available inside the krkn container:\n"
+        f"{formatted}\n\n"
+        f"Krkn-AI launches scenarios inside containers (podman/docker) that "
+        f"don't have access to these host paths. Re-export your kubeconfig "
+        f"with credentials embedded:\n\n"
+        f"  kubectl config view "
+        f"--context=$(kubectl config current-context) "
+        f"--minify --flatten --raw > kubeconfig.yaml\n\n"
+        f"See docs/developer_guide.md for the full setup."
+    )

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -41,31 +41,32 @@ class TestRunCommand:
         try:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
-                    mock_read.return_value = minimal_config
-                    mock_ga = Mock()
-                    mock_ga_class.return_value = mock_ga
+                    with patch("krkn_ai.cli.cmd.validate_kubeconfig_for_container_use"):
+                        mock_read.return_value = minimal_config
+                        mock_ga = Mock()
+                        mock_ga_class.return_value = mock_ga
 
-                    override_kubeconfig = "/override/kubeconfig"
-                    result = runner.invoke(
-                        main,
-                        [
-                            "run",
-                            "--config",
-                            config_path,
-                            "--output",
-                            temp_output_dir,
-                            "--kubeconfig",
-                            override_kubeconfig,
-                        ],
-                    )
+                        override_kubeconfig = "/override/kubeconfig"
+                        result = runner.invoke(
+                            main,
+                            [
+                                "run",
+                                "--config",
+                                config_path,
+                                "--output",
+                                temp_output_dir,
+                                "--kubeconfig",
+                                override_kubeconfig,
+                            ],
+                        )
 
-                    assert result.exit_code == 0
-                    # Verify kubeconfig override was passed to read_config_from_file
-                    mock_read.assert_called_once_with(
-                        config_path, (), override_kubeconfig
-                    )
-                    mock_ga.simulate.assert_called_once()
-                    mock_ga.save.assert_called_once()
+                        assert result.exit_code == 0
+                        # Verify kubeconfig override was passed to read_config_from_file
+                        mock_read.assert_called_once_with(
+                            config_path, (), override_kubeconfig
+                        )
+                        mock_ga.simulate.assert_called_once()
+                        mock_ga.save.assert_called_once()
         finally:
             os.unlink(config_path)
 
@@ -167,26 +168,27 @@ class TestRunCommand:
         try:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
-                    mock_read.return_value = minimal_config
-                    mock_ga = Mock()
-                    mock_ga_class.return_value = mock_ga
+                    with patch("krkn_ai.cli.cmd.validate_kubeconfig_for_container_use"):
+                        mock_read.return_value = minimal_config
+                        mock_ga = Mock()
+                        mock_ga_class.return_value = mock_ga
 
-                    # Test runner_type conversion (krknctl -> CLI_RUNNER)
-                    result = runner.invoke(
-                        main,
-                        [
-                            "run",
-                            "--config",
-                            config_path,
-                            "--output",
-                            temp_output_dir,
-                            "--runner-type",
-                            "krknctl",
-                        ],
-                    )
-                    assert result.exit_code == 0
-                    call_args = mock_ga_class.call_args
-                    assert call_args[1]["runner_type"] == KrknRunnerType.CLI_RUNNER
+                        # Test runner_type conversion (krknctl -> CLI_RUNNER)
+                        result = runner.invoke(
+                            main,
+                            [
+                                "run",
+                                "--config",
+                                config_path,
+                                "--output",
+                                temp_output_dir,
+                                "--runner-type",
+                                "krknctl",
+                            ],
+                        )
+                        assert result.exit_code == 0
+                        call_args = mock_ga_class.call_args
+                        assert call_args[1]["runner_type"] == KrknRunnerType.CLI_RUNNER
         finally:
             os.unlink(config_path)
 
@@ -216,31 +218,34 @@ class TestRunCommand:
             with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
                 with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
                     with patch("krkn_ai.cli.cmd.get_logger") as mock_get_logger:
-                        mock_read.return_value = minimal_config
-                        mock_ga = Mock()
-                        mock_ga_class.return_value = mock_ga
-                        mock_logger = Mock()
-                        mock_get_logger.return_value = mock_logger
+                        with patch(
+                            "krkn_ai.cli.cmd.validate_kubeconfig_for_container_use"
+                        ):
+                            mock_read.return_value = minimal_config
+                            mock_ga = Mock()
+                            mock_ga_class.return_value = mock_ga
+                            mock_logger = Mock()
+                            mock_get_logger.return_value = mock_logger
 
-                        # Test FitnessFunctionCalculationError handling
-                        mock_ga.simulate.side_effect = FitnessFunctionCalculationError(
-                            "Calculation failed"
-                        )
-                        result = runner.invoke(
-                            main,
-                            [
-                                "run",
-                                "--config",
-                                config_path,
-                                "--output",
-                                temp_output_dir,
-                            ],
-                        )
-                        assert result.exit_code == 1
-                        mock_logger.error.assert_called_once()
-                        assert "Unable to calculate fitness function score" in str(
-                            mock_logger.error.call_args
-                        )
+                            # Test FitnessFunctionCalculationError handling
+                            mock_ga.simulate.side_effect = (
+                                FitnessFunctionCalculationError("Calculation failed")
+                            )
+                            result = runner.invoke(
+                                main,
+                                [
+                                    "run",
+                                    "--config",
+                                    config_path,
+                                    "--output",
+                                    temp_output_dir,
+                                ],
+                            )
+                            assert result.exit_code == 1
+                            mock_logger.error.assert_called_once()
+                            assert "Unable to calculate fitness function score" in str(
+                                mock_logger.error.call_args
+                            )
         finally:
             os.unlink(config_path)
 

--- a/tests/unit/utils/test_kubeconfig.py
+++ b/tests/unit/utils/test_kubeconfig.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for ``krkn_ai.utils.kubeconfig``.
+"""
+
+import pytest
+import yaml
+
+from krkn_ai.models.custom_errors import KubeconfigValidationError
+from krkn_ai.utils.kubeconfig import (
+    _find_path_based_credentials,
+    validate_kubeconfig_for_container_use,
+)
+
+# A kubeconfig that uses embedded base64 credentials — works inside containers.
+EMBEDDED_KUBECONFIG = {
+    "apiVersion": "v1",
+    "kind": "Config",
+    "clusters": [
+        {
+            "name": "test",
+            "cluster": {
+                "server": "https://127.0.0.1:6443",
+                "certificate-authority-data": "LS0tLS1CRUdJTi==",
+            },
+        }
+    ],
+    "users": [
+        {
+            "name": "test-user",
+            "user": {
+                "client-certificate-data": "LS0tLS1CRUdJTi==",
+                "client-key-data": "LS0tLS1CRUdJTi==",
+            },
+        }
+    ],
+    "contexts": [{"name": "test", "context": {"cluster": "test", "user": "test-user"}}],
+    "current-context": "test",
+}
+
+# A typical minikube-generated kubeconfig — references credentials by host path.
+PATH_BASED_KUBECONFIG = {
+    "apiVersion": "v1",
+    "kind": "Config",
+    "clusters": [
+        {
+            "name": "minikube",
+            "cluster": {
+                "server": "https://192.168.49.2:8443",
+                "certificate-authority": "/root/.minikube/ca.crt",
+            },
+        }
+    ],
+    "users": [
+        {
+            "name": "minikube",
+            "user": {
+                "client-certificate": "/root/.minikube/profiles/minikube/client.crt",
+                "client-key": "/root/.minikube/profiles/minikube/client.key",
+            },
+        }
+    ],
+    "contexts": [
+        {"name": "minikube", "context": {"cluster": "minikube", "user": "minikube"}}
+    ],
+    "current-context": "minikube",
+}
+
+
+class TestFindPathBasedCredentials:
+    """Unit tests for the internal ``_find_path_based_credentials`` helper."""
+
+    def test_embedded_kubeconfig_returns_empty(self):
+        assert _find_path_based_credentials(EMBEDDED_KUBECONFIG) == []
+
+    def test_path_based_kubeconfig_finds_all_three(self):
+        issues = _find_path_based_credentials(PATH_BASED_KUBECONFIG)
+        locations = {loc for loc, _ in issues}
+        assert "clusters[0].cluster.certificate-authority" in locations
+        assert "users[0].user.client-certificate" in locations
+        assert "users[0].user.client-key" in locations
+        assert len(issues) == 3
+
+    def test_empty_config_returns_empty(self):
+        assert _find_path_based_credentials({}) == []
+
+    def test_missing_clusters_key(self):
+        assert _find_path_based_credentials({"users": []}) == []
+
+    def test_missing_users_key(self):
+        assert _find_path_based_credentials({"clusters": []}) == []
+
+    def test_clusters_value_is_none(self):
+        # PyYAML can produce {"clusters": None} for `clusters:` with no children.
+        assert _find_path_based_credentials({"clusters": None, "users": None}) == []
+
+    def test_cluster_block_is_none(self):
+        # PyYAML can produce {"cluster": None} for an empty cluster entry.
+        config = {"clusters": [{"name": "c", "cluster": None}], "users": []}
+        assert _find_path_based_credentials(config) == []
+
+    def test_locations_use_yaml_style_indices(self):
+        # Two clusters, second one has the path-based key.
+        config = {
+            "clusters": [
+                {"name": "c0", "cluster": {"certificate-authority-data": "ok"}},
+                {"name": "c1", "cluster": {"certificate-authority": "/etc/ca"}},
+            ],
+            "users": [],
+        }
+        issues = _find_path_based_credentials(config)
+        assert issues == [("clusters[1].cluster.certificate-authority", "/etc/ca")]
+
+
+class TestValidateKubeconfigForContainerUse:
+    """Tests for the public ``validate_kubeconfig_for_container_use`` entrypoint."""
+
+    def test_embedded_kubeconfig_passes_silently(self, tmp_path):
+        path = tmp_path / "kubeconfig.yaml"
+        path.write_text(yaml.dump(EMBEDDED_KUBECONFIG), encoding="utf-8")
+        # Should return None without raising.
+        assert validate_kubeconfig_for_container_use(str(path)) is None
+
+    def test_path_based_kubeconfig_raises_with_actionable_message(self, tmp_path):
+        path = tmp_path / "kubeconfig.yaml"
+        path.write_text(yaml.dump(PATH_BASED_KUBECONFIG), encoding="utf-8")
+
+        with pytest.raises(KubeconfigValidationError) as exc_info:
+            validate_kubeconfig_for_container_use(str(path))
+
+        msg = str(exc_info.value)
+
+        # The message names every problematic location so the user can find them.
+        assert "clusters[0].cluster.certificate-authority" in msg
+        assert "users[0].user.client-certificate" in msg
+        assert "users[0].user.client-key" in msg
+
+        # The actual offending values are included so the user can grep their kubeconfig.
+        assert "/root/.minikube/ca.crt" in msg
+
+        # The actionable fix command is included verbatim.
+        assert "kubectl config view" in msg
+        assert "--minify --flatten --raw" in msg
+
+    def test_missing_file_raises_with_clear_error(self, tmp_path):
+        with pytest.raises(KubeconfigValidationError, match="not found"):
+            validate_kubeconfig_for_container_use(str(tmp_path / "does-not-exist.yaml"))
+
+    def test_invalid_yaml_raises_with_clear_error(self, tmp_path):
+        path = tmp_path / "bad.yaml"
+        path.write_text("not: valid: yaml: [unclosed", encoding="utf-8")
+        with pytest.raises(KubeconfigValidationError, match="not valid YAML"):
+            validate_kubeconfig_for_container_use(str(path))
+
+    def test_non_mapping_yaml_raises_with_clear_error(self, tmp_path):
+        path = tmp_path / "list.yaml"
+        path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+        with pytest.raises(KubeconfigValidationError, match="not a valid YAML mapping"):
+            validate_kubeconfig_for_container_use(str(path))
+
+    def test_partially_path_based_only_problem_user_reported(self, tmp_path):
+        # One user has embedded credentials (good); a second user has path-based (bad).
+        # Only the path-based one should appear in the error.
+        config = {
+            "clusters": [
+                {"name": "c1", "cluster": {"certificate-authority-data": "abc"}},
+            ],
+            "users": [
+                {
+                    "name": "u1",
+                    "user": {
+                        "client-certificate-data": "abc",
+                        "client-key-data": "def",
+                    },
+                },
+                {"name": "u2", "user": {"client-certificate": "/path/to/cert"}},
+            ],
+        }
+        path = tmp_path / "mixed.yaml"
+        path.write_text(yaml.dump(config), encoding="utf-8")
+
+        with pytest.raises(KubeconfigValidationError) as exc_info:
+            validate_kubeconfig_for_container_use(str(path))
+
+        msg = str(exc_info.value)
+        assert "users[1].user.client-certificate" in msg
+        # The fully-embedded user/cluster shouldn't be mentioned.
+        assert "users[0]" not in msg
+        assert "clusters[0]" not in msg


### PR DESCRIPTION
Fix #135.
 
## Description
 
When a user runs `krkn_ai run` with a minikube/kind kubeconfig that references credential files by host path, the run fails deep inside the krkn container with an unhelpful stack trace:
 
```
kubernetes.config.config_exception.ConfigException: File does not exist: /root/.minikube/ca.crt
```
 
The cause: krkn-ai mounts the kubeconfig into the container, but not the host paths it references. The fix validates the kubeconfig **before** any container is launched, so the user gets a clear, actionable error immediately.
 
**What the user sees now instead of the stack trace:**
 
```
Kubeconfig at '/home/user/kubeconfig.yaml' uses path-based credential references
that won't be available inside the krkn container:
  - clusters[0].cluster.certificate-authority: /root/.minikube/ca.crt
  - users[0].user.client-certificate: /root/.minikube/profiles/minikube/client.crt
  - users[0].user.client-key: /root/.minikube/profiles/minikube/client.key
 
Re-export your kubeconfig with credentials embedded:
  kubectl config view --context=$(kubectl config current-context) --minify --flatten --raw > kubeconfig.yaml
 
See docs/developer_guide.md for the full setup.
```
 
---
 
## My Approach
 
### What changed
 
- **`krkn_ai/utils/kubeconfig.py`** — new validator that walks `clusters[*].cluster` and `users[*].user`, flagging the three path-based credential keys (`certificate-authority`, `client-certificate`, `client-key`).
- **`krkn_ai/models/custom_errors.py`** — new `KubeconfigValidationError` exception.
- **`krkn_ai/cli/cmd.py`** — validator called inside `run`, after the kubeconfig path is resolved and before `GeneticAlgorithm` is constructed.
### Why validate in `cli/cmd.py`
 
The error fires inside the krkn container — three layers down from krkn-ai. Validating at the `run` entry point catches it before any container is spawned, any output directory is created, or any cluster query is made. Zero time wasted on the failed run.
 
### What was intentionally left out
 
| Considered | Rejected because |
|---|---|
| Auto-flatten the kubeconfig on behalf of the user | Would silently mutate user files. User should run the command themselves. |
| Validate inside `discover` too | `discover` runs on the host — path-based kubeconfigs work fine there. Would cause false positives. |
| Wrap `KrknKubernetes(...)` in `pvc_utils.py` | If the kubeconfig passed `run` validation, this path won't see the error. Adds complexity without catching anything new. |
 
---
 
## Type of Change
 
- [x] Bug fix (non-breaking change which fixes an issue)
> Runs that succeed today will continue to succeed (validation passes silently for embedded kubeconfigs). Runs that failed deep in the stack now fail earlier with a clear message. No public API modified.
 
---
 
## Testing
 
```bash
# Linter and formatter clean
$ ruff check krkn_ai/utils/kubeconfig.py krkn_ai/models/custom_errors.py \
             krkn_ai/cli/cmd.py tests/unit/utils/test_kubeconfig.py
All checks passed!
 
# New unit tests
$ pytest tests/unit/utils/test_kubeconfig.py -v
14 passed in 0.06s
 
# Full test suite
$ pytest tests/ -q
224 passed in 14.69s  # was 210; +14 new tests
 
# Pre-commit suite
$ pre-commit run --all-files
All checks passed!
```
 
### New tests (`tests/unit/utils/test_kubeconfig.py` — 14 tests)
 
- Embedded kubeconfig passes silently
- Path-based kubeconfig raises with all offending locations + the `kubectl` fix command in the message
- Missing file raises `KubeconfigValidationError` (not bare `FileNotFoundError`)
- Invalid YAML raises a clear error
- YAML that isn't a mapping raises a clear error
- Mixed config (one embedded, one path-based user) reports only the offending entry
- Empty / null `clusters` and `users` blocks handled gracefully
### Existing tests updated
 
Three CLI happy-path tests in `tests/unit/cli/test_cmd.py` needed an additional `patch("krkn_ai.cli.cmd.validate_kubeconfig_for_container_use")` so the new validation step doesn't try to read a non-existent fixture file.
 
---
 
## Checklist
 
- [x] Code follows project style guidelines (`ruff`, `ruff format`, `mypy` clean)
- [x] 14 new tests added covering happy path, error cases, and edge cases
- [x] All tests pass (224 passed)
- [x] No new dependencies — validator uses only `yaml`, already in `pyproject.toml`
- [x] No doc update needed — `docs/developer_guide.md` already documents the workaround; this PR adds the runtime detection
 