### PR TITLE
fix(results): update completed_generations counter before simulate() exits

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -147,6 +147,7 @@ class GeneticAlgorithm:
 
             # Check all stopping criteria before processing generation
             if self._check_and_stop(cur_generation, elapsed_time):
+                self.completed_generations = cur_generation
                 break
 
             # Log remaining time if duration is set
@@ -196,6 +197,7 @@ class GeneticAlgorithm:
             # Check stopping criteria after fitness evaluation (for fitness threshold, saturation, and exploration)
             elapsed_after_eval = time.time() - start_time
             if self._check_and_stop(cur_generation, elapsed_after_eval):
+                self.completed_generations = cur_generation
                 break
 
             # Repopulate off-springs


### PR DESCRIPTION
What :
The `results.json` summary always reports `"generations_completed": 0` regardless of how many generations the genetic algorithm actually completed.

Why :
In `simulate()`, the generation counter is tracked by a local variable `cur_generation`, which is incremented each iteration. However, the instance variable `self.completed_generations` is never updated from it before the loop exits. When `save()` passes `self.completed_generations` to `JSONSummaryReporter`, the value is always 0.

How :
Sync `self.completed_generations` = `cur_generation` at both exit points in the `while` loop before the pre-evaluation break (line 149) and the post-evaluation break (line 198).

Changes :
`krkn_ai/algorithm/genetic.py`: Added ``self.completed_generations = cur_generation` before both `break` statements in `simulate()`

Closes #225 

