### PR TITLE
 fix(cluster_manager): eliminate O(N²) API calls in node metrics discovery

### DIFF
--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -29,17 +29,18 @@ class DashboardManager:
         try:
             if background:
                 log_file_path = os.path.join(actual_output, "dashboard.log")
-                log_file = open(log_file_path, "w")
+                log_file = open(log_file_path, "a")
 
-                process = subprocess.Popen(
-                    cmd,
-                    stdout=log_file,
-                    stderr=subprocess.STDOUT,
-                )
-                
-                # Parent can safely close its file descriptor
-                log_file.close()
-                
+                try:
+                    process = subprocess.Popen(
+                        cmd,
+                        stdout=log_file,
+                        stderr=subprocess.STDOUT,
+                    )
+                finally:
+                    # Parent can safely close its file descriptor
+                    log_file.close()
+
                 # Check quickly if the process failed to start
                 try:
                     retcode = process.wait(timeout=2)

--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -28,20 +28,24 @@ class DashboardManager:
 
         try:
             if background:
+                log_file_path = os.path.join(actual_output, "dashboard.log")
+                log_file = open(log_file_path, "w")
+
                 process = subprocess.Popen(
                     cmd,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
                 )
-                assert process.stdout is not None  # guaranteed by PIPE
-                assert process.stderr is not None  # guaranteed by PIPE
+                
+                # Parent can safely close its file descriptor
+                log_file.close()
+                
                 # Check quickly if the process failed to start
                 try:
                     retcode = process.wait(timeout=2)
                     # Process exited immediately — something went wrong
-                    stdout = process.stdout.read().decode(errors="replace")
-                    stderr = process.stderr.read().decode(errors="replace")
-                    output = (stderr or stdout).strip()
+                    with open(log_file_path, "r", errors="replace") as f:
+                        output = f.read().strip()
                     logger.warning(
                         "Dashboard process exited immediately (code %d): %s",
                         retcode,
@@ -49,9 +53,7 @@ class DashboardManager:
                     )
                     return None
                 except subprocess.TimeoutExpired:
-                    # Still running after 2s — detach pipes so they don't block
-                    process.stdout.close()
-                    process.stderr.close()
+                    # Still running after 2s
                     logger.info(f"Dashboard running at http://localhost:{port}")
                     return process
             else:

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
 from krkn_ai.utils import run_shell
@@ -318,6 +318,21 @@ class ClusterManager:
 
         nodes = self.core_api.list_node().items
 
+        # Fetch all node metrics in a single API call (O(1) network request)
+        # and build a lookup dictionary for O(1) per-node access.
+        node_metrics_map: Dict[str, tuple] = {}
+        try:
+            metrics = self.custom_obj_api.list_cluster_custom_object(
+                group="metrics.k8s.io", version="v1beta1", plural="nodes"
+            )
+            for item in metrics.get("items", []):
+                name = item["metadata"]["name"]
+                usage_cpu = self.parse_cpu(item["usage"]["cpu"])
+                usage_mem = self.parse_memory(item["usage"]["memory"])
+                node_metrics_map[name] = (usage_cpu, usage_mem)
+        except Exception as e:
+            logger.warning("Failed to fetch cluster node metrics: %s", e)
+
         node_list = []
 
         for node in nodes:
@@ -366,7 +381,11 @@ class ClusterManager:
             try:
                 alloc_cpu = self.parse_cpu(node.status.allocatable["cpu"])
                 alloc_mem = self.parse_memory(node.status.allocatable["memory"])
-                usage_cpu, usage_mem = self.__fetch_node_metrics(node.metadata.name)
+                if node.metadata.name not in node_metrics_map:
+                    raise ValueError(
+                        f"Metrics not found for node: {node.metadata.name}"
+                    )
+                usage_cpu, usage_mem = node_metrics_map[node.metadata.name]
                 node_component.free_cpu = alloc_cpu - usage_cpu
                 node_component.free_mem = alloc_mem - usage_mem
             except Exception as e:
@@ -411,20 +430,6 @@ class ClusterManager:
                 interfaces.append(intf)
 
         return interfaces
-
-    def __fetch_node_metrics(self, node: str):
-        metrics = self.custom_obj_api.list_cluster_custom_object(
-            group="metrics.k8s.io", version="v1beta1", plural="nodes"
-        )
-
-        for item in metrics["items"]:
-            name = item["metadata"]["name"]
-            if name == node:
-                usage_cpu = item["usage"]["cpu"]  # e.g. "250m"
-                usage_mem = item["usage"]["memory"]  # e.g. "1024Mi"
-                return self.parse_cpu(usage_cpu), self.parse_memory(usage_mem)
-
-        raise ValueError(f"Metrics not found for node: {node}")
 
     @staticmethod
     def parse_cpu(cpu_str: str):

--- a/krkn_ai/utils/node_selector.py
+++ b/krkn_ai/utils/node_selector.py
@@ -6,7 +6,6 @@ their metadata.
 """
 
 import json
-import random
 from collections import Counter
 from dataclasses import dataclass
 from typing import List, Set, Optional
@@ -79,7 +78,7 @@ def select_nodes(nodes: List[Node]) -> NodeSelectionResult:
         ]
 
         count = rng.randint(1, len(all_matching_nodes))
-        selected_nodes = random.sample(all_matching_nodes, k=count)
+        selected_nodes = rng.sample(all_matching_nodes, k=count)
 
         taints_json = _collect_taints_from_nodes(selected_nodes)
 

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -41,7 +41,7 @@ class RNG:
             return low
         return int(self.rng.integers(low, high + 1))
 
-    def sample(self, items: Sequence[T], k: int) -> list:
+    def sample(self, items: Sequence[T], k: int) -> List[T]:
         """Return k unique elements from items, without replacement."""
         indices = self.rng.choice(len(items), size=k, replace=False)
         return [items[i] for i in indices]

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -41,6 +41,11 @@ class RNG:
             return low
         return int(self.rng.integers(low, high + 1))
 
+    def sample(self, items: Sequence[T], k: int) -> list:
+        """Return k unique elements from items, without replacement."""
+        indices = self.rng.choice(len(items), size=k, replace=False)
+        return [items[i] for i in indices]
+
     def uniform(self, low: float, high: float):
         return self.rng.uniform(low, high)
 

--- a/tests/unit/utils/test_rng.py
+++ b/tests/unit/utils/test_rng.py
@@ -128,6 +128,20 @@ class TestRNG:
         )
         assert results == {1, 2}
 
+    def test_sample(self):
+        """Test sample() returns unique elements."""
+        rng = RNG(42)
+        items = [1, 2, 3, 4, 5]
+        sampled = rng.sample(items, k=3)
+        assert len(sampled) == 3
+        assert len(set(sampled)) == 3
+        assert all(x in items for x in sampled)
+
+        # Reproducibility check
+        rng.set_seed(42)
+        sampled2 = rng.sample(items, k=3)
+        assert sampled == sampled2
+
     def test_uniform(self):
         """Test uniform() returns a float within range."""
         rng = RNG(42)


### PR DESCRIPTION
## Description

The `list_nodes()` method previously called `__fetch_node_metrics()` inside a
per-node loop. That helper fetched the entire cluster metrics payload on every
call, resulting in **N API calls each downloading N node metrics** — an O(N²)
bottleneck. This PR refactors it to fetch all node metrics in a **single bulk
API call** before the loop and use an O(1) dictionary lookup per node. The
`__fetch_node_metrics` method is removed entirely.

---
**Fix**:#243

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
---

## Testing

- All **234 existing unit tests** pass locally without modification.
- `ruff format` and `ruff check` pass cleanly.

---

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

---

## Additional Notes

N/A