### PR TITLE
fix(results): initialize seed from config instead of hardcoding None

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -97,7 +97,7 @@ class GeneticAlgorithm:
         # Track run metadata for results summary
         self.start_time: Optional[datetime.datetime] = None
         self.end_time: Optional[datetime.datetime] = None
-        self.seed: Optional[int] = None  # Seed can be set externally if needed
+        self.seed: Optional[int] = self.config.seed
         self.completed_generations: int = 0
 
         if self.config.population_size < 2:


### PR DESCRIPTION
What :
The `results.json` summary always reports `"seed": null` even when a seed is explicitly configured via the config file or `--seed` CLI flag.

Why : 
In `GeneticAlgorithm.__init__()`, `self.seed` is hardcoded to `None`. The actual seed value from `self.config.seed` is correctly used to initialize the RNG (`rng.set_seed(self.config.seed)`), but it is never stored in `self.seed`. When `save()` passes `self.seed` to `JSONSummaryReporter`, the value is always `None`.

How : 
Initialize `self.seed` from `self.config.seed` instead of hardcoding `None`.

Changes : 
`krkn_ai/algorithm/genetic.py`: Changed `self.seed: Optional[int] = None` to `self.seed: Optional[int] = self.config.seed`

Closes #226 