### PR TITLE
fix: handle missing url in health checks and catch Kubernetes API errors in discover command

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -1,6 +1,9 @@
 import os
+import sys
 import uuid
 import json
+from kubernetes.client.rest import ApiException
+from urllib3.exceptions import MaxRetryError
 from krkn_ai.constants import STATUS_STARTED, STATUS_FAILED
 
 import click
@@ -245,14 +248,24 @@ def discover(
         logger.error("Kubeconfig file not found.")
         exit(1)
 
-    cluster_manager = ClusterManager(kubeconfig)
+    try:
+        cluster_manager = ClusterManager(kubeconfig)
 
-    cluster_components = cluster_manager.discover_components(
-        namespace_pattern=namespace,
-        pod_label_pattern=pod_label,
-        node_label_pattern=node_label,
-        skip_pod_name=skip_pod_name,
-    )
+        cluster_components = cluster_manager.discover_components(
+            namespace_pattern=namespace,
+            pod_label_pattern=pod_label,
+            node_label_pattern=node_label,
+            skip_pod_name=skip_pod_name,
+        )
+    except ApiException as e:
+        logger.error("Kubernetes API error: %s", e)
+        sys.exit(1)
+    except MaxRetryError as e:
+        logger.error("Failed to connect to Kubernetes cluster: %s", e)
+        sys.exit(1)
+    except Exception as e:
+        logger.error("An unexpected error occurred during discovery: %s", e)
+        sys.exit(1)
 
     cluster_components_data = cluster_components.model_dump(
         mode="json", warnings="none", exclude_defaults=True

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -48,7 +48,8 @@ def read_config_from_file(
 
         # Replace parameter in health check url string
         for app in config.get("health_checks", {}).get("applications", []):
-            app["url"] = preprocess_param_string(app["url"], raw)
+            if "url" in app:
+                app["url"] = preprocess_param_string(app["url"], raw)
 
         # Replace parameter in elastic configuration
         if "elastic" in config and "server" in config["elastic"]:


### PR DESCRIPTION
Problem
This PR addresses two reliability issues in the CLI and configuration parsing logic:

1. `KeyError` in Health Checks: The configuration parser attempted to preprocess parameters in health check URLs before validation. If the `url` key was missing in the configuration file, the program would crash with a `KeyError` instead of allowing Pydantic to provide a friendly validation error.
2. Raw Tracebacks in `discover`: The `discover` command lacked exception handling for Kubernetes API and connection errors. If a user provided an invalid kubeconfig or had network connectivity issues, the tool would exit with a full Python traceback (e.g., `ApiException` or `MaxRetryError`).

Solution
1. Graceful Key Access: Updated `krkn_ai/utils/fs.py` to check for the existence of the `url` key within the health check applications loop before attempting to process it. This ensures that missing required fields are handled by the schema validator rather than causing a runtime crash.
2. Improved Error Handling: Wrapped the `ClusterManager` instantiation and component discovery logic in `krkn_ai/cli/cmd.py` within a `try/except` block. It now catches `ApiException` and `MaxRetryError`, logging a user-friendly error message and exiting gracefully with status code 1.

Testing
The following static analysis and formatting checks were performed and passed:

* `ruff check .`
* `ruff format .`
* `mypy --config-file mypy.ini krkn_ai`
* `pre-commit run --all-files` (skipping `hadolint-docker`)

Type of Change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* Documentation update