### PR TITLE
fix: completed_generations and seed always wrong in results.json

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -97,7 +97,7 @@ class GeneticAlgorithm:
         # Track run metadata for results summary
         self.start_time: Optional[datetime.datetime] = None
         self.end_time: Optional[datetime.datetime] = None
-        self.seed: Optional[int] = None  # Seed can be set externally if needed
+        self.seed = self.config.seed
         self.completed_generations: int = 0
 
         if self.config.population_size < 2:
@@ -312,6 +312,7 @@ class GeneticAlgorithm:
         """
         should_stop, reason = self.should_stop(cur_generation, elapsed_time)
         if should_stop:
+            self.completed_generations = cur_generation
             self.end_time = datetime.datetime.now(datetime.timezone.utc)
             logger.info("Stopping algorithm: %s", reason)
             logger.info(

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -2,11 +2,15 @@
 GeneticAlgorithm core functionality tests
 """
 
+import datetime
 import pytest
 from unittest.mock import Mock, patch
 
 from krkn_ai.algorithm.genetic import GeneticAlgorithm
+from krkn_ai.models.app import CommandRunResult, FitnessResult
+from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.models.custom_errors import PopulationSizeError
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 
 
 class TestGeneticAlgorithmInitialization:
@@ -98,3 +102,136 @@ class TestGeneticAlgorithmCoreMethods:
                             assert mock_sort.called
                             assert mock_summary_reporter.called
                             assert mock_reporter_instance.save.called
+
+
+class TestCompletedGenerations:
+    """Regression tests for completed_generations tracking"""
+
+    def test_completed_generations_starts_at_zero(self, genetic_algorithm):
+        """completed_generations is 0 before simulate() runs"""
+        assert genetic_algorithm.completed_generations == 0
+
+    def test_completed_generations_updated_after_simulate(
+        self, minimal_config, temp_output_dir
+    ):
+        """simulate() must update completed_generations to the actual count, not leave it at 0"""
+        minimal_config.generations = 2
+        minimal_config.population_size = 2
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+        dummy = DummyScenario(cluster_components=ClusterComponents())
+        mock_result = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=dummy,
+            cmd="test",
+            log="",
+            returncode=0,
+            start_time=datetime.datetime.now(),
+            end_time=datetime.datetime.now(),
+            fitness_result=FitnessResult(fitness_score=1.0),
+            health_check_results={},
+        )
+
+        with patch.object(ga, "run_baseline"):
+            with patch.object(ga, "create_population", return_value=[dummy, dummy]):
+                with patch.object(ga, "calculate_fitness", return_value=mock_result):
+                    with patch.object(ga, "save_scenario_result"):
+                        with patch.object(ga.health_check_reporter, "plot_report"):
+                            with patch.object(
+                                ga.health_check_reporter, "write_fitness_result"
+                            ):
+                                with patch.object(
+                                    ga, "select_parents", return_value=(dummy, dummy)
+                                ):
+                                    with patch.object(
+                                        ga,
+                                        "crossover",
+                                        return_value=(dummy, dummy),
+                                    ):
+                                        with patch.object(
+                                            ga, "composition", return_value=dummy
+                                        ):
+                                            with patch.object(
+                                                ga, "mutate", side_effect=lambda s: s
+                                            ):
+                                                ga.simulate()
+
+        assert ga.completed_generations == 2
+
+    def test_results_json_records_correct_generations_completed(
+        self, genetic_algorithm, temp_output_dir
+    ):
+        """results.json summary.generations_completed must reflect the actual run count"""
+        import json
+
+        genetic_algorithm.completed_generations = 3
+
+        with patch.object(genetic_algorithm.generations_reporter, "save_best_generations"):
+            with patch.object(
+                genetic_algorithm.generations_reporter, "save_best_generation_graph"
+            ):
+                with patch.object(genetic_algorithm.health_check_reporter, "save_report"):
+                    with patch.object(
+                        genetic_algorithm.health_check_reporter, "sort_fitness_result_csv"
+                    ):
+                        genetic_algorithm.seen_population = {}
+                        genetic_algorithm.best_of_generation = []
+                        genetic_algorithm.save()
+
+        results_path = f"{temp_output_dir}/results.json"
+        with open(results_path) as f:
+            data = json.load(f)
+
+        assert data["summary"]["generations_completed"] == 3
+
+    def test_seed_assigned_from_config_on_init(self, minimal_config, temp_output_dir):
+        """self.seed must be set from config.seed at init, not left as None"""
+        minimal_config.seed = 42
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+        assert ga.seed == 42
+
+    def test_results_json_records_correct_seed(self, minimal_config, temp_output_dir):
+        """results.json seed must reflect config.seed, not always null"""
+        import json
+
+        minimal_config.seed = 42
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+        with patch.object(ga.generations_reporter, "save_best_generations"):
+            with patch.object(ga.generations_reporter, "save_best_generation_graph"):
+                with patch.object(ga.health_check_reporter, "save_report"):
+                    with patch.object(ga.health_check_reporter, "sort_fitness_result_csv"):
+                        ga.seen_population = {}
+                        ga.best_of_generation = []
+                        ga.save()
+
+        with open(f"{temp_output_dir}/results.json") as f:
+            data = json.load(f)
+
+        assert data["seed"] == 42


### PR DESCRIPTION
## Summary

- `self.completed_generations` was initialized to `0` in `__init__` and never updated — `results.json` always reported `0` generations regardless of how many ran.
- Fixed by assigning `self.completed_generations = cur_generation` inside `_check_and_stop()` at the point the stopping decision is made, covering all exit paths (generation limit, duration, fitness threshold, saturation, exploration).
- Added regression test `TestCompletedGenerations::test_completed_generations_updated_after_simulate` that would have caught this.

Fixes #256 

## Type of Change

- [x] Bug fix

## Testing

- [x] `pytest` — 202 passed, 0 failed
- [x] `ruff check` — no issues
- [x] `ruff format --check` — already formatted

## Checklist

- [x] Tests added for the bug
- [x] All existing tests pass
- [x] No unrelated changes
