### PR TITLE
fix(genetic): use active components during scenario mutation

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -63,9 +63,6 @@ class GeneticAlgorithm:
         self.krkn_client = KrknRunner(
             config, output_dir=self.output_dir, runner_type=runner_type
         )
-        self.active_cluster_components = (
-            self.config.cluster_components.get_active_components()
-        )
         self.population: List[BaseScenario] = []
 
         self.stagnant_generations = 0
@@ -587,7 +584,7 @@ class GeneticAlgorithm:
         for _, scenario_cls in self.valid_scenarios:
             # instantiate new scenario for a scenario type
             new_scenario = scenario_cls(
-                cluster_components=self.active_cluster_components
+                cluster_components=self.config.cluster_components.get_active_components()
             )
 
             common_params = set([type(x) for x in new_scenario.parameters]) & set(

--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -63,6 +63,9 @@ class GeneticAlgorithm:
         self.krkn_client = KrknRunner(
             config, output_dir=self.output_dir, runner_type=runner_type
         )
+        self.active_cluster_components = (
+            self.config.cluster_components.get_active_components()
+        )
         self.population: List[BaseScenario] = []
 
         self.stagnant_generations = 0
@@ -584,7 +587,7 @@ class GeneticAlgorithm:
         for _, scenario_cls in self.valid_scenarios:
             # instantiate new scenario for a scenario type
             new_scenario = scenario_cls(
-                cluster_components=self.config.cluster_components
+                cluster_components=self.active_cluster_components
             )
 
             common_params = set([type(x) for x in new_scenario.parameters]) & set(

--- a/tests/unit/algorithm/test_mutation.py
+++ b/tests/unit/algorithm/test_mutation.py
@@ -87,9 +87,6 @@ class TestMutation:
             ],
         )
         genetic_algorithm.config.cluster_components = cluster_components
-        genetic_algorithm.active_cluster_components = (
-            cluster_components.get_active_components()
-        )
         genetic_algorithm.valid_scenarios = [("recording_scenario", RecordingScenario)]
         RecordingScenario.received_components = []
 

--- a/tests/unit/algorithm/test_mutation.py
+++ b/tests/unit/algorithm/test_mutation.py
@@ -2,9 +2,30 @@
 Mutation operation tests
 """
 
+from typing import ClassVar, List
+
 from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
+from krkn_ai.models.scenario.parameters import DummyEndParameter
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
-from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.cluster_components import ClusterComponents, Namespace, Node
+
+
+class SourceScenario(DummyScenario):
+    name: str = "source-scenario"
+    krknctl_name: str = "source-scenario"
+    krknhub_image: str = "source-scenario"
+
+
+class RecordingScenario(DummyScenario):
+    name: str = "recording-scenario"
+    krknctl_name: str = "recording-scenario"
+    krknhub_image: str = "recording-scenario"
+
+    received_components: ClassVar[List[ClusterComponents]] = []
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.received_components.append(self._cluster_components)
 
 
 class TestMutation:
@@ -52,3 +73,39 @@ class TestMutation:
         assert mutated.scenario_b is not None
         assert hasattr(mutated.scenario_a, "mutate")
         assert hasattr(mutated.scenario_b, "mutate")
+
+    def test_scenario_mutation_uses_active_cluster_components(self, genetic_algorithm):
+        """Disabled components should stay out of scenario mutation."""
+        cluster_components = ClusterComponents(
+            namespaces=[
+                Namespace(name="active-namespace"),
+                Namespace(name="disabled-namespace", disabled=True),
+            ],
+            nodes=[
+                Node(name="active-node"),
+                Node(name="disabled-node", disabled=True),
+            ],
+        )
+        genetic_algorithm.config.cluster_components = cluster_components
+        genetic_algorithm.active_cluster_components = (
+            cluster_components.get_active_components()
+        )
+        genetic_algorithm.valid_scenarios = [("recording_scenario", RecordingScenario)]
+        RecordingScenario.received_components = []
+
+        source = SourceScenario(cluster_components=cluster_components)
+        source.end = DummyEndParameter(value=42)
+
+        success, mutated = genetic_algorithm.scenario_mutation(source)
+
+        assert success
+        assert isinstance(mutated, RecordingScenario)
+        assert mutated.end.value == 42
+        assert RecordingScenario.received_components
+
+        received_components = RecordingScenario.received_components[-1]
+        assert [ns.name for ns in received_components.namespaces] == [
+            "active-namespace"
+        ]
+        assert [node.name for node in received_components.nodes] == ["active-node"]
+        assert mutated._cluster_components == received_components


### PR DESCRIPTION
## What I fixed

I fixed scenario mutation so it creates candidate scenarios with only active cluster components. Disabled namespaces, pods, services, PVCs, VMIs, and nodes now stay filtered out in the mutation path, the same way they already do during valid scenario discovery and random scenario creation.

## How I found it

I checked `scenario_mutation()` in `krkn_ai/algorithm/genetic.py` and compared it with `ScenarioFactory.generate_valid_scenarios()` and `generate_random_scenario()`. The factory paths both call `get_active_components()`, but mutation was still passing the raw `config.cluster_components`. Since scenario constructors call `mutate()` and sample from `_cluster_components`, that raw input could let disabled targets come back during mutation.

## What I changed

- I cache `active_cluster_components` when `GeneticAlgorithm` is initialized.
- I use that cached active component set when `scenario_mutation()` instantiates candidate scenarios.
- I added a focused mutation test with small helper scenarios to prove disabled namespaces and nodes are not passed into mutation candidates.

## Why this is legit

This keeps mutation aligned with the existing factory behavior without changing public config, scenario APIs, or scenario constructor contracts. The fix is small and stays in the genetic algorithm path where the mismatch existed.

## Commit reasoning

- `Fix mutation`: I kept the commit focused on the active component leak. The code change only swaps mutation candidate construction to the filtered component set, and the test covers the exact disabled-component regression.

## Tests

- <img width="1052" height="327" alt="Screenshot 2026-05-10 at 5 56 17 PM" src="https://github.com/user-attachments/assets/b3f43e26-08fc-4cf1-89b4-1245933fcdca" />

- <img width="1046" height="358" alt="Screenshot 2026-05-10 at 5 56 51 PM" src="https://github.com/user-attachments/assets/7019416f-aab1-4284-8b23-ddf7de632649" />

- <img width="1030" height="683" alt="Screenshot 2026-05-10 at 5 57 15 PM" src="https://github.com/user-attachments/assets/564fb46e-9a29-441e-92d1-7468e8018276" />




