### PR TITLE
fix(genetic): keep adaptive mutation from changing config

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -99,6 +99,7 @@ class GeneticAlgorithm:
         self.end_time: Optional[datetime.datetime] = None
         self.seed: Optional[int] = None  # Seed can be set externally if needed
         self.completed_generations: int = 0
+        self.current_scenario_mutation_rate: float = self.config.scenario_mutation_rate
 
         if self.config.population_size < 2:
             raise PopulationSizeError("Population size should be at least 2")
@@ -282,19 +283,24 @@ class GeneticAlgorithm:
         if self.stagnant_generations < cfg.generations:
             return
 
-        # adaptive update
-        if improvement < cfg.threshold:
-            self.config.scenario_mutation_rate *= 1.2
-        else:
-            self.config.scenario_mutation_rate *= 0.9
+        if cfg.min > cfg.max:
+            raise ValueError(
+                f"Invalid adaptive mutation configuration: min ({cfg.min}) "
+                f"must be less than or equal to max ({cfg.max})"
+            )
 
-        self.config.scenario_mutation_rate = max(
-            cfg.min, min(self.config.scenario_mutation_rate, cfg.max)
+        if improvement < cfg.threshold:
+            self.current_scenario_mutation_rate *= 1.2
+        else:
+            self.current_scenario_mutation_rate *= 0.9
+
+        self.current_scenario_mutation_rate = max(
+            cfg.min, min(self.current_scenario_mutation_rate, cfg.max)
         )
 
         logger.info(
-            "Adaptive mutation triggered | mutation_rate=%.4f",
-            self.config.scenario_mutation_rate,
+            "Adaptive mutation triggered | scenario_mutation_rate=%.4f",
+            self.current_scenario_mutation_rate,
         )
 
         self.stagnant_generations = 0
@@ -562,7 +568,7 @@ class GeneticAlgorithm:
             return scenario
 
         # Scenario mutation (new scenario, try to preserve properties)
-        if rng.random() < self.config.scenario_mutation_rate:
+        if rng.random() < self.current_scenario_mutation_rate:
             success, new_scenario = self.scenario_mutation(scenario)
             if success:
                 # logger.debug("Scenario mutation successful")
@@ -740,6 +746,7 @@ class GeneticAlgorithm:
             end_time=self.end_time,
             completed_generations=self.completed_generations,
             seed=self.seed,
+            final_scenario_mutation_rate=self.current_scenario_mutation_rate,
         )
         summary_reporter.save(self.output_dir)
 

--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -746,7 +746,7 @@ class GeneticAlgorithm:
             end_time=self.end_time,
             completed_generations=self.completed_generations,
             seed=self.seed,
-            final_scenario_mutation_rate=self.current_scenario_mutation_rate,
+            scenario_mutation_rate=self.current_scenario_mutation_rate,
         )
         summary_reporter.save(self.output_dir)
 

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -34,6 +34,7 @@ class JSONSummaryReporter:
         end_time: Optional[datetime.datetime] = None,
         completed_generations: int = 0,
         seed: Optional[int] = None,
+        final_scenario_mutation_rate: Optional[float] = None,
     ):
         """
         Initialize the JSON summary reporter.
@@ -47,6 +48,8 @@ class JSONSummaryReporter:
             end_time: When the run ended.
             completed_generations: Number of generations completed.
             seed: Random seed used for the run (if any).
+            final_scenario_mutation_rate: Scenario mutation rate to write in the
+                summary.
         """
         self.run_uuid = run_uuid
         self.config = config
@@ -57,6 +60,11 @@ class JSONSummaryReporter:
         self.end_time = end_time
         self.completed_generations = completed_generations
         self.seed = seed
+        self.scenario_mutation_rate = (
+            config.scenario_mutation_rate
+            if final_scenario_mutation_rate is None
+            else final_scenario_mutation_rate
+        )
         self.status = STATUS_COMPLETED
 
     def generate_summary(self) -> Dict[str, Any]:
@@ -111,7 +119,7 @@ class JSONSummaryReporter:
                 "generations": self.config.generations,
                 "population_size": self.config.population_size,
                 "mutation_rate": self.config.mutation_rate,
-                "scenario_mutation_rate": self.config.scenario_mutation_rate,
+                "scenario_mutation_rate": self.scenario_mutation_rate,
                 "crossover_rate": self.config.crossover_rate,
                 "composition_rate": self.config.composition_rate,
             },

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -34,7 +34,7 @@ class JSONSummaryReporter:
         end_time: Optional[datetime.datetime] = None,
         completed_generations: int = 0,
         seed: Optional[int] = None,
-        final_scenario_mutation_rate: Optional[float] = None,
+        scenario_mutation_rate: Optional[float] = None,
     ):
         """
         Initialize the JSON summary reporter.
@@ -48,7 +48,7 @@ class JSONSummaryReporter:
             end_time: When the run ended.
             completed_generations: Number of generations completed.
             seed: Random seed used for the run (if any).
-            final_scenario_mutation_rate: Scenario mutation rate to write in the
+            scenario_mutation_rate: Scenario mutation rate to write in the
                 summary.
         """
         self.run_uuid = run_uuid
@@ -62,8 +62,8 @@ class JSONSummaryReporter:
         self.seed = seed
         self.scenario_mutation_rate = (
             config.scenario_mutation_rate
-            if final_scenario_mutation_rate is None
-            else final_scenario_mutation_rate
+            if scenario_mutation_rate is None
+            else scenario_mutation_rate
         )
         self.status = STATUS_COMPLETED
 

--- a/tests/unit/algorithm/test_adaptive_mutation.py
+++ b/tests/unit/algorithm/test_adaptive_mutation.py
@@ -2,8 +2,10 @@
 Tests for GeneticAlgorithm.adapt_mutation_rate method
 """
 
-import pytest
 from unittest.mock import Mock
+
+import pytest
+import yaml
 
 from krkn_ai.models.config import AdaptiveMutation
 from krkn_ai.models.app import FitnessResult
@@ -24,11 +26,13 @@ class TestAdaptMutationRateEarlyReturns:
         genetic_algorithm.config.adaptive_mutation.enable = False
         genetic_algorithm.stagnant_generations = 10
         original_rate = genetic_algorithm.config.scenario_mutation_rate
+        original_current_rate = genetic_algorithm.current_scenario_mutation_rate
 
         genetic_algorithm.adapt_mutation_rate()
 
         assert genetic_algorithm.stagnant_generations == 10
         assert genetic_algorithm.config.scenario_mutation_rate == original_rate
+        assert genetic_algorithm.current_scenario_mutation_rate == original_current_rate
 
     @pytest.mark.parametrize("generations", [[], [make_generation_result(10.0)]])
     def test_returns_early_with_insufficient_generations(
@@ -39,11 +43,13 @@ class TestAdaptMutationRateEarlyReturns:
         genetic_algorithm.best_of_generation = generations
         genetic_algorithm.stagnant_generations = 5
         original_rate = genetic_algorithm.config.scenario_mutation_rate
+        original_current_rate = genetic_algorithm.current_scenario_mutation_rate
 
         genetic_algorithm.adapt_mutation_rate()
 
         assert genetic_algorithm.stagnant_generations == 5
         assert genetic_algorithm.config.scenario_mutation_rate == original_rate
+        assert genetic_algorithm.current_scenario_mutation_rate == original_current_rate
 
 
 class TestAdaptMutationRateStagnantTracking:
@@ -89,11 +95,13 @@ class TestAdaptMutationRateUpdate:
         ]
         genetic_algorithm.stagnant_generations = 3  # Will become 4, still < 5
         original_rate = genetic_algorithm.config.scenario_mutation_rate
+        original_current_rate = genetic_algorithm.current_scenario_mutation_rate
 
         genetic_algorithm.adapt_mutation_rate()
 
         assert genetic_algorithm.stagnant_generations == 4
         assert genetic_algorithm.config.scenario_mutation_rate == original_rate
+        assert genetic_algorithm.current_scenario_mutation_rate == original_current_rate
 
     def test_increases_rate_when_stagnating(self, genetic_algorithm):
         """Should multiply rate by 1.2 when stagnating"""
@@ -101,6 +109,7 @@ class TestAdaptMutationRateUpdate:
             enable=True, threshold=0.5, generations=5, min=0.05, max=0.9
         )
         genetic_algorithm.config.scenario_mutation_rate = 0.3
+        genetic_algorithm.current_scenario_mutation_rate = 0.3
         genetic_algorithm.best_of_generation = [
             make_generation_result(10.0),
             make_generation_result(10.1),
@@ -109,5 +118,60 @@ class TestAdaptMutationRateUpdate:
 
         genetic_algorithm.adapt_mutation_rate()
 
-        assert genetic_algorithm.config.scenario_mutation_rate == pytest.approx(0.36)
+        assert genetic_algorithm.config.scenario_mutation_rate == pytest.approx(0.3)
+        assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.36)
         assert genetic_algorithm.stagnant_generations == 0
+
+    def test_clamps_current_rate_only(self, genetic_algorithm):
+        """Should clamp the current rate while preserving the configured rate"""
+        genetic_algorithm.config.adaptive_mutation = AdaptiveMutation(
+            enable=True, threshold=0.5, generations=1, min=0.05, max=0.35
+        )
+        genetic_algorithm.config.scenario_mutation_rate = 0.3
+        genetic_algorithm.current_scenario_mutation_rate = 0.3
+        genetic_algorithm.best_of_generation = [
+            make_generation_result(10.0),
+            make_generation_result(10.1),
+        ]
+
+        genetic_algorithm.adapt_mutation_rate()
+
+        assert genetic_algorithm.config.scenario_mutation_rate == pytest.approx(0.3)
+        assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.35)
+
+    def test_raises_when_min_exceeds_max(self, genetic_algorithm):
+        """Should reject invalid adaptive mutation bounds"""
+        genetic_algorithm.config.adaptive_mutation = AdaptiveMutation(
+            enable=True, threshold=0.5, generations=1, min=0.8, max=0.2
+        )
+        genetic_algorithm.current_scenario_mutation_rate = 0.3
+        genetic_algorithm.best_of_generation = [
+            make_generation_result(10.0),
+            make_generation_result(10.1),
+        ]
+
+        with pytest.raises(ValueError, match="Invalid adaptive mutation configuration"):
+            genetic_algorithm.adapt_mutation_rate()
+
+        assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.3)
+
+    def test_save_config_uses_original_rate_after_adaptation(self, genetic_algorithm):
+        """Saving config after adaptive mutation should keep the configured rate"""
+        genetic_algorithm.config.adaptive_mutation = AdaptiveMutation(
+            enable=True, threshold=0.5, generations=1, min=0.05, max=0.9
+        )
+        original_rate = genetic_algorithm.config.scenario_mutation_rate
+        genetic_algorithm.best_of_generation = [
+            make_generation_result(10.0),
+            make_generation_result(10.1),
+        ]
+
+        genetic_algorithm.adapt_mutation_rate()
+        genetic_algorithm.save_config()
+
+        config_path = f"{genetic_algorithm.output_dir}/krkn-ai.yaml"
+        with open(config_path, encoding="utf-8") as f:
+            saved_config = yaml.safe_load(f)
+
+        assert genetic_algorithm.current_scenario_mutation_rate != original_rate
+        assert saved_config["scenario_mutation_rate"] == original_rate

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -89,6 +89,10 @@ class TestGeneticAlgorithmCoreMethods:
                             mock_summary_reporter.return_value = mock_reporter_instance
                             genetic_algorithm.best_of_generation = [Mock()]
                             genetic_algorithm.seen_population = {Mock(): Mock()}
+                            final_rate = 0.42
+                            genetic_algorithm.current_scenario_mutation_rate = (
+                                final_rate
+                            )
                             genetic_algorithm.save()
 
                             # Verify all reporter methods are called
@@ -97,4 +101,10 @@ class TestGeneticAlgorithmCoreMethods:
                             assert mock_save_report.called
                             assert mock_sort.called
                             assert mock_summary_reporter.called
+                            assert (
+                                mock_summary_reporter.call_args.kwargs[
+                                    "final_scenario_mutation_rate"
+                                ]
+                                == final_rate
+                            )
                             assert mock_reporter_instance.save.called

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -103,7 +103,7 @@ class TestGeneticAlgorithmCoreMethods:
                             assert mock_summary_reporter.called
                             assert (
                                 mock_summary_reporter.call_args.kwargs[
-                                    "final_scenario_mutation_rate"
+                                    "scenario_mutation_rate"
                                 ]
                                 == final_rate
                             )

--- a/tests/unit/algorithm/test_mutation.py
+++ b/tests/unit/algorithm/test_mutation.py
@@ -15,7 +15,7 @@ class TestMutation:
         scenario = DummyScenario(cluster_components=ClusterComponents())
 
         # Set mutation rate to 0 to test parameter mutation path
-        genetic_algorithm.config.scenario_mutation_rate = 0.0
+        genetic_algorithm.current_scenario_mutation_rate = 0.0
 
         mutated = genetic_algorithm.mutate(scenario)
 
@@ -39,7 +39,7 @@ class TestMutation:
         )
 
         # Set mutation rates to 0 to avoid scenario_mutation which requires valid scenarios
-        genetic_algorithm.config.scenario_mutation_rate = 0.0
+        genetic_algorithm.current_scenario_mutation_rate = 0.0
 
         mutated = genetic_algorithm.mutate(composite)
 


### PR DESCRIPTION

## What I fixed

Adaptive mutation was changing `self.config.scenario_mutation_rate` while the run was going on. I changed it so adaptive mutation updates a separate runtime rate and leaves the original config value unchanged.

The run still uses the updated mutation rate internally, and `results.json` still shows the final rate in the same field as before.

## How I found it

I started from `adapt_mutation_rate()` in `krkn_ai/algorithm/genetic.py`. That method was multiplying `self.config.scenario_mutation_rate` directly.

Then I checked where the same value is used: mutation, saving config, Elasticsearch config indexing, and the JSON summary. The issue was that runtime state and config input were sharing the same field.

## What I changed

- Added `current_scenario_mutation_rate` on `GeneticAlgorithm`.
- Adaptive mutation now updates this current rate, not the config.
- Mutation now reads from the current rate.
- The JSON summary can still receive and write the final rate.
- Added a guard for invalid adaptive mutation bounds where `min > max`.
- Added tests for the config staying unchanged, clamping, invalid bounds, saving YAML, and summary reporting.


## Why this is legit

This keeps the config as the original input. The algorithm still has a changing mutation rate during the run, but that value is now kept separately.

It also keeps the old `results.json` shape, so existing readers do not need to change.

## Tests

- `python -m pytest tests/unit/algorithm/test_adaptive_mutation.py tests/unit/algorithm/test_mutation.py tests/unit/algorithm/test_genetic_algorithm.py` - Passed, 19 tests.

- `ruff check krkn_ai/algorithm/genetic.py krkn_ai/reporter/json_summary_reporter.py tests/unit/algorithm/test_adaptive_mutation.py tests/unit/algorithm/test_mutation.py tests/unit/algorithm/test_genetic_algorithm.py` - Passed.
- `ruff format --check krkn_ai/algorithm/genetic.py krkn_ai/reporter/json_summary_reporter.py tests/unit/algorithm/test_adaptive_mutation.py tests/unit/algorithm/test_mutation.py tests/unit/algorithm/test_genetic_algorithm.py` - Passed after formatting `tests/unit/algorithm/test_adaptive_mutation.py`.
- `python -m pytest` - Passed, 212 tests.
- `pre-commit run --from-ref main --to-ref HEAD` - Passed.



