### PR TITLE
fix(discover): filter nodes by label match to skip irrelevant nodes

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -292,11 +292,21 @@ class ClusterManager:
         """
         List nodes with optional label filtering.
 
+        When a specific label pattern is provided, only nodes that carry at
+        least one matching label key are returned.  This prevents expensive
+        interface listing (``oc debug``) and metrics fetching for nodes the
+        caller is not interested in.
+
+        The ``kubernetes.io/hostname`` label is always included in the output
+        labels for identification, but does not affect which nodes pass the
+        filter.
+
         Args:
-            node_label_pattern: Pattern for node label keys to include.
-                - None or '': Include all labels (default_match_all=True)
-                - '*': Include all labels
-                - 'kubernetes.io/hostname': Include specific labels
+            node_label_pattern: Pattern for node label keys to filter by.
+                - None or '': Return all nodes with all labels
+                - '*': Return all nodes with all labels
+                - 'node-role.kubernetes.io/control-plane': Return only nodes
+                  that carry this label key
                 - 'node-role.*': Regex pattern for label keys
 
         Returns:
@@ -307,7 +317,17 @@ class ClusterManager:
             node_label_pattern, default_match_all=True
         )
 
+        # Build a separate matcher from the original pattern (before hostname
+        # injection) to decide whether a node should be included at all.
+        # When a specific label pattern is given, only nodes that carry at
+        # least one matching label are kept — this avoids expensive interface
+        # listing and metrics fetching for irrelevant nodes.  (Fixes #174)
+        user_matcher = PatternMatcher.from_string(
+            node_label_pattern, default_match_all=True
+        )
+
         # If specific patterns provided, ensure hostname is always included
+        # in the *display* matcher so node names are always visible.
         if not label_matcher.match_all and label_matcher.include_patterns:
             # Check if hostname pattern is already included
             hostname_key = "kubernetes.io/hostname"
@@ -349,11 +369,24 @@ class ClusterManager:
                 logger.debug("Node %s is not Ready, skipping", node.metadata.name)
                 return None
 
+            # When a specific label pattern is active, skip nodes that have
+            # no labels matching the user's original pattern.
+            if not user_matcher.match_all:
+                node_labels = node.metadata.labels or {}
+                has_user_match = any(user_matcher.matches(k) for k in node_labels)
+                if not has_user_match:
+                    logger.debug(
+                        "Node %s has no labels matching pattern, skipping",
+                        node.metadata.name,
+                    )
+                    return None
+
             labels = {}
             if node.metadata.labels is not None:
                 for label_key, label_value in node.metadata.labels.items():
                     if label_matcher.matches(label_key):
                         labels[label_key] = label_value
+
             # Get node taints and format as strings: "key:effect" or "key=value:effect"
             taints = []
             if node.spec.taints is not None:

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -461,6 +461,156 @@ class TestClusterManager:
         assert nodes[0].free_mem == -1  # Error indicator
         assert nodes[0].interfaces == []  # Empty on failure
 
+    def test_list_nodes_excludes_nodes_without_matching_labels(self, cluster_manager):
+        """Test list_nodes excludes nodes that have no matching labels when a
+        specific label pattern is provided (fixes #174)"""
+        # Node 1: has the target label
+        mock_node1 = Mock()
+        mock_node1.metadata.name = "control-plane-1"
+        mock_node1.metadata.labels = {
+            "kubernetes.io/hostname": "control-plane-1",
+            "node-role.kubernetes.io/control-plane": "",
+        }
+        mock_node1.spec.taints = None
+        mock_node1.spec.unschedulable = False
+        mock_ready1 = Mock()
+        mock_ready1.type = "Ready"
+        mock_ready1.status = "True"
+        mock_node1.status.conditions = [mock_ready1]
+        mock_node1.status.allocatable = {"cpu": "4", "memory": "8Gi"}
+
+        # Node 2: does NOT have the target label
+        mock_node2 = Mock()
+        mock_node2.metadata.name = "worker-1"
+        mock_node2.metadata.labels = {
+            "kubernetes.io/hostname": "worker-1",
+            "node-role.kubernetes.io/worker": "",
+        }
+        mock_node2.spec.taints = None
+        mock_node2.spec.unschedulable = False
+        mock_ready2 = Mock()
+        mock_ready2.type = "Ready"
+        mock_ready2.status = "True"
+        mock_node2.status.conditions = [mock_ready2]
+        mock_node2.status.allocatable = {"cpu": "8", "memory": "16Gi"}
+
+        cluster_manager.core_api.list_node.return_value.items = [
+            mock_node1,
+            mock_node2,
+        ]
+
+        # Mock metrics
+        cluster_manager.custom_obj_api.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "control-plane-1"},
+                    "usage": {"cpu": "500m", "memory": "2Gi"},
+                }
+            ]
+        }
+
+        # Mock interfaces
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=("eth0\n", 0),
+        ):
+            nodes = cluster_manager.list_nodes(
+                node_label_pattern="node-role.kubernetes.io/control-plane"
+            )
+
+        # Only the control-plane node should be returned
+        assert len(nodes) == 1
+        assert nodes[0].name == "control-plane-1"
+
+    def test_list_nodes_includes_all_nodes_when_no_pattern_given(self, cluster_manager):
+        """Test list_nodes returns all nodes when no label pattern is specified
+        (backward compatibility)"""
+        mock_node1 = Mock()
+        mock_node1.metadata.name = "node-1"
+        mock_node1.metadata.labels = {"kubernetes.io/hostname": "node-1"}
+        mock_node1.spec.taints = None
+        mock_node1.spec.unschedulable = False
+        mock_ready1 = Mock()
+        mock_ready1.type = "Ready"
+        mock_ready1.status = "True"
+        mock_node1.status.conditions = [mock_ready1]
+        mock_node1.status.allocatable = {"cpu": "2", "memory": "4Gi"}
+
+        mock_node2 = Mock()
+        mock_node2.metadata.name = "node-2"
+        mock_node2.metadata.labels = {"kubernetes.io/hostname": "node-2"}
+        mock_node2.spec.taints = None
+        mock_node2.spec.unschedulable = False
+        mock_ready2 = Mock()
+        mock_ready2.type = "Ready"
+        mock_ready2.status = "True"
+        mock_node2.status.conditions = [mock_ready2]
+        mock_node2.status.allocatable = {"cpu": "2", "memory": "4Gi"}
+
+        cluster_manager.core_api.list_node.return_value.items = [
+            mock_node1,
+            mock_node2,
+        ]
+
+        # Mock metrics
+        cluster_manager.custom_obj_api.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "node-1"},
+                    "usage": {"cpu": "500m", "memory": "2Gi"},
+                },
+                {
+                    "metadata": {"name": "node-2"},
+                    "usage": {"cpu": "500m", "memory": "2Gi"},
+                },
+            ]
+        }
+
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=("eth0\n", 0),
+        ):
+            nodes = cluster_manager.list_nodes(node_label_pattern=None)
+
+        # Both nodes should be returned with no pattern
+        assert len(nodes) == 2
+        assert {n.name for n in nodes} == {"node-1", "node-2"}
+
+    def test_list_nodes_includes_all_nodes_with_wildcard_pattern(self, cluster_manager):
+        """Test list_nodes returns all nodes when '*' wildcard pattern is used
+        (backward compatibility)"""
+        mock_node = Mock()
+        mock_node.metadata.name = "node-1"
+        mock_node.metadata.labels = {"kubernetes.io/hostname": "node-1"}
+        mock_node.spec.taints = None
+        mock_node.spec.unschedulable = False
+        mock_ready = Mock()
+        mock_ready.type = "Ready"
+        mock_ready.status = "True"
+        mock_node.status.conditions = [mock_ready]
+        mock_node.status.allocatable = {"cpu": "2", "memory": "4Gi"}
+
+        cluster_manager.core_api.list_node.return_value.items = [mock_node]
+
+        # Mock metrics
+        cluster_manager.custom_obj_api.list_cluster_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "node-1"},
+                    "usage": {"cpu": "500m", "memory": "2Gi"},
+                }
+            ]
+        }
+
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=("eth0\n", 0),
+        ):
+            nodes = cluster_manager.list_nodes(node_label_pattern="*")
+
+        assert len(nodes) == 1
+        assert nodes[0].name == "node-1"
+
     def test_list_node_interfaces_filters_network_interfaces(self, cluster_manager):
         """Test list_node_interfaces filters and returns only ens/eth interfaces"""
         with patch(


### PR DESCRIPTION
## Summary

Fixes #174 — `list_nodes()` now excludes nodes that do not carry any label key matching the user's `--node-label` pattern, preventing unnecessary `oc debug` calls and metrics fetching for irrelevant nodes.

## Bug

When a user runs `krkn-ai discover --node-label "node-role.kubernetes.io/control-plane"`, the intent is to discover only control-plane nodes. Previously, `list_nodes()` used the `node_label_pattern` to filter which label **keys** appear on each node object, but still processed **every** node in the cluster — including running `oc debug` (up to 180s timeout per node) for interface listing and querying the metrics API.

## Fix

Introduced a separate `user_matcher` built from the original pattern (before the automatic `kubernetes.io/hostname` injection) to decide whether a node should be included:

- If `user_matcher.match_all` is `True` (no pattern or `*`), all nodes are included — **backward compatible**
- Otherwise, only nodes with at least one label key matching the user's pattern are kept
- The existing `label_matcher` (with hostname injected) continues to control which labels appear in the output, so `kubernetes.io/hostname` is always visible for identification

Updated the docstring to reflect the new filtering semantics.

## Testing

Added 3 unit tests:
- `test_list_nodes_excludes_nodes_without_matching_labels` — verifies only nodes with matching labels are returned
- `test_list_nodes_includes_all_nodes_when_no_pattern_given` — backward compatibility
- `test_list_nodes_includes_all_nodes_with_wildcard_pattern` — backward compatibility

