### PR TITLE
feat(config): add input validation for genetic algorithm parameters

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from pydantic import (
     BaseModel,
     Field,
@@ -226,7 +226,7 @@ class AdaptiveMutation(BaseModel):
 
     @field_validator("min", "max", mode="after")
     @classmethod
-    def validate_rate_range(cls, value: float, info) -> float:
+    def validate_rate_range(cls, value: float, info: Any) -> float:
         if value < 0 or value > 1:
             raise ValueError(
                 f"adaptive_mutation.{info.field_name} must be between 0.0 and 1.0, got {value}. "
@@ -284,7 +284,7 @@ class StoppingCriteria(BaseModel):
 
     @field_validator("generation_saturation", "exploration_saturation", mode="after")
     @classmethod
-    def validate_positive_int(cls, value: Optional[int], info) -> Optional[int]:
+    def validate_positive_int(cls, value: Optional[int], info: Any) -> Optional[int]:
         if value is not None and value <= 0:
             field_name = info.field_name
             raise ValueError(
@@ -361,7 +361,7 @@ class ConfigFile(BaseModel):
         mode="after",
     )
     @classmethod
-    def validate_probability_rate(cls, value: float, info) -> float:
+    def validate_probability_rate(cls, value: float, info: Any) -> float:
         """Validate that probability rate parameters are within [0.0, 1.0]."""
         if value < 0 or value > 1:
             raise ValueError(

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -70,6 +70,16 @@ class BaselineConfig(BaseModel):
     enable: bool = True
     duration: int = 60 * 2  # 2 minutes
 
+    @field_validator("duration", mode="after")
+    @classmethod
+    def validate_duration(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError(
+                f"baseline duration must be a positive integer, got {value}. "
+                "Please check the 'baseline.duration' parameter in your krkn-ai config file."
+            )
+        return value
+
 
 class ScenarioConfig(BaseModel):
     application_outages: Optional[AppOutageScenarioConfig] = Field(
@@ -214,6 +224,36 @@ class AdaptiveMutation(BaseModel):
     threshold: float = 0.1
     generations: int = 5
 
+    @field_validator("min", "max", mode="after")
+    @classmethod
+    def validate_rate_range(cls, value: float, info) -> float:
+        if value < 0 or value > 1:
+            raise ValueError(
+                f"adaptive_mutation.{info.field_name} must be between 0.0 and 1.0, got {value}. "
+                f"Please check the 'adaptive_mutation.{info.field_name}' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("generations", mode="after")
+    @classmethod
+    def validate_generations(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError(
+                f"adaptive_mutation.generations must be a positive integer, got {value}. "
+                "Please check the 'adaptive_mutation.generations' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @model_validator(mode="after")
+    def validate_min_less_than_max(self):
+        if self.min >= self.max:
+            raise ValueError(
+                f"adaptive_mutation.min ({self.min}) must be less than "
+                f"adaptive_mutation.max ({self.max}). "
+                "Please check the 'adaptive_mutation' parameters in your krkn-ai config file."
+            )
+        return self
+
 
 class StoppingCriteria(BaseModel):
     """
@@ -311,3 +351,76 @@ class ConfigFile(BaseModel):
     stopping_criteria: StoppingCriteria = (
         StoppingCriteria()
     )  # Additional stopping criteria for the algorithm
+
+    @field_validator(
+        "mutation_rate",
+        "scenario_mutation_rate",
+        "crossover_rate",
+        "composition_rate",
+        "population_injection_rate",
+        mode="after",
+    )
+    @classmethod
+    def validate_probability_rate(cls, value: float, info) -> float:
+        """Validate that probability rate parameters are within [0.0, 1.0]."""
+        if value < 0 or value > 1:
+            raise ValueError(
+                f"{info.field_name} must be between 0.0 and 1.0, got {value}. "
+                f"Please check the '{info.field_name}' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("population_size", mode="after")
+    @classmethod
+    def validate_population_size(cls, value: int) -> int:
+        """Validate that population size is at least 2."""
+        if value < 2:
+            raise ValueError(
+                f"population_size must be at least 2, got {value}. "
+                "Please check the 'population_size' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("population_injection_size", mode="after")
+    @classmethod
+    def validate_injection_size(cls, value: int) -> int:
+        """Validate that population injection size is at least 1."""
+        if value < 1:
+            raise ValueError(
+                f"population_injection_size must be at least 1, got {value}. "
+                "Please check the 'population_injection_size' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("generations", mode="after")
+    @classmethod
+    def validate_generations(cls, value: Optional[int]) -> Optional[int]:
+        """Validate that generations is positive when set."""
+        if value is not None and value <= 0:
+            raise ValueError(
+                f"generations must be a positive integer, got {value}. "
+                "Please check the 'generations' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("duration", mode="after")
+    @classmethod
+    def validate_duration(cls, value: Optional[int]) -> Optional[int]:
+        """Validate that duration is positive when set."""
+        if value is not None and value <= 0:
+            raise ValueError(
+                f"duration must be a positive integer, got {value}. "
+                "Please check the 'duration' parameter in your krkn-ai config file."
+            )
+        return value
+
+    @field_validator("wait_duration", mode="after")
+    @classmethod
+    def validate_wait_duration(cls, value: int) -> int:
+        """Validate that wait duration is non-negative."""
+        if value < 0:
+            raise ValueError(
+                f"wait_duration must be non-negative, got {value}. "
+                "Please check the 'wait_duration' parameter in your krkn-ai config file."
+            )
+        return value

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -224,7 +224,7 @@ class AdaptiveMutation(BaseModel):
     threshold: float = 0.1
     generations: int = 5
 
-    @field_validator("min", "max", mode="after")
+    @field_validator("min", "max", "threshold", mode="after")
     @classmethod
     def validate_rate_range(cls, value: float, info: Any) -> float:
         if value < 0 or value > 1:

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -1,0 +1,319 @@
+"""
+Tests for ConfigFile, BaselineConfig, and AdaptiveMutation input validation.
+
+Validates that genetic algorithm parameters are properly constrained:
+- Probability rates within [0.0, 1.0]
+- Positive integer constraints on sizes, generations, and durations
+- Cross-field validation (adaptive_mutation.min < adaptive_mutation.max)
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from krkn_ai.models.config import (
+    AdaptiveMutation,
+    BaselineConfig,
+    ConfigFile,
+    FitnessFunction,
+)
+from krkn_ai.models.cluster_components import ClusterComponents
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides) -> ConfigFile:
+    """Create a valid ConfigFile with optional field overrides."""
+    defaults = {
+        "kubeconfig_file_path": "/path/to/kubeconfig",
+        "fitness_function": FitnessFunction(query="up"),
+        "cluster_components": ClusterComponents(namespaces=[], nodes=[]),
+    }
+    defaults.update(overrides)
+    return ConfigFile(**defaults)
+
+
+# ===========================================================================
+# BaselineConfig validation
+# ===========================================================================
+
+
+class TestBaselineConfigValidation:
+    """Tests for BaselineConfig.duration validation."""
+
+    def test_valid_duration(self):
+        config = BaselineConfig(duration=120)
+        assert config.duration == 120
+
+    def test_duration_zero_raises(self):
+        with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
+            BaselineConfig(duration=0)
+
+    def test_duration_negative_raises(self):
+        with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
+            BaselineConfig(duration=-10)
+
+
+# ===========================================================================
+# AdaptiveMutation validation
+# ===========================================================================
+
+
+class TestAdaptiveMutationValidation:
+    """Tests for AdaptiveMutation field and cross-field validation."""
+
+    # --- rate range ---
+
+    def test_valid_min_max(self):
+        am = AdaptiveMutation(min=0.1, max=0.8)
+        assert am.min == 0.1
+        assert am.max == 0.8
+
+    def test_min_below_zero_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"):
+            AdaptiveMutation(min=-0.1)
+
+    def test_min_above_one_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"):
+            AdaptiveMutation(min=1.5)
+
+    def test_max_below_zero_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"):
+            AdaptiveMutation(max=-0.5)
+
+    def test_max_above_one_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"):
+            AdaptiveMutation(max=2.0)
+
+    def test_boundary_min_zero_max_one(self):
+        """Boundary: min=0.0 and max=1.0 are valid."""
+        am = AdaptiveMutation(min=0.0, max=1.0)
+        assert am.min == 0.0
+        assert am.max == 1.0
+
+    # --- cross-field: min < max ---
+
+    def test_min_equals_max_raises(self):
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveMutation(min=0.5, max=0.5)
+
+    def test_min_greater_than_max_raises(self):
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveMutation(min=0.9, max=0.1)
+
+    # --- generations ---
+
+    def test_valid_generations(self):
+        am = AdaptiveMutation(generations=10)
+        assert am.generations == 10
+
+    def test_generations_zero_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.generations must be a positive integer"):
+            AdaptiveMutation(generations=0)
+
+    def test_generations_negative_raises(self):
+        with pytest.raises(ValidationError, match="adaptive_mutation.generations must be a positive integer"):
+            AdaptiveMutation(generations=-5)
+
+
+# ===========================================================================
+# ConfigFile probability rate validation
+# ===========================================================================
+
+
+class TestConfigFileProbabilityRates:
+    """Tests for rate fields that must be within [0.0, 1.0]."""
+
+    RATE_FIELDS = [
+        "mutation_rate",
+        "scenario_mutation_rate",
+        "crossover_rate",
+        "composition_rate",
+        "population_injection_rate",
+    ]
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_valid_rate_zero(self, field):
+        config = _make_config(**{field: 0.0})
+        assert getattr(config, field) == 0.0
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_valid_rate_one(self, field):
+        config = _make_config(**{field: 1.0})
+        assert getattr(config, field) == 1.0
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_valid_rate_midpoint(self, field):
+        config = _make_config(**{field: 0.5})
+        assert getattr(config, field) == 0.5
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_rate_above_one_raises(self, field):
+        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+            _make_config(**{field: 1.5})
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_rate_negative_raises(self, field):
+        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+            _make_config(**{field: -0.1})
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_rate_large_value_raises(self, field):
+        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+            _make_config(**{field: 99.0})
+
+
+# ===========================================================================
+# ConfigFile population_size validation
+# ===========================================================================
+
+
+class TestConfigFilePopulationSize:
+    """Tests for population_size validation (must be >= 2)."""
+
+    def test_valid_population_size(self):
+        config = _make_config(population_size=10)
+        assert config.population_size == 10
+
+    def test_population_size_minimum(self):
+        config = _make_config(population_size=2)
+        assert config.population_size == 2
+
+    def test_population_size_one_raises(self):
+        with pytest.raises(ValidationError, match="population_size must be at least 2"):
+            _make_config(population_size=1)
+
+    def test_population_size_zero_raises(self):
+        with pytest.raises(ValidationError, match="population_size must be at least 2"):
+            _make_config(population_size=0)
+
+    def test_population_size_negative_raises(self):
+        with pytest.raises(ValidationError, match="population_size must be at least 2"):
+            _make_config(population_size=-5)
+
+
+# ===========================================================================
+# ConfigFile population_injection_size validation
+# ===========================================================================
+
+
+class TestConfigFileInjectionSize:
+    """Tests for population_injection_size validation (must be >= 1)."""
+
+    def test_valid_injection_size(self):
+        config = _make_config(population_injection_size=5)
+        assert config.population_injection_size == 5
+
+    def test_injection_size_minimum(self):
+        config = _make_config(population_injection_size=1)
+        assert config.population_injection_size == 1
+
+    def test_injection_size_zero_raises(self):
+        with pytest.raises(ValidationError, match="population_injection_size must be at least 1"):
+            _make_config(population_injection_size=0)
+
+    def test_injection_size_negative_raises(self):
+        with pytest.raises(ValidationError, match="population_injection_size must be at least 1"):
+            _make_config(population_injection_size=-3)
+
+
+# ===========================================================================
+# ConfigFile generations validation
+# ===========================================================================
+
+
+class TestConfigFileGenerations:
+    """Tests for generations validation (must be > 0 when set)."""
+
+    def test_valid_generations(self):
+        config = _make_config(generations=20)
+        assert config.generations == 20
+
+    def test_generations_none_allowed(self):
+        config = _make_config(generations=None)
+        assert config.generations is None
+
+    def test_generations_one_valid(self):
+        config = _make_config(generations=1)
+        assert config.generations == 1
+
+    def test_generations_zero_raises(self):
+        with pytest.raises(ValidationError, match="generations must be a positive integer"):
+            _make_config(generations=0)
+
+    def test_generations_negative_raises(self):
+        with pytest.raises(ValidationError, match="generations must be a positive integer"):
+            _make_config(generations=-10)
+
+
+# ===========================================================================
+# ConfigFile duration validation
+# ===========================================================================
+
+
+class TestConfigFileDuration:
+    """Tests for duration validation (must be > 0 when set)."""
+
+    def test_valid_duration(self):
+        config = _make_config(duration=3600)
+        assert config.duration == 3600
+
+    def test_duration_none_allowed(self):
+        config = _make_config(duration=None)
+        assert config.duration is None
+
+    def test_duration_one_valid(self):
+        config = _make_config(duration=1)
+        assert config.duration == 1
+
+    def test_duration_zero_raises(self):
+        with pytest.raises(ValidationError, match="duration must be a positive integer"):
+            _make_config(duration=0)
+
+    def test_duration_negative_raises(self):
+        with pytest.raises(ValidationError, match="duration must be a positive integer"):
+            _make_config(duration=-60)
+
+
+# ===========================================================================
+# ConfigFile wait_duration validation
+# ===========================================================================
+
+
+class TestConfigFileWaitDuration:
+    """Tests for wait_duration validation (must be >= 0)."""
+
+    def test_valid_wait_duration(self):
+        config = _make_config(wait_duration=120)
+        assert config.wait_duration == 120
+
+    def test_wait_duration_zero_allowed(self):
+        config = _make_config(wait_duration=0)
+        assert config.wait_duration == 0
+
+    def test_wait_duration_negative_raises(self):
+        with pytest.raises(ValidationError, match="wait_duration must be non-negative"):
+            _make_config(wait_duration=-1)
+
+
+# ===========================================================================
+# Integration: valid defaults pass all validation
+# ===========================================================================
+
+
+class TestConfigFileDefaultsValid:
+    """Ensure the default values for all fields pass validation."""
+
+    def test_defaults_pass(self):
+        config = _make_config()
+        assert config.population_size == 10
+        assert config.generations == 20
+        assert config.duration is None
+        assert config.wait_duration == 120
+        assert config.mutation_rate == 0.7
+        assert config.scenario_mutation_rate == 0.6
+        assert config.crossover_rate == 0.6
+        assert config.composition_rate == 0
+        assert config.population_injection_rate == 0
+        assert config.population_injection_size == 2

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -7,6 +7,7 @@ Validates that genetic algorithm parameters are properly constrained:
 - Cross-field validation (adaptive_mutation.min < adaptive_mutation.max)
 """
 
+from typing import Any
 import pytest
 from pydantic import ValidationError
 
@@ -23,7 +24,7 @@ from krkn_ai.models.cluster_components import ClusterComponents
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_config(**overrides) -> ConfigFile:
+def _make_config(**overrides: Any) -> ConfigFile:
     """Create a valid ConfigFile with optional field overrides."""
     defaults = {
         "kubeconfig_file_path": "/path/to/kubeconfig",
@@ -43,14 +44,17 @@ class TestBaselineConfigValidation:
     """Tests for BaselineConfig.duration validation."""
 
     def test_valid_duration(self):
+        """Test BaselineConfig with a valid duration."""
         config = BaselineConfig(duration=120)
         assert config.duration == 120
 
     def test_duration_zero_raises(self):
+        """Test BaselineConfig duration=0 raises ValidationError."""
         with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
             BaselineConfig(duration=0)
 
     def test_duration_negative_raises(self):
+        """Test BaselineConfig negative duration raises ValidationError."""
         with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
             BaselineConfig(duration=-10)
 
@@ -66,11 +70,13 @@ class TestAdaptiveMutationValidation:
     # --- rate range ---
 
     def test_valid_min_max(self):
+        """Test AdaptiveMutation with valid min and max values."""
         am = AdaptiveMutation(min=0.1, max=0.8)
         assert am.min == 0.1
         assert am.max == 0.8
 
     def test_min_below_zero_raises(self):
+        """Test AdaptiveMutation min < 0 raises ValidationError."""
         with pytest.raises(ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"):
             AdaptiveMutation(min=-0.1)
 
@@ -135,6 +141,7 @@ class TestConfigFileProbabilityRates:
 
     @pytest.mark.parametrize("field", RATE_FIELDS)
     def test_valid_rate_zero(self, field):
+        """Test that probability rate fields accept 0.0."""
         config = _make_config(**{field: 0.0})
         assert getattr(config, field) == 0.0
 
@@ -306,6 +313,7 @@ class TestConfigFileDefaultsValid:
     """Ensure the default values for all fields pass validation."""
 
     def test_defaults_pass(self):
+        """Integration test verifying that default ConfigFile values pass all validators."""
         config = _make_config()
         assert config.population_size == 10
         assert config.generations == 20

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -111,6 +111,24 @@ class TestAdaptiveMutationValidation:
         assert am.min == 0.0
         assert am.max == 1.0
 
+    # --- threshold range ---
+
+    def test_valid_threshold(self):
+        am = AdaptiveMutation(threshold=0.5)
+        assert am.threshold == 0.5
+
+    def test_threshold_below_zero_raises(self):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.threshold must be between 0.0 and 1.0"
+        ):
+            AdaptiveMutation(threshold=-0.1)
+
+    def test_threshold_above_one_raises(self):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.threshold must be between 0.0 and 1.0"
+        ):
+            AdaptiveMutation(threshold=1.5)
+
     # --- cross-field: min < max ---
 
     def test_min_equals_max_raises(self):

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -119,13 +119,15 @@ class TestAdaptiveMutationValidation:
 
     def test_threshold_below_zero_raises(self):
         with pytest.raises(
-            ValidationError, match="adaptive_mutation.threshold must be between 0.0 and 1.0"
+            ValidationError,
+            match="adaptive_mutation.threshold must be between 0.0 and 1.0",
         ):
             AdaptiveMutation(threshold=-0.1)
 
     def test_threshold_above_one_raises(self):
         with pytest.raises(
-            ValidationError, match="adaptive_mutation.threshold must be between 0.0 and 1.0"
+            ValidationError,
+            match="adaptive_mutation.threshold must be between 0.0 and 1.0",
         ):
             AdaptiveMutation(threshold=1.5)
 

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -24,6 +24,7 @@ from krkn_ai.models.cluster_components import ClusterComponents
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_config(**overrides: Any) -> ConfigFile:
     """Create a valid ConfigFile with optional field overrides."""
     defaults = {
@@ -50,12 +51,16 @@ class TestBaselineConfigValidation:
 
     def test_duration_zero_raises(self):
         """Test BaselineConfig duration=0 raises ValidationError."""
-        with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="baseline duration must be a positive integer"
+        ):
             BaselineConfig(duration=0)
 
     def test_duration_negative_raises(self):
         """Test BaselineConfig negative duration raises ValidationError."""
-        with pytest.raises(ValidationError, match="baseline duration must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="baseline duration must be a positive integer"
+        ):
             BaselineConfig(duration=-10)
 
 
@@ -77,19 +82,27 @@ class TestAdaptiveMutationValidation:
 
     def test_min_below_zero_raises(self):
         """Test AdaptiveMutation min < 0 raises ValidationError."""
-        with pytest.raises(ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"
+        ):
             AdaptiveMutation(min=-0.1)
 
     def test_min_above_one_raises(self):
-        with pytest.raises(ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.min must be between 0.0 and 1.0"
+        ):
             AdaptiveMutation(min=1.5)
 
     def test_max_below_zero_raises(self):
-        with pytest.raises(ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"
+        ):
             AdaptiveMutation(max=-0.5)
 
     def test_max_above_one_raises(self):
-        with pytest.raises(ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match="adaptive_mutation.max must be between 0.0 and 1.0"
+        ):
             AdaptiveMutation(max=2.0)
 
     def test_boundary_min_zero_max_one(self):
@@ -115,11 +128,17 @@ class TestAdaptiveMutationValidation:
         assert am.generations == 10
 
     def test_generations_zero_raises(self):
-        with pytest.raises(ValidationError, match="adaptive_mutation.generations must be a positive integer"):
+        with pytest.raises(
+            ValidationError,
+            match="adaptive_mutation.generations must be a positive integer",
+        ):
             AdaptiveMutation(generations=0)
 
     def test_generations_negative_raises(self):
-        with pytest.raises(ValidationError, match="adaptive_mutation.generations must be a positive integer"):
+        with pytest.raises(
+            ValidationError,
+            match="adaptive_mutation.generations must be a positive integer",
+        ):
             AdaptiveMutation(generations=-5)
 
 
@@ -157,17 +176,23 @@ class TestConfigFileProbabilityRates:
 
     @pytest.mark.parametrize("field", RATE_FIELDS)
     def test_rate_above_one_raises(self, field):
-        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match=f"{field} must be between 0.0 and 1.0"
+        ):
             _make_config(**{field: 1.5})
 
     @pytest.mark.parametrize("field", RATE_FIELDS)
     def test_rate_negative_raises(self, field):
-        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match=f"{field} must be between 0.0 and 1.0"
+        ):
             _make_config(**{field: -0.1})
 
     @pytest.mark.parametrize("field", RATE_FIELDS)
     def test_rate_large_value_raises(self, field):
-        with pytest.raises(ValidationError, match=f"{field} must be between 0.0 and 1.0"):
+        with pytest.raises(
+            ValidationError, match=f"{field} must be between 0.0 and 1.0"
+        ):
             _make_config(**{field: 99.0})
 
 
@@ -217,11 +242,15 @@ class TestConfigFileInjectionSize:
         assert config.population_injection_size == 1
 
     def test_injection_size_zero_raises(self):
-        with pytest.raises(ValidationError, match="population_injection_size must be at least 1"):
+        with pytest.raises(
+            ValidationError, match="population_injection_size must be at least 1"
+        ):
             _make_config(population_injection_size=0)
 
     def test_injection_size_negative_raises(self):
-        with pytest.raises(ValidationError, match="population_injection_size must be at least 1"):
+        with pytest.raises(
+            ValidationError, match="population_injection_size must be at least 1"
+        ):
             _make_config(population_injection_size=-3)
 
 
@@ -246,11 +275,15 @@ class TestConfigFileGenerations:
         assert config.generations == 1
 
     def test_generations_zero_raises(self):
-        with pytest.raises(ValidationError, match="generations must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="generations must be a positive integer"
+        ):
             _make_config(generations=0)
 
     def test_generations_negative_raises(self):
-        with pytest.raises(ValidationError, match="generations must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="generations must be a positive integer"
+        ):
             _make_config(generations=-10)
 
 
@@ -275,11 +308,15 @@ class TestConfigFileDuration:
         assert config.duration == 1
 
     def test_duration_zero_raises(self):
-        with pytest.raises(ValidationError, match="duration must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="duration must be a positive integer"
+        ):
             _make_config(duration=0)
 
     def test_duration_negative_raises(self):
-        with pytest.raises(ValidationError, match="duration must be a positive integer"):
+        with pytest.raises(
+            ValidationError, match="duration must be a positive integer"
+        ):
             _make_config(duration=-60)
 
 


### PR DESCRIPTION
## What

Add comprehensive Pydantic input validation for all genetic algorithm parameters in `ConfigFile`, `BaselineConfig`, and `AdaptiveMutation`. Currently, rate parameters like `mutation_rate`, `crossover_rate`, etc. are documented as `(0.0-1.0)` in inline comments but have **no enforcement** — users can pass values like `mutation_rate: 99.0` or `crossover_rate: -1` and the algorithm silently produces garbage results.

## Why

The config model should **fail fast** with clear, actionable error messages instead of silently accepting invalid values. This aligns with existing validation patterns already used in the codebase (`FitnessFunctionItem.weight` and `StoppingCriteria`).

## Changes

### `krkn_ai/models/config.py`

**`ConfigFile` validators:**
| Parameter | Constraint |
|---|---|
| `mutation_rate`, `scenario_mutation_rate`, `crossover_rate`, `composition_rate`, `population_injection_rate` | `[0.0, 1.0]` |
| `population_size` | `>= 2` |
| `population_injection_size` | `>= 1` |
| `generations` | `> 0` (when set) |
| `duration` | `> 0` (when set) |
| `wait_duration` | `>= 0` |

**`BaselineConfig` validators:**
| Parameter | Constraint |
|---|---|
| `duration` | `> 0` |

**`AdaptiveMutation` validators:**
| Parameter | Constraint |
|---|---|
| `min`, `max` | `[0.0, 1.0]` |
| `generations` | `> 0` |
| `min` < `max` | cross-field validation |

### `tests/unit/models/test_config_validation.py` (new)

Comprehensive test suite with **319 lines** covering:
- Valid values, boundary values (0.0, 1.0), and every invalid case
- Parametrized tests across all 5 rate fields
- Cross-field validation (adaptive_mutation.min < max)
- Integration test verifying all defaults pass validation

## Backward Compatibility

✅ **No breaking changes** — all default parameter values and any currently valid configs continue to work. Only previously-invalid values (which would have produced incorrect behavior anyway) are now rejected.

Closes #229 
