### PR TITLE
fix: skip URLs with insufficient data in summarize_response_time inst…

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -138,7 +138,7 @@ class HealthCheckWatcher:
     ) -> float:
         score: float = 0.0
         total = 0
-        for _, results in health_check_results.items():
+        for url, results in health_check_results.items():
             response_times = []
             for result in results:
                 if result.success:
@@ -146,8 +146,9 @@ class HealthCheckWatcher:
 
             if len(response_times) < 4:  # Not enough data to calculate outliers
                 logger.debug(
-                    "Skipping response time outlier calculation for URL "
+                    "Skipping response time outlier calculation for URL %s "
                     "(only %d successful checks, need at least 4)",
+                    url,
                     len(response_times),
                 )
                 continue

--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -145,7 +145,12 @@ class HealthCheckWatcher:
                     response_times.append(result.response_time)
 
             if len(response_times) < 4:  # Not enough data to calculate outliers
-                return 0
+                logger.debug(
+                    "Skipping response time outlier calculation for URL "
+                    "(only %d successful checks, need at least 4)",
+                    len(response_times),
+                )
+                continue
 
             q1 = np.percentile(response_times, 25)
             q3 = np.percentile(response_times, 75)

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -210,6 +210,122 @@ class TestHealthCheckWatcherResults:
         assert score == 0
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_summarize_response_time_skips_insufficient_url_processes_others(
+        self, mock_get
+    ):
+        """Test that summarize_response_time skips URLs with < 4 data points
+        but still processes remaining URLs with sufficient data.
+
+        This is a regression test for the early-return bug where `return 0`
+        inside the for-loop would abort the entire method when any single URL
+        had insufficient data, silently dropping outlier data from other URLs.
+        """
+        config = HealthCheckConfig(applications=[])
+        watcher = HealthCheckWatcher(config)
+
+        # URL A: only 2 successful checks (insufficient, should be skipped)
+        url_a_results = [
+            HealthCheckResult(
+                name="app-a", status_code=200, success=True,
+                response_time=0.1, error=None,
+            ),
+            HealthCheckResult(
+                name="app-a", status_code=200, success=True,
+                response_time=0.15, error=None,
+            ),
+        ]
+
+        # URL B: 10 successful checks with clear outliers (should be processed)
+        # 8 tightly clustered normal times + 2 extreme outliers ensures IQR detection works
+        url_b_results = [
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.10, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.11, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.10, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.12, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.10, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.11, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.10, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=0.12, error=None,
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=10.0, error=None,  # extreme outlier
+            ),
+            HealthCheckResult(
+                name="app-b", status_code=200, success=True,
+                response_time=10.0, error=None,  # extreme outlier
+            ),
+        ]
+
+        results = {
+            "http://app-a/health": url_a_results,
+            "http://app-b/health": url_b_results,
+        }
+
+        score = watcher.summarize_response_time(results)
+
+        # URL A should be skipped (< 4 data points), URL B should be processed.
+        # URL B has 2 outliers out of 10 results -> score = (2/10) * 10 = 2.0
+        assert score > 0, (
+            "Score should be > 0 because URL B has outliers; "
+            "the method must not abort when URL A has insufficient data"
+        )
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
+    def test_summarize_response_time_all_urls_insufficient_returns_zero(
+        self, mock_get
+    ):
+        """Test that summarize_response_time returns 0 when ALL URLs have
+        insufficient data (< 4 data points each)."""
+        config = HealthCheckConfig(applications=[])
+        watcher = HealthCheckWatcher(config)
+
+        results = {
+            "http://app-a/health": [
+                HealthCheckResult(
+                    name="app-a", status_code=200, success=True,
+                    response_time=0.1, error=None,
+                ),
+            ],
+            "http://app-b/health": [
+                HealthCheckResult(
+                    name="app-b", status_code=200, success=True,
+                    response_time=0.2, error=None,
+                ),
+                HealthCheckResult(
+                    name="app-b", status_code=200, success=True,
+                    response_time=0.3, error=None,
+                ),
+            ],
+        }
+
+        score = watcher.summarize_response_time(results)
+        assert score == 0.0
+
+    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_handles_request_exceptions_gracefully(self, mock_get):
         """Test health check handles request exceptions gracefully"""
         # Mock request to raise exception

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -209,9 +209,8 @@ class TestHealthCheckWatcherResults:
         # Should return 0 when less than 4 successful checks
         assert score == 0
 
-    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_summarize_response_time_skips_insufficient_url_processes_others(
-        self, mock_get
+        self,
     ):
         """Test that summarize_response_time skips URLs with < 4 data points
         but still processes remaining URLs with sufficient data.
@@ -226,12 +225,18 @@ class TestHealthCheckWatcherResults:
         # URL A: only 2 successful checks (insufficient, should be skipped)
         url_a_results = [
             HealthCheckResult(
-                name="app-a", status_code=200, success=True,
-                response_time=0.1, error=None,
+                name="app-a",
+                status_code=200,
+                success=True,
+                response_time=0.1,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-a", status_code=200, success=True,
-                response_time=0.15, error=None,
+                name="app-a",
+                status_code=200,
+                success=True,
+                response_time=0.15,
+                error=None,
             ),
         ]
 
@@ -239,44 +244,74 @@ class TestHealthCheckWatcherResults:
         # 8 tightly clustered normal times + 2 extreme outliers ensures IQR detection works
         url_b_results = [
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.10, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.10,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.11, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.11,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.10, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.10,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.12, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.12,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.10, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.10,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.11, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.11,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.10, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.10,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=0.12, error=None,
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=0.12,
+                error=None,
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=10.0, error=None,  # extreme outlier
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=10.0,
+                error=None,  # extreme outlier
             ),
             HealthCheckResult(
-                name="app-b", status_code=200, success=True,
-                response_time=10.0, error=None,  # extreme outlier
+                name="app-b",
+                status_code=200,
+                success=True,
+                response_time=10.0,
+                error=None,  # extreme outlier
             ),
         ]
 
@@ -294,10 +329,7 @@ class TestHealthCheckWatcherResults:
             "the method must not abort when URL A has insufficient data"
         )
 
-    @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
-    def test_summarize_response_time_all_urls_insufficient_returns_zero(
-        self, mock_get
-    ):
+    def test_summarize_response_time_all_urls_insufficient_returns_zero(self):
         """Test that summarize_response_time returns 0 when ALL URLs have
         insufficient data (< 4 data points each)."""
         config = HealthCheckConfig(applications=[])
@@ -306,18 +338,27 @@ class TestHealthCheckWatcherResults:
         results = {
             "http://app-a/health": [
                 HealthCheckResult(
-                    name="app-a", status_code=200, success=True,
-                    response_time=0.1, error=None,
+                    name="app-a",
+                    status_code=200,
+                    success=True,
+                    response_time=0.1,
+                    error=None,
                 ),
             ],
             "http://app-b/health": [
                 HealthCheckResult(
-                    name="app-b", status_code=200, success=True,
-                    response_time=0.2, error=None,
+                    name="app-b",
+                    status_code=200,
+                    success=True,
+                    response_time=0.2,
+                    error=None,
                 ),
                 HealthCheckResult(
-                    name="app-b", status_code=200, success=True,
-                    response_time=0.3, error=None,
+                    name="app-b",
+                    status_code=200,
+                    success=True,
+                    response_time=0.3,
+                    error=None,
                 ),
             ],
         }


### PR DESCRIPTION
## Description

`HealthCheckWatcher.summarize_response_time()` contained a `return 0` statement inside its `for` loop (line 148 of `health_check_watcher.py`). In multi-URL health check configurations, if **any** URL had fewer than 4 successful data points, the method immediately exited — silently discarding response-time outlier data from **all remaining URLs**, even those with sufficient data and real latency spikes.

This corrupted the fitness score's response-time component, causing the genetic algorithm to miss genuine performance degradation on monitored endpoints.

**Root cause:** `return 0` exits the entire method; it should be `continue` to skip only the insufficient URL and keep processing the rest.

**Fix:** Replace `return 0` with `continue` and add a `logger.debug()` message for observability when a URL is skipped.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

---

## Testing

Ran the full test suite locally — **236/236 tests pass**.

Two new regression tests were added to `tests/unit/chaos_engines/test_health_check_watcher.py`:

1. **`test_summarize_response_time_skips_insufficient_url_processes_others`** — sets up two URLs: URL A with 2 checks (insufficient), URL B with 10 checks including 2 extreme outliers. Asserts `score > 0`, proving URL B is still processed when URL A is skipped.
2. **`test_summarize_response_time_all_urls_insufficient_returns_zero`** — sets up two URLs both with fewer than 4 checks. Asserts `score == 0.0` (backward compatibility).

```bash
python -m pytest tests/unit/chaos_engines/test_health_check_watcher.py -v
# 16 passed in 12.14s

python -m pytest tests/ -v
# 236 passed in 20.58s
```
## Checklist
 - [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
 - [x] My code follows the project's style guidelines
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I have updated the documentation accordingly
 - [x] My changes generate no new warnings or errorsChecklist
 
## Additional Notes
The existing test test_summarize_response_time_returns_zero_with_insufficient_data uses only a single URL, so it passes regardless of whether return 0 or continue is used — it cannot distinguish between the two behaviors. The new regression tests explicitly cover the multi-URL scenario to prevent this bug from recurring.

Fixes #259 