### PR TITLE
fix: parallelize node interface discovery to remove O(N) oc debug bottleneck

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,4 +1,5 @@
 import re
+import concurrent.futures
 from typing import Dict, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
@@ -366,17 +367,6 @@ class ClusterManager:
             node_component = Node(name=node.metadata.name, labels=labels, taints=taints)
 
             try:
-                node_component.interfaces = self.list_node_interfaces(
-                    node.metadata.name
-                )
-            except Exception as e:
-                logger.error(
-                    "Failed to list node interfaces for node %s: %s",
-                    node.metadata.name,
-                    e,
-                )
-
-            try:
                 alloc_cpu = self.parse_cpu(node.status.allocatable["cpu"])
                 alloc_mem = self.parse_memory(node.status.allocatable["memory"])
                 if node.metadata.name not in node_metrics_map:
@@ -397,7 +387,6 @@ class ClusterManager:
             return node_component
 
         node_list = []
-        import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
             futures = [executor.submit(process_node, node) for node in nodes]
@@ -405,6 +394,23 @@ class ClusterManager:
                 result = future.result()
                 if result is not None:
                     node_list.append(result)
+
+        if node_list:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                future_to_node = {
+                    executor.submit(self.list_node_interfaces, node.name): node
+                    for node in node_list
+                }
+                for future in concurrent.futures.as_completed(future_to_node):
+                    node = future_to_node[future]
+                    try:
+                        node.interfaces = future.result()
+                    except Exception as e:
+                        logger.error(
+                            "Failed to list node interfaces for node %s: %s",
+                            node.name,
+                            e,
+                        )
 
         logger.debug("Filtered %d nodes", len(node_list))
         return node_list

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -483,3 +483,79 @@ class TestClusterManager:
             interfaces = cluster_manager.list_node_interfaces("test-node")
 
         assert interfaces == []
+
+    def test_list_nodes_fetches_interfaces_for_all_nodes(self, cluster_manager):
+        """All nodes get interfaces populated even when fetched concurrently"""
+
+        def make_node(name):
+            node = Mock()
+            node.metadata.name = name
+            node.metadata.labels = {"kubernetes.io/hostname": name}
+            node.spec.taints = None
+            node.spec.unschedulable = False
+            ready = Mock()
+            ready.type = "Ready"
+            ready.status = "True"
+            node.status.conditions = [ready]
+            node.status.allocatable = {"cpu": "2", "memory": "4Gi"}
+            return node
+
+        cluster_manager.core_api.list_node.return_value.items = [
+            make_node("node-a"),
+            make_node("node-b"),
+            make_node("node-c"),
+        ]
+        cluster_manager.custom_obj_api.list_cluster_custom_object.side_effect = (
+            Exception("no metrics")
+        )
+
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell",
+            return_value=("eth0\n", 0),
+        ):
+            nodes = cluster_manager.list_nodes()
+
+        assert len(nodes) == 3
+        assert all(n.interfaces == ["eth0"] for n in nodes)
+
+    def test_list_nodes_one_interface_timeout_does_not_block_others(
+        self, cluster_manager
+    ):
+        """A failed interface lookup on one node leaves others unaffected"""
+        from krkn_ai.models.custom_errors import ShellCommandTimeoutError
+
+        def make_node(name):
+            node = Mock()
+            node.metadata.name = name
+            node.metadata.labels = {"kubernetes.io/hostname": name}
+            node.spec.taints = None
+            node.spec.unschedulable = False
+            ready = Mock()
+            ready.type = "Ready"
+            ready.status = "True"
+            node.status.conditions = [ready]
+            node.status.allocatable = {"cpu": "2", "memory": "4Gi"}
+            return node
+
+        cluster_manager.core_api.list_node.return_value.items = [
+            make_node("good-node"),
+            make_node("bad-node"),
+        ]
+        cluster_manager.custom_obj_api.list_cluster_custom_object.side_effect = (
+            Exception("no metrics")
+        )
+
+        def fake_run_shell(cmd, **kwargs):
+            if "bad-node" in cmd:
+                raise ShellCommandTimeoutError("timed out")
+            return ("eth0\n", 0)
+
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell", side_effect=fake_run_shell
+        ):
+            nodes = cluster_manager.list_nodes()
+
+        assert len(nodes) == 2
+        by_name = {n.name: n for n in nodes}
+        assert by_name["good-node"].interfaces == ["eth0"]
+        assert by_name["bad-node"].interfaces == []


### PR DESCRIPTION
## Description

`list_nodes()` calls `list_node_interfaces()` sequentially for every node in the cluster. Since each call shells out to `oc debug node/<name>` (which spins up a pod, runs, then tears down), discovery time grows linearly with node count on a 100-node cluster that's easily 30+ minutes just for interface detection. A single unresponsive node also blocks everything for up to 180s.

Switched to `ThreadPoolExecutor` so interface lookups run concurrently. Errors and timeouts on individual nodes are caught per-future and don't affect the rest.

Fixes #251

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added two unit tests to `test_cluster_manager.py`:
- All nodes get interfaces populated when fetched concurrently
- A timeout on one node doesn't block or clear interfaces on others

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

`__fetch_node_metrics` is left sequential, it hits the metrics API (cheap) rather than scheduling pods, so it doesn't have the same problem.
