### PR TITLE
fix(rng): correct off-by-one in randint — make upper bound inclusive

### DIFF
--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -29,10 +29,17 @@ class RNG:
     def choices(self, items: List[Any], weights: List[float], k: int = 1):
         return list(self.rng.choice(items, p=weights, size=k))
 
-    def randint(self, low: int, high: int):
+    def randint(self, low: int, high: int) -> int:
+        """Return a random integer N such that low <= N <= high (both inclusive).
+
+        Note: numpy's ``integers(low, high)`` uses an exclusive upper bound.
+        We add 1 to ``high`` so that the public contract of this method is
+        inclusive on both ends, matching the behaviour of Python's
+        ``random.randint``.
+        """
         if low == high:
             return low
-        return int(self.rng.integers(low, high))
+        return int(self.rng.integers(low, high + 1))
 
     def uniform(self, low: float, high: float):
         return self.rng.uniform(low, high)

--- a/tests/unit/utils/test_rng.py
+++ b/tests/unit/utils/test_rng.py
@@ -72,16 +72,61 @@ class TestRNG:
         choices2 = rng.choices(items, weights, k=5)
         assert choices == choices2
 
-    def test_randint(self):
-        """Test randint() returns an integer within range."""
+    def test_randint_returns_int_in_inclusive_range(self):
+        """Test randint() returns an integer within [low, high] inclusive."""
         rng = RNG(42)
         low, high = 1, 10
         val = rng.randint(low, high)
         assert isinstance(val, int)
-        assert low <= val < high
+        assert low <= val <= high  # both bounds inclusive
 
-        # Test low == high case
+    def test_randint_equal_bounds(self):
+        """Test randint() with equal low and high returns that value."""
+        rng = RNG(42)
         assert rng.randint(5, 5) == 5
+        assert rng.randint(0, 0) == 0
+
+    def test_randint_upper_bound_is_reachable(self):
+        """Verify the upper bound can actually be produced (catches the numpy off-by-one bug).
+
+        numpy.integers(low, high) is exclusive of high.  Our wrapper must add 1
+        so that callers using rng.randint(a, b) get an inclusive [a, b] range.
+        Over 10 000 draws, the upper bound *must* appear at least once.
+        """
+        rng = RNG(seed=0)
+        results = {rng.randint(1, 3) for _ in range(10_000)}
+        assert 3 in results, (
+            "Upper bound 3 was never produced by randint(1, 3) — "
+            "likely caused by numpy.integers exclusive-high off-by-one bug."
+        )
+        assert 1 in results, "Lower bound 1 was never produced by randint(1, 3)."
+        assert results == {1, 2, 3}
+
+    def test_randint_covers_full_range(self):
+        """Verify every integer in [low, high] is reachable over many draws."""
+        rng = RNG(seed=99)
+        low, high = 1, 10
+        results = {rng.randint(low, high) for _ in range(50_000)}
+        assert results == set(range(low, high + 1)), (
+            f"Not all values in [{low}, {high}] were produced. Missing: "
+            f"{set(range(low, high + 1)) - results}"
+        )
+
+    def test_randint_disruption_count_inclusive(self):
+        """Regression test: scenario_container uses rng.randint(1, len(containers)).
+
+        With 2 containers, disruption_count must be able to equal 2 (all containers).
+        Previously broken because randint(1, 2) with numpy exclusive upper bound
+        could only produce 1, silently making the multi-container branch in
+        ContainerScenario.mutate() unreachable.
+        """
+        rng = RNG(seed=7)
+        results = {rng.randint(1, 2) for _ in range(10_000)}
+        assert 2 in results, (
+            "randint(1, 2) never produced 2 — disruption_count could never "
+            "equal the number of containers in a 2-container pod."
+        )
+        assert results == {1, 2}
 
     def test_uniform(self):
         """Test uniform() returns a float within range."""


### PR DESCRIPTION
### Description

`RNG.randint(low, high)` in `krkn_ai/utils/rng.py` never returns `high`. The underlying `numpy.integers(low, high)` uses an **exclusive** upper bound, but every caller across the codebase passes `high` as an **inclusive** maximum — matching Python's `random.randint` contract. This silently narrows the genetic algorithm's search space on every run.

Fixes #198

---

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

### Testing

```bash
pytest tests/unit/utils/test_rng.py -v
```

```
PASSED tests/unit/utils/test_rng.py::TestRNG::test_randint_returns_int_in_inclusive_range
PASSED tests/unit/utils/test_rng.py::TestRNG::test_randint_equal_bounds
PASSED tests/unit/utils/test_rng.py::TestRNG::test_randint_upper_bound_is_reachable
PASSED tests/unit/utils/test_rng.py::TestRNG::test_randint_covers_full_range
PASSED tests/unit/utils/test_rng.py::TestRNG::test_randint_disruption_count_inclusive
12 passed ✅
```

**Evidence that the bug was real (before fix):**

```python
# With the old code
results = {rng.randint(1, 10) for _ in range(10_000)}
print(sorted(results))  # [1, 2, 3, 4, 5, 6, 7, 8, 9] — 10 never appears

# After fix
results = {rng.randint(1, 10) for _ in range(10_000)}
print(sorted(results))  # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] ✅
```

---

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

---

### Additional Notes

**What changed:**

| File | Change |
|---|---|
| `krkn_ai/utils/rng.py` | `integers(low, high)` → `integers(low, high + 1)` + docstring added |
| `tests/unit/utils/test_rng.py` | Fixed wrong assertion `val < high` → `val <= high` + 4 new regression tests |

**Downstream impact fixed:**

| Call-site | Was broken | Now fixed |
|---|---|---|
| `ContainerScenario` (2-container pods) | `disruption_count` always `1` | Can be `1` or `2` |
| `NumberOfWorkersParameter` | Max 9, never 10 | Full range `[1, 10]` |
| `IOWorkersParameter` | Max 9, never 10 | Full range `[1, 10]` |
| `node_selector` | Max count never reached | Full range sampled |
| Network chaos mutation | Upper latency/bandwidth cut off | Full range sampled |
