### PR TITLE
fix(discover): clarify node interface enumeration failures

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -357,8 +357,10 @@ class ClusterManager:
                     node.metadata.name
                 )
             except Exception as e:
-                logger.error(
-                    "Failed to list node interfaces for node %s: %s",
+                node_component.interfaces = []
+                logger.warning(
+                    "Failed to list node interfaces for node %s: %s. "
+                    "network-scenarios will skip this node.",
                     node.metadata.name,
                     e,
                 )

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -3,7 +3,7 @@ ClusterManager unit tests
 """
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from krkn_ai.utils.cluster_manager import ClusterManager
 from krkn_ai.models.cluster_components import Namespace
@@ -451,8 +451,15 @@ class TestClusterManager:
             Exception("Metrics API error")
         )
 
-        # Mock interfaces failure
-        with patch("krkn_ai.utils.cluster_manager.run_shell", return_value=("", 1)):
+        # Mock interface enumeration failure
+        with (
+            patch.object(
+                cluster_manager,
+                "list_node_interfaces",
+                side_effect=Exception("Interface discovery error"),
+            ),
+            patch("krkn_ai.utils.cluster_manager.logger.warning") as mock_warning,
+        ):
             nodes = cluster_manager.list_nodes()
 
         assert len(nodes) == 1
@@ -460,6 +467,12 @@ class TestClusterManager:
         assert nodes[0].free_cpu == -1  # Error indicator
         assert nodes[0].free_mem == -1  # Error indicator
         assert nodes[0].interfaces == []  # Empty on failure
+        mock_warning.assert_any_call(
+            "Failed to list node interfaces for node %s: %s. "
+            "network-scenarios will skip this node.",
+            "test-node",
+            ANY,
+        )
 
     def test_list_node_interfaces_filters_network_interfaces(self, cluster_manager):
         """Test list_node_interfaces filters and returns only ens/eth interfaces"""


### PR DESCRIPTION

## Summary

While auditing the `discover` path for [#188](https://github.com/krkn-chaos/krkn-ai/issues/188#issuecomment-4430507465), I noticed that node interface enumeration failures are logged as errors even though discovery continues and the node is still emitted. This can make non-OpenShift Kubernetes runs look broken when the actual behavior is that `network-scenarios` cannot use that node because no interfaces were discovered.

This PR makes that fallback explicit:

- sets `node_component.interfaces = []` when interface enumeration raises
- demotes the log from `error` to `warning`
- explains the impact: `network-scenarios will skip this node.`
- extends the existing `ClusterManager.list_nodes` unit test to cover the raised-exception path and warning message

## Why

On non-OpenShift clusters, this path can fail when interface discovery depends on OpenShift-specific tooling. The failure is recoverable: the node still belongs in discovered cluster components, but without interfaces it is not a candidate for network scenarios.

This keeps `discover` behavior intact while making the fallback clearer in logs.

## Test

```bash
python -m pytest tests/unit/utils/test_cluster_manager.py -q
python -m pytest -q
npx commitlint --extends @commitlint/config-conventional --from main --to HEAD
```

Result:

- <img width="1067" height="518" alt="Screenshot 2026-05-12 at 6 48 35 PM" src="https://github.com/user-attachments/assets/071a21b2-5937-41b3-85f7-0a53dcb7e6ed" />


```text
18 passed, 1 warning
233 passed, 1 warning
passed
```


