### PR TITLE
fix : prevent ValueError in ContainerScenario for empty pod containers

### DIFF
--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -66,6 +66,11 @@ class ContainerScenario(Scenario):
         # pod_label is a string of the form "key=value"
         self.label_selector.value = "{}={}".format(label, labels[label])
 
+        if not pod.containers:
+            self.disruption_count.value = 1
+            self.container_name.value = ""
+            return
+
         self.disruption_count.value = rng.randint(1, len(pod.containers))
 
         if self.disruption_count.value == 1:

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -105,6 +105,22 @@ class TestContainerScenario:
         ):
             ContainerScenario(cluster_components=cluster)
 
+    def test_container_scenario_empty_pod(self):
+        """Test that ContainerScenario handles pods with no containers gracefully."""
+        pod_empty = Pod(
+            name="empty-pod",
+            containers=[],  # zero containers
+            labels={"app": "test"},
+            disabled=False,
+        )
+        ns = Namespace(name="test-ns", pods=[pod_empty], services=[], pvcs=[], vmis=[])
+        components = ClusterComponents(namespaces=[ns], nodes=[])
+
+        scenario = ContainerScenario(cluster_components=components)
+        # Should not raise; safe defaults are set
+        assert scenario.disruption_count.value == 1
+        assert scenario.container_name.value == ""
+
 
 class TestNodeCPUHogScenario:
     """Test NodeCPUHogScenario class"""


### PR DESCRIPTION
Closes #237

- Added a guard in `mutate()` to safely handle pods with zero containers.
- Sets safe defaults (disruption_count=1, container_name='') and returns early.
- Added unit test `test_container_scenario_empty_pod` that reproduces the crashing scenario and verifies the fix.

## How to test
```bash
pytest tests/unit/models/scenario/test_scenario_classes.py::TestContainerScenario::test_container_scenario_empty_pod -v