### PR TITLE
fix: wrong variable in list_vmis log and ScenarioInitError message

### DIFF
--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -121,7 +121,7 @@ class ScenarioFactory:
             _, cls = rng.choice(candidates)
             return cls(cluster_components=active_components)
         except Exception as error:
-            raise ScenarioInitError("Unable to initialize scenario: %s", error)
+            raise ScenarioInitError("Unable to initialize scenario: %s" % error)
 
     @staticmethod
     def create_dummy_scenario():

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -269,7 +269,7 @@ class ClusterManager:
                 logger.debug(
                     "Found %d vmis in namespace %s",
                     len(vmis),
-                    vmis[0]["metadata"]["name"],
+                    namespace.name,
                 )
             else:
                 logger.debug("No VMIs found in namespace %s", namespace.name)

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -114,3 +114,24 @@ class TestScenarioFactory:
         scenario = ScenarioFactory.create_dummy_scenario()
         assert isinstance(scenario, DummyScenario)
         assert scenario._cluster_components == ClusterComponents()
+
+    def test_generate_random_scenario_error_message_is_string_not_tuple(self):
+        """ScenarioInitError message must be a readable string, not a raw tuple"""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            cluster_components=cluster,
+        )
+
+        class FailingScenario:
+            def __init__(self, **kwargs):
+                raise ValueError("cluster components missing")
+
+        candidates = [("failing", FailingScenario)]
+        with pytest.raises(ScenarioInitError) as exc_info:
+            ScenarioFactory.generate_random_scenario(config, candidates)
+
+        message = str(exc_info.value)
+        assert "cluster components missing" in message
+        assert message.startswith("(") is False

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -483,3 +483,22 @@ class TestClusterManager:
             interfaces = cluster_manager.list_node_interfaces("test-node")
 
         assert interfaces == []
+
+    def test_list_vmis_logs_namespace_name_not_vmi_name(self, cluster_manager):
+        """list_vmis debug log must show namespace name, not the first VMI's metadata name"""
+        namespace = Namespace(name="production", pods=[], services=[])
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {"metadata": {"name": "vmi-abc-123"}},
+                {"metadata": {"name": "vmi-xyz-456"}},
+            ]
+        }
+
+        with patch("krkn_ai.utils.cluster_manager.logger") as mock_logger:
+            cluster_manager.list_vmis(namespace)
+
+        debug_calls = [str(call) for call in mock_logger.debug.call_args_list]
+        found_call = next((c for c in debug_calls if "Found" in c and "vmis" in c), None)
+        assert found_call is not None
+        assert "production" in found_call
+        assert "vmi-abc-123" not in found_call


### PR DESCRIPTION
## Description

Fixes two bugs where the wrong variable was passed to a format string, producing misleading debug output and unreadable exception messages.

**Fix A — `cluster_manager.py`:** `list_vmis()` was logging `vmis[0]["metadata"]["name"]` (the first VMI's name) instead of `namespace.name` in the "Found N vmis in namespace" debug message.

**Fix B — `factory.py`:** `ScenarioInitError` was raised with two separate constructor arguments (`Exception("fmt %s", arg)`), which Python stores as a tuple in `args` without interpolating `%s`. The message always appeared as a raw tuple like `('Unable to initialize scenario: %s', ValueError(...))` instead of a readable string.

Fixes #258

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Testing

Regression tests were added for both bugs and verified in both directions:

**On `main` (unfixed) — new tests fail as expected:**
- `test_list_vmis_logs_namespace_name_not_vmi_name` → FAILED
- `test_generate_random_scenario_error_message_is_string_not_tuple` → FAILED

**On this branch (fixed) — all tests pass:**
```
202 passed
```


## Additional Notes

Both fixes are single-line changes. No behaviour is altered beyond correcting the output of a debug log and an exception message.
