### PR TITLE
fix: replace deprecated tempfile.mktemp() with mkstemp()

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -285,8 +285,8 @@ class KrknRunner:
 
         # Create JSON for krknctl graph runner
         scenario_json = self.__expand_composite_json(scenario)
-        json_file = tempfile.mktemp(suffix=".json", dir=graph_json_directory)
-        with open(json_file, "w", encoding="utf-8") as f:
+        fd, json_file = tempfile.mkstemp(suffix=".json", dir=graph_json_directory)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(scenario_json, f, ensure_ascii=False, indent=4)
         logger.info("Created scenario json in path: %s", json_file)
 


### PR DESCRIPTION
## Description

Replaces `tempfile.mktemp()` with `tempfile.mkstemp()` in `krkn_runner.py`. The old call is deprecated and creates a race condition between path generation and file creation.

Closes #265

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Manually verified the `graph_command` method still produces a valid JSON file at the expected path under `output_dir/graphs/`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings or errors