### PR TITLE
Fix response time scoring for sparse health checks

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -128,7 +128,7 @@ class HealthCheckWatcher:
                     response_times.append(result.response_time)
 
             if len(response_times) < 4:  # Not enough data to calculate outliers
-                return 0
+                continue
 
             q1 = np.percentile(response_times, 25)
             q3 = np.percentile(response_times, 75)

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -208,7 +208,7 @@ class TestHealthCheckWatcherResults:
         # Should return 0 when less than 4 successful checks
         assert score == 0
 
-    def test_summarize_response_time_skips_urls_with_insufficient_data(self):
+    def test_summarize_response_time_skips_sparse_urls(self):
         """Test summarize_response_time skips URLs with insufficient data"""
         config = HealthCheckConfig(applications=[])
         watcher = HealthCheckWatcher(config)

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -208,6 +208,39 @@ class TestHealthCheckWatcherResults:
         # Should return 0 when less than 4 successful checks
         assert score == 0
 
+    def test_summarize_response_time_skips_urls_with_insufficient_data(self):
+        """Test summarize_response_time skips URLs with insufficient data"""
+        config = HealthCheckConfig(applications=[])
+        watcher = HealthCheckWatcher(config)
+
+        sparse_results = [
+            HealthCheckResult(
+                name="sparse-app",
+                response_time=response_time,
+                status_code=200,
+                success=True,
+            )
+            for response_time in [0.1, 0.2, 0.3]
+        ]
+        outlier_results = [
+            HealthCheckResult(
+                name="outlier-app",
+                response_time=response_time,
+                status_code=200,
+                success=True,
+            )
+            for response_time in [0.1, 0.1, 0.1, 0.1, 5.0]
+        ]
+
+        score = watcher.summarize_response_time(
+            {
+                "http://localhost:8080/health": sparse_results,
+                "http://localhost:8081/health": outlier_results,
+            }
+        )
+
+        assert score == 2.0
+
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_handles_request_exceptions_gracefully(self, mock_get):
         """Test health check handles request exceptions gracefully"""


### PR DESCRIPTION
## Summary

Fixed response-time scoring for health checks when one URL does not have enough successful samples.

## What Was Happening

`summarize_response_time` checks response times URL by URL. If any URL had fewer than four successful samples, the function returned `0` immediately.

That meant the rest of the URLs were never checked, even if they had enough data and clear response-time outliers.

## Why This Needed a Fix

One sparse or temporarily failing app should not wipe out the response-time score for every other monitored app. The score should still include URLs that have enough successful samples.

## What Changed

- Added a regression test for the multi-URL case.
- Changed the insufficient-samples path to skip that URL and keep checking the rest.
- Left the existing scoring and outlier calculation unchanged.
- Kept the `0.0` result when every URL has insufficient data.

## Validation
<img width="826" height="513" alt="Screenshot 2026-05-08 at 3 21 29 PM" src="https://github.com/user-attachments/assets/359363dd-839b-44fc-ae04-97c3f3567f16" />
