### PR TITLE
fix(chaos_engines): use NamedTemporaryFile for graph JSON creation

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -285,8 +285,14 @@ class KrknRunner:
 
         # Create JSON for krknctl graph runner
         scenario_json = self.__expand_composite_json(scenario)
-        json_file = tempfile.mktemp(suffix=".json", dir=graph_json_directory)
-        with open(json_file, "w", encoding="utf-8") as f:
+        with tempfile.NamedTemporaryFile(
+            suffix=".json",
+            dir=graph_json_directory,
+            delete=False,
+            mode="w",
+            encoding="utf-8",
+        ) as f:
+            json_file = f.name
             json.dump(scenario_json, f, ensure_ascii=False, indent=4)
         logger.info("Created scenario json in path: %s", json_file)
 


### PR DESCRIPTION
## Summary

This PR replaces `tempfile.mktemp()` with `tempfile.NamedTemporaryFile()` while creating the graph JSON file for composite Krkn scenarios.
https://github.com/krkn-chaos/krkn-ai/blob/b972366407a619980d3efdd8968ceae64504abc1/krkn_ai/chaos_engines/krkn_runner.py#L281-L298
Earlier, the code first generated a temporary file path using `mktemp()` and then opened that path separately. This is not a safe pattern because the file is not created immediately when the path is generated. There is a small gap where another process could create the same file before our code opens it.

## Changes

- Replaced `tempfile.mktemp()` with `tempfile.NamedTemporaryFile()`.
- The JSON file is now created and opened in one step.
- Used `delete=False` so the file stays on disk for `krknctl graph run` to read.
- Kept the existing `.json` suffix, output directory, write mode, UTF-8 encoding, and JSON formatting.

## Testing

<img width="733" height="76" alt="Screenshot 2026-05-02 at 5 44 58 PM" src="https://github.com/user-attachments/assets/07f6e383-2b6e-4ab6-bd86-c40b5bffc870" />
