### PR TITLE
[fix]: silent VMI discovery failures caused by swallowed ApiException

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -243,6 +243,19 @@ class ClusterManager:
                 "Discovered %d PVCs in namespace %s", len(pvc_list), namespace.name
             )
             return pvc_list
+        except ApiException as e:
+            if e.status == 403:
+                logger.warning(
+                    "RBAC denied listing PVCs in namespace %s, skipping",
+                    namespace.name,
+                )
+            else:
+                logger.warning(
+                    "Failed to list PVCs in namespace %s (HTTP %d), skipping",
+                    namespace.name,
+                    e.status,
+                )
+            return []
         except Exception as e:
             logger.warning(
                 "Failed to list PVCs in namespace %s: %s", namespace.name, str(e)
@@ -288,17 +301,23 @@ class ClusterManager:
                     "KubeVirt CRDs not installed, skipping VMI discovery in namespace %s",
                     namespace.name,
                 )
-                return []
-            if e.status == 403:
-                logger.error(
-                    "RBAC denied listing virtualmachineinstances in namespace %s. "
-                    "Grant kubevirt.io list permission to the ServiceAccount or use --skip-vmi.",
+            elif e.status == 403:
+                logger.warning(
+                    "RBAC denied listing virtualmachineinstances in namespace %s, skipping. "
+                    "Grant kubevirt.io list permission to the ServiceAccount.",
                     namespace.name,
                 )
-                raise
-            raise
-        except Exception:
-            logger.warning("Unable to find VMIs in namespace %s", namespace.name)
+            else:
+                logger.warning(
+                    "Failed to list VMIs in namespace %s (HTTP %d), skipping",
+                    namespace.name,
+                    e.status,
+                )
+            return []
+        except Exception as e:
+            logger.warning(
+                "Failed to list VMIs in namespace %s: %s", namespace.name, str(e)
+            )
             return []
 
     def list_nodes(

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -2,6 +2,7 @@ import re
 from typing import List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
+from kubernetes.client.rest import ApiException
 from krkn_ai.utils import run_shell
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.models.custom_errors import ShellCommandTimeoutError
@@ -269,7 +270,7 @@ class ClusterManager:
                 logger.debug(
                     "Found %d vmis in namespace %s",
                     len(vmis),
-                    vmis[0]["metadata"]["name"],
+                    namespace.name,
                 )
             else:
                 logger.debug("No VMIs found in namespace %s", namespace.name)
@@ -281,6 +282,21 @@ class ClusterManager:
                 "Filtered %d vmis in namespace %s", len(vmi_list), namespace.name
             )
             return vmi_list
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug(
+                    "KubeVirt CRDs not installed, skipping VMI discovery in namespace %s",
+                    namespace.name,
+                )
+                return []
+            if e.status == 403:
+                logger.error(
+                    "RBAC denied listing virtualmachineinstances in namespace %s. "
+                    "Grant kubevirt.io list permission to the ServiceAccount or use --skip-vmi.",
+                    namespace.name,
+                )
+                raise
+            raise
         except Exception:
             logger.warning("Unable to find VMIs in namespace %s", namespace.name)
             return []


### PR DESCRIPTION
## Description
  
  This fixes silent under-discovery in list_vmis() and list_pvcs() where all exceptions were swallowed
  indistinguishably and returned as [], with no signal to the operator about why discovery came up empty. 

  **Previously**:
  - 403 Forbidden (RBAC issues)
  - 404 (KubeVirt CRD not installed)
  - 429 / 5xx (transient API failures)
  - any other error

  …all looked identical: a single generic warning and return []. This caused krkn-discover to generate
  wrong configs and disable VMI chaos scenarios even when VMIs actually existed in the cluster, with no     actionable log to debug from.

---

 ## Changes

  - Added explicit ApiException handling for list_vmis() and list_pvcs().
  - 404 → debug log, skip (KubeVirt CRDs are optional, so this is expected on non-KubeVirt clusters).
  - 403 → warning log naming the RBAC permission needed, skip the namespace and continue discovery.       
  - 429 / 5xx / other → warning log including the HTTP status, skip the namespace and continue discovery.
  - Generic Exception fallback still returns [] but now logs the actual error message instead of a generic   "unable to find" string.                                                                               
  - Fixed incorrect namespace logging in VMI discovery (was logging vmis[0]["metadata"]["name"] instead of   namespace.name).

  Rationale for skipping vs. re-raising

  Discovery runs across many namespaces. Raising on the first 403 or transient 5xx would abort the entire 
  discovery pass and lose results from every other namespace. Instead, each namespace's failure is logged
  with enough detail to act on (RBAC permission name, HTTP status) and discovery continues. The operator  
  can grep the warnings to see exactly which namespaces were skipped and why.

 **Before**
```python
  except Exception:
      logger.warning("Unable to find VMIs in namespace %s", namespace.name)
      return []
```

 **After**
```python
  except ApiException as e:
      if e.status == 404:
          logger.debug("KubeVirt CRDs not installed, skipping VMI discovery in namespace %s",
  namespace.name)
      elif e.status == 403:
          logger.warning(
              "RBAC denied listing virtualmachineinstances in namespace %s, skipping. "
              "Grant kubevirt.io list permission to the ServiceAccount.",
              namespace.name,
          )
      else:
          logger.warning("Failed to list VMIs in namespace %s (HTTP %d), skipping", namespace.name,
  e.status)
      return []
  except Exception as e:
      logger.warning("Failed to list VMIs in namespace %s: %s", namespace.name, str(e))
      return []
```