### PR TITLE
fix: generate genetic run UUID per instance

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -44,11 +44,11 @@ class GeneticAlgorithm:
         output_dir: str,
         format: str,
         runner_type: KrknRunnerType = None,
-        run_uuid: str = str(uuid.uuid4()),
+        run_uuid: Optional[str] = None,
     ):
         self.config = config
         self.format = format
-        self.run_uuid = run_uuid
+        self.run_uuid = run_uuid or str(uuid.uuid4())
 
         # Organize results under run_uuid subdirectory
         self.output_dir = output_dir

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -63,7 +63,6 @@ class TestGeneticAlgorithmInitialization:
                 )
                 assert ga.config.population_size == 6
 
-
     def test_init_generates_fresh_run_uuid_when_not_provided(
         self, minimal_config, temp_output_dir
     ):

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -64,6 +64,25 @@ class TestGeneticAlgorithmInitialization:
                 assert ga.config.population_size == 6
 
 
+    def test_init_generates_fresh_run_uuid_when_not_provided(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test default run UUID is generated per instance, not at import time"""
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                first = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                second = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+                assert first.run_uuid != second.run_uuid
+
+
 class TestGeneticAlgorithmCoreMethods:
     """Test GeneticAlgorithm core methods"""
 


### PR DESCRIPTION
Fixes #219.

This changes `GeneticAlgorithm.__init__` so the default `run_uuid` is generated inside the constructor instead of evaluating `uuid.uuid4()` once at import time. Passing an explicit `run_uuid` still works unchanged.

I also added a focused initialization regression test that builds two instances without an explicit run UUID and asserts they receive distinct values.

Verification run locally in this environment:
- `python3 -m py_compile krkn_ai/algorithm/genetic.py tests/unit/algorithm/test_genetic_algorithm.py`
- `git diff --check`

I could not run the pytest target here because this runtime does not have `pytest` installed.