### PR TITLE
fix(dashboard): prevent SIGPIPE crash by redirecting output to log file

### DIFF
--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -29,17 +29,18 @@ class DashboardManager:
         try:
             if background:
                 log_file_path = os.path.join(actual_output, "dashboard.log")
-                log_file = open(log_file_path, "w")
+                log_file = open(log_file_path, "a")
 
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                )
-                
-                # Parent can safely close its file descriptor
-                log_file.close()
-                
+                try:
+                    process = subprocess.Popen(
+                        cmd,
+                        stdout=log_file,
+                        stderr=subprocess.STDOUT,
+                    )
+                finally:
+                    # Parent can safely close its file descriptor
+                    log_file.close()
+
                 # Check quickly if the process failed to start
                 try:
                     retcode = process.wait(timeout=2)

--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -28,20 +28,24 @@ class DashboardManager:
 
         try:
             if background:
+                log_file_path = os.path.join(actual_output, "dashboard.log")
+                log_file = open(log_file_path, "w")
+
                 process = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
                 )
-                assert process.stdout is not None  # guaranteed by PIPE
-                assert process.stderr is not None  # guaranteed by PIPE
+                
+                # Parent can safely close its file descriptor
+                log_file.close()
+                
                 # Check quickly if the process failed to start
                 try:
                     retcode = process.wait(timeout=2)
                     # Process exited immediately — something went wrong
-                    stdout = process.stdout.read().decode(errors="replace")
-                    stderr = process.stderr.read().decode(errors="replace")
-                    output = (stderr or stdout).strip()
+                    with open(log_file_path, "r", errors="replace") as f:
+                        output = f.read().strip()
                     logger.warning(
                         "Dashboard process exited immediately (code %d): %s",
                         retcode,
@@ -49,9 +53,7 @@ class DashboardManager:
                     )
                     return None
                 except subprocess.TimeoutExpired:
-                    # Still running after 2s — detach pipes so they don't block
-                    process.stdout.close()
-                    process.stderr.close()
+                    # Still running after 2s
                     logger.info(f"Dashboard running at http://localhost:{port}")
                     return process
             else:

--- a/krkn_ai/utils/node_selector.py
+++ b/krkn_ai/utils/node_selector.py
@@ -6,7 +6,6 @@ their metadata.
 """
 
 import json
-import random
 from collections import Counter
 from dataclasses import dataclass
 from typing import List, Set, Optional
@@ -79,7 +78,7 @@ def select_nodes(nodes: List[Node]) -> NodeSelectionResult:
         ]
 
         count = rng.randint(1, len(all_matching_nodes))
-        selected_nodes = random.sample(all_matching_nodes, k=count)
+        selected_nodes = rng.sample(all_matching_nodes, k=count)
 
         taints_json = _collect_taints_from_nodes(selected_nodes)
 

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -41,7 +41,7 @@ class RNG:
             return low
         return int(self.rng.integers(low, high + 1))
 
-    def sample(self, items: Sequence[T], k: int) -> list:
+    def sample(self, items: Sequence[T], k: int) -> List[T]:
         """Return k unique elements from items, without replacement."""
         indices = self.rng.choice(len(items), size=k, replace=False)
         return [items[i] for i in indices]

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -41,6 +41,11 @@ class RNG:
             return low
         return int(self.rng.integers(low, high + 1))
 
+    def sample(self, items: Sequence[T], k: int) -> list:
+        """Return k unique elements from items, without replacement."""
+        indices = self.rng.choice(len(items), size=k, replace=False)
+        return [items[i] for i in indices]
+
     def uniform(self, low: float, high: float):
         return self.rng.uniform(low, high)
 

--- a/tests/unit/utils/test_rng.py
+++ b/tests/unit/utils/test_rng.py
@@ -128,6 +128,20 @@ class TestRNG:
         )
         assert results == {1, 2}
 
+    def test_sample(self):
+        """Test sample() returns unique elements."""
+        rng = RNG(42)
+        items = [1, 2, 3, 4, 5]
+        sampled = rng.sample(items, k=3)
+        assert len(sampled) == 3
+        assert len(set(sampled)) == 3
+        assert all(x in items for x in sampled)
+
+        # Reproducibility check
+        rng.set_seed(42)
+        sampled2 = rng.sample(items, k=3)
+        assert sampled == sampled2
+
     def test_uniform(self):
         """Test uniform() returns a float within range."""
         rng = RNG(42)


### PR DESCRIPTION

## Description

This PR addresses a critical, silent background crash in the Streamlit `DashboardManager`. Previously, the manager used `subprocess.PIPE` to capture output from the background process but closed its end of the pipes after 2 seconds to avoid OS buffer deadlocks. This unfortunately caused a `SIGPIPE` exception (or `BrokenPipeError`) in the child process whenever Streamlit subsequently tried to write logs (e.g., during web interaction), killing the dashboard.

This PR modifies `DashboardManager.start()` to redirect the Streamlit process's `stdout` and `stderr` directly to a persistent `dashboard.log` file instead of OS pipes. This prevents OS buffer deadlocks while providing the child process with a safe file descriptor to write to, ensuring it remains stable and alive in the background.

---
**Fix**:#241

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

---

## Testing

- Tested locally by spinning up the background dashboard manager via a python script and verifying it successfully returns the PID.
- Triggered manual HTTP requests to the dashboard to simulate Streamlit logging activity.
- Confirmed the dashboard process remains alive via `p.poll()` after interactions.
- Validated that Streamlit's logs correctly appear in the `dashboard.log` file within the output directory.

---

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

---

## Additional Notes

This fix ensures that users no longer experience their dashboard background process randomly terminating without a visible stack trace during chaos experiment executions.