### PR TITLE
fix: strip ASCII art banner lines from krkn JSON output before parsing

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -597,7 +597,7 @@ class KrknRunner:
                 return default_returncode, None
 
             # Drop ASCII art banner lines — they contain no JSON structural characters
-            json_lines = [l for l in json_lines if re.search(r'["{}\[\]:]', l)]
+            json_lines = [l for l in json_lines if any(c in l for c in '"{}[]:')]
 
             # Join all JSON lines into a single string
             json_str = "\n".join(json_lines)

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -30,6 +30,9 @@ from krkn_ai.utils.rng import rng
 
 logger = get_logger(__name__)
 
+# Matches all ANSI CSI escape sequences (colors, cursor movement, erase, etc.)
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
 # TODO: Cleanup of temp kubeconfig after running the script
 
 PODMAN_TEMPLATE = 'podman run -e PUBLISH_KRAKEN_STATUS="False" -e TELEMETRY_PROMETHEUS_BACKUP="False" -e WAIT_DURATION={wait_duration} {env_list} {{es_env_list}} --net=host -v {kubeconfig}:/home/krkn/.kube/config:Z {image}'
@@ -553,8 +556,7 @@ class KrknRunner:
             # TODO: Look into if we can save telemetry data to file from Krkn itself.
             # Hacky way to extract return code from log
             # Strip ANSI escape codes so ASCII art banners don't corrupt JSON parsing
-            ansi_re = re.compile(r"\x1b\[[0-9;]*m")
-            clean_log = ansi_re.sub("", log)
+            clean_log = _ANSI_ESCAPE_RE.sub("", log)
 
             # Find the line with "Chaos data:" and extract JSON from next lines
             lines = clean_log.split("\n")
@@ -597,7 +599,10 @@ class KrknRunner:
                 return default_returncode, None
 
             # Drop ASCII art banner lines — they contain no JSON structural characters
-            json_lines = [l for l in json_lines if any(c in l for c in '"{}[]:')]
+            json_lines = [
+                line for line in json_lines
+                if any(char in line for char in '"{}[]:')
+            ]
 
             # Join all JSON lines into a single string
             json_str = "\n".join(json_lines)

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import datetime
 import tempfile
@@ -551,8 +552,12 @@ class KrknRunner:
         try:
             # TODO: Look into if we can save telemetry data to file from Krkn itself.
             # Hacky way to extract return code from log
+            # Strip ANSI escape codes so ASCII art banners don't corrupt JSON parsing
+            ansi_re = re.compile(r"\x1b\[[0-9;]*m")
+            clean_log = ansi_re.sub("", log)
+
             # Find the line with "Chaos data:" and extract JSON from next lines
-            lines = log.split("\n")
+            lines = clean_log.split("\n")
             chaos_data_idx = -1
 
             for i, line in enumerate(lines):
@@ -590,6 +595,9 @@ class KrknRunner:
             if not json_lines:
                 logger.warning("Could not extract JSON content from log")
                 return default_returncode, None
+
+            # Drop ASCII art banner lines — they contain no JSON structural characters
+            json_lines = [l for l in json_lines if re.search(r'["{}\[\]:]', l)]
 
             # Join all JSON lines into a single string
             json_str = "\n".join(json_lines)

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -585,3 +585,66 @@ class TestCalculateFitnessValueRetries:
             # Each retry calls calculate_point_fitness which calls _query_prometheus_single_point
             # for the start point. The guard fails immediately, so 1 Prometheus call per retry = 3 total.
             assert mock_prom_client.process_prom_query_in_range.call_count == 3
+
+
+class TestExtractReturncode:
+    """Tests for __extract_returncode_from_run (bug #181)."""
+
+    def _runner(self, minimal_config, temp_output_dir):
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client"):
+            return KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+
+    def _call(self, runner, log):
+        return runner._KrknRunner__extract_returncode_from_run(log, default_returncode=99)
+
+    def test_clean_json(self, minimal_config, temp_output_dir):
+        log = (
+            "preamble\n"
+            "Chaos data:\n"
+            '{"telemetry": {"run_uuid": "abc-123", "scenarios": [{"exit_status": 0}]}}\n'
+        )
+        code, uuid = self._call(self._runner(minimal_config, temp_output_dir), log)
+        assert code == 0
+        assert uuid == "abc-123"
+
+    def test_ascii_art_banner_mid_json(self, minimal_config, temp_output_dir):
+        """Bug #181: banner lines inside the JSON block must be dropped before json.loads."""
+        log = (
+            "Chaos data:\n"
+            "{\n"
+            '  "telemetry": {\n'
+            "  __ _  _ __| | ___ __\n"
+            " | |/ /| '__| |/ / '_ \\\n"
+            " |   < | |  |   <| | | |\n"
+            " |_|\\_\\|_|  |_|\\_\\_| |_|\n"
+            '    "run_uuid": "xyz-999",\n'
+            '    "scenarios": [{"exit_status": 2}]\n'
+            "  }\n"
+            "}\n"
+        )
+        code, uuid = self._call(self._runner(minimal_config, temp_output_dir), log)
+        assert code == 2
+        assert uuid == "xyz-999"
+
+    def test_ansi_codes_stripped(self, minimal_config, temp_output_dir):
+        log = (
+            "\x1b[32mChaos data:\x1b[0m\n"
+            "{\x1b[0m\n"
+            '  \x1b[33m"telemetry"\x1b[0m: {\n'
+            '    "run_uuid": "ansi-test",\n'
+            '    "scenarios": [{"exit_status": 0}]\n'
+            "  }\n"
+            "}\n"
+        )
+        code, uuid = self._call(self._runner(minimal_config, temp_output_dir), log)
+        assert code == 0
+        assert uuid == "ansi-test"
+
+    def test_missing_marker_returns_default(self, minimal_config, temp_output_dir):
+        code, uuid = self._call(self._runner(minimal_config, temp_output_dir), "no marker here\n")
+        assert code == 99
+        assert uuid is None


### PR DESCRIPTION
Fixes #181

## Root cause
The \`__extract_returncode_from_run\` function in \`krkn_runner.py\` extracted the JSON object from krkn's stdout based on counting braces, but krkn prints its ASCII art banner *within* the JSON object. The banner lines were parsed exactly as-is, resulting in \`json.loads\` failing and silently returning \`default_returncode\` instead of the actual return code and run UUID.

This same issue was addressed by \`data_loader.py\` (line 158), where it simply skipped using \`json.loads\` altogether. This PR applies that same defensive programming practice to \`krkn_runner.py\`.

## Fix
- Remove ANSI escape sequences from the unprocessed log before parsing
- Skip lines with the banner (lines without any JSON structural tokens: \`\"\`, \`{\`, \`}\`, \`[\`, \`]\`, \`:\`) when calling \`json.loads\`

Both cases from the issue screenshots are accounted for: the banner within the top-level telemetry object, and the banner nested in an array within a deeper level.

## Tests
Created \`TestExtractReturncode\` with 4 tests:
- Baseline clean JSON
- ASCII art banner in the middle of the JSON (exactly the bug)
- ANSI escape sequences in the JSON string
- Missing \`Chaos data:\` fallback"