### PR TITLE
feat: send run summary to Elasticsearch after genetic algorithm completes

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -776,7 +776,10 @@ class GeneticAlgorithm:
         )
         summary_reporter.save(self.output_dir)
 
-        # TODO: Send run summary to Elasticsearch
+        if self.elastic_client is not None:
+            self.elastic_client.index_run_summary(
+                summary_reporter.generate_summary(), self.run_uuid
+            )
 
     def save_config(self):
         logger.info("Saving config file to config.yaml")

--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -114,6 +114,31 @@ class ElasticSearchClient:
         )
         return self.__handle_index_status(status)
 
+    def index_run_summary(self, summary: dict, run_uuid: str) -> bool:
+        """
+        Index the end-of-run summary into the krkn-ai "summary" index in Elasticsearch.
+
+        Args:
+            summary: Dict produced by JSONSummaryReporter.generate_summary()
+            run_uuid: Unique identifier for this run
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.config.enable or self.client is None:
+            logger.debug(
+                "Elasticsearch indexing is disabled. Skipping indexing of run summary."
+            )
+            return False
+
+        INDEX_NAME = f"{self.config.index}-summary"
+        summary["run_uuid"] = run_uuid
+
+        status = self.client.upload_data_to_elasticsearch(
+            item=summary, index=INDEX_NAME
+        )
+        return self.__handle_index_status(status)
+
     def index_run_result(self, result: CommandRunResult, run_uuid: str) -> bool:
         """
         Index the run result into krkn-ai "results" index in Elasticsearch.


### PR DESCRIPTION
## Description

Implements the long-standing TODO in `genetic.py` - after a run completes, the aggregated summary (fitness progression, best scenarios, duration, seed, config) is now indexed into Elasticsearch under the `{index}-summary` index.

Changes:
- Added `index_run_summary(summary, run_uuid)` to `ElasticSearchClient`
- Called it in `genetic.py` after `summary_reporter.save()` when `elastic_client` is not None

Closes #271

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Verified with Elasticsearch disabled, no change in behavior. With Elasticsearch enabled, the summary dict is uploaded to `{index}-summary` index.

## Checklist

- [x] My code follows the project's style guidelines
- [x] My changes generate no new warnings or errors