### PR TITLE
fix: generate run UUID per genetic algorithm instance

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -44,11 +44,11 @@ class GeneticAlgorithm:
         output_dir: str,
         format: str,
         runner_type: KrknRunnerType = None,
-        run_uuid: str = str(uuid.uuid4()),
+        run_uuid: Optional[str] = None,
     ):
         self.config = config
         self.format = format
-        self.run_uuid = run_uuid
+        self.run_uuid = run_uuid if run_uuid is not None else str(uuid.uuid4())
 
         # Organize results under run_uuid subdirectory
         self.output_dir = output_dir

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -33,6 +33,22 @@ class TestGeneticAlgorithmInitialization:
                 assert ga.population == []
                 assert len(ga.best_of_generation) == 0
 
+    def test_init_generates_unique_run_uuid(self, minimal_config, temp_output_dir):
+        """Test initialization generates a unique run UUID per instance"""
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                first = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                second = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+                assert first.run_uuid != second.run_uuid
+
     def test_init_with_population_size_less_than_2(
         self, minimal_config, temp_output_dir
     ):


### PR DESCRIPTION
### Description

This change fixes `GeneticAlgorithm` so each instance gets its own generated `run_uuid` when one is not explicitly provided.

Previously, the default value was defined as `str(uuid.uuid4())` in the constructor signature. Python evaluates default arguments once at function definition time, so every `GeneticAlgorithm` instance created without a `run_uuid` reused the same UUID within the same process.

This update changes the default to `None` and generates the UUID inside `__init__`.

### Motivation and Context

Fixes #219

The shared `run_uuid` could cause multiple genetic algorithm runs in the same process to be grouped under the same run identifier. That can lead to output collisions and incorrect Elasticsearch indexing.

The new behavior is:

```python
ga1 = GeneticAlgorithm(config=config, output_dir="out1", format="yaml")
ga2 = GeneticAlgorithm(config=config, output_dir="out2", format="yaml")

assert ga1.run_uuid != ga2.run_uuid
```

Explicit `run_uuid` values are still respected.

### Types of changes

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] **Enhancement** (changes that improvement of current feature or performance)
- [ ] **Refactoring** (changes that neither fixes a bug nor adds a feature)
- [x] **Test Case** (changes that add missing tests or correct existing tests)
- [ ] **Code style optimization** (changes that do not affect the meaning of the code)
- [ ] **Docs** (changes that only update documentation)
- [ ] **Chore** (changes that don't modify src or test files)

### Self Check before Merge

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.