### PR TITLE
fix(cluster_manger): broden node interface filter for network chaos

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Union
+from typing import Iterable, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
 from krkn_ai.utils import run_shell
@@ -397,20 +397,31 @@ class ClusterManager:
             logger.warning("Unable to find interfaces for node %s", node)
             return []
 
-        interfaces = []
-        interfaces_list = [x.strip() for x in log.splitlines()]
+        return self._filter_chaos_interfaces(
+            x.strip() for x in log.splitlines() if x.strip()
+        )
 
-        # TODO: Check which interfaces to consider for network chaos
-        # For now, consider specific interfaces like ens5, eth0, etc.
+    # Linux interface name rules: up to 15 chars, alphanumerics with '_' or '-'.
+    # krknctl rejects names with characters outside this set.
+    _VALID_INTERFACE_NAME = re.compile(r"^[A-Za-z0-9_-]{1,15}$")
 
-        for intf in interfaces_list:
-            # TODO: Check which interfaces to consider for network chaos
-            # ens5, eth0, br-ex, br-int, etc. as well as other interfaces like lo, ovs-system, etc.
-            # Krkn validation doesn't work with interfaces with name like ABC-XYZ
-            if intf.startswith("ens") or intf.startswith("eth"):
-                interfaces.append(intf)
+    # Virtual/internal interfaces that aren't useful targets for network chaos:
+    # loopback, OVS/OVN internals, dynamic tunnel devices, and veth pairs.
+    _SKIP_INTERFACE_EXACT = frozenset({"lo", "ovs-system", "br-int"})
+    _SKIP_INTERFACE_PREFIXES = ("genev_sys", "vxlan_sys", "veth", "tun", "tap")
 
-        return interfaces
+    @classmethod
+    def _filter_chaos_interfaces(cls, interfaces: "Iterable[str]") -> List[str]:
+        result = []
+        for intf in interfaces:
+            if intf in cls._SKIP_INTERFACE_EXACT:
+                continue
+            if intf.startswith(cls._SKIP_INTERFACE_PREFIXES):
+                continue
+            if not cls._VALID_INTERFACE_NAME.match(intf):
+                continue
+            result.append(intf)
+        return result
 
     def __fetch_node_metrics(self, node: str):
         metrics = self.custom_obj_api.list_cluster_custom_object(

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -462,18 +462,49 @@ class TestClusterManager:
         assert nodes[0].interfaces == []  # Empty on failure
 
     def test_list_node_interfaces_filters_network_interfaces(self, cluster_manager):
-        """Test list_node_interfaces filters and returns only ens/eth interfaces"""
+        """Test list_node_interfaces keeps physical/external NICs and bridges
+        and drops loopback/OVS internals."""
         with patch(
             "krkn_ai.utils.cluster_manager.run_shell",
-            return_value=("eth0\nens5\nlo\novs-system\nbr-ex\n", 0),
+            return_value=("eth0\nens5\nlo\novs-system\nbr-ex\nbr-int\n", 0),
         ):
             interfaces = cluster_manager.list_node_interfaces("test-node")
 
-        assert len(interfaces) == 2
         assert "eth0" in interfaces
         assert "ens5" in interfaces
+        assert "br-ex" in interfaces
         assert "lo" not in interfaces
         assert "ovs-system" not in interfaces
+        assert "br-int" not in interfaces
+
+    def test_list_node_interfaces_keeps_bare_metal_and_bond_names(
+        self, cluster_manager
+    ):
+        """Test list_node_interfaces keeps enp/eno/bond names that the old
+        ens/eth-only filter used to drop."""
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=("enp0s3\neno1\nbond0\n", 0),
+        ):
+            interfaces = cluster_manager.list_node_interfaces("test-node")
+
+        assert set(interfaces) == {"enp0s3", "eno1", "bond0"}
+
+    def test_list_node_interfaces_drops_dynamic_and_invalid_names(
+        self, cluster_manager
+    ):
+        """Test list_node_interfaces drops veth/genev/vxlan tunnels and any
+        name with characters krknctl would reject."""
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=(
+                "eth0\nveth1234abc\ngenev_sys_6081\nvxlan_sys_4789\nABC.XYZ\n",
+                0,
+            ),
+        ):
+            interfaces = cluster_manager.list_node_interfaces("test-node")
+
+        assert interfaces == ["eth0"]
 
     def test_list_node_interfaces_returns_empty_list_on_shell_error(
         self, cluster_manager


### PR DESCRIPTION
## Summary

Resolves the `TODO` in `list_node_interfaces` (cluster_manager.py:403)
that limited network-chaos targets to interfaces starting with `ens`
or `eth`.

The previous filter dropped valid physical NICs commonly seen on
bare-metal and OpenShift nodes — `enp0s3`, `eno1`, `bond0` — and the
external OVN bridge `br-ex`, which is a legitimate target for egress
network chaos.

## Changes

- Replace the narrow `startswith("ens"/"eth")` allowlist with a
  blocklist approach in `_filter_chaos_interfaces`:
  - Skip exact internals: `lo`, `ovs-system`, `br-int`.
  - Skip dynamic/virtual prefixes: `veth*`, `genev_sys*`, `vxlan_sys*`,
    `tun*`, `tap*`.
  - Reject names with characters outside krknctl's accepted set
    (`[A-Za-z0-9_-]`, max 15 chars per Linux IFNAMSIZ).
- Extract the filtering logic into a small, testable classmethod.

## Tests

Updated `tests/unit/utils/test_cluster_manager.py`:

- Existing `test_list_node_interfaces_filters_network_interfaces`
  extended to assert `br-ex` is kept and `br-int` is dropped.
- New `test_list_node_interfaces_keeps_bare_metal_and_bond_names`
  covers `enp0s3`, `eno1`, `bond0` — the regression cases the old
  filter missed.
- New `test_list_node_interfaces_drops_dynamic_and_invalid_names`
  covers `veth*`, `genev_sys_*`, `vxlan_sys_*`, and names with
  invalid characters (`ABC.XYZ`).

