### PR TITLE
feat(reporter): enrich results.json with stopping reason, health check summary, SLO breakdown, and worst scenarios

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -99,6 +99,7 @@ class GeneticAlgorithm:
         self.end_time: Optional[datetime.datetime] = None
         self.seed: Optional[int] = None  # Seed can be set externally if needed
         self.completed_generations: int = 0
+        self.stopping_reason: Optional[str] = None
 
         if self.config.population_size < 2:
             raise PopulationSizeError("Population size should be at least 2")
@@ -313,6 +314,7 @@ class GeneticAlgorithm:
         should_stop, reason = self.should_stop(cur_generation, elapsed_time)
         if should_stop:
             self.end_time = datetime.datetime.now(datetime.timezone.utc)
+            self.stopping_reason = reason
             logger.info("Stopping algorithm: %s", reason)
             logger.info(
                 "Completed %d generations in %s",
@@ -773,6 +775,7 @@ class GeneticAlgorithm:
             end_time=self.end_time,
             completed_generations=self.completed_generations,
             seed=self.seed,
+            stopping_reason=self.stopping_reason,
         )
         summary_reporter.save(self.output_dir)
 

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -254,11 +254,17 @@ def discover(
         skip_pod_name=skip_pod_name,
     )
 
+    health_check_urls = cluster_manager.discover_health_check_urls(
+        cluster_components.namespaces
+    )
+
     cluster_components_data = cluster_components.model_dump(
         mode="json", warnings="none", exclude_defaults=True
     )
 
-    template = create_krkn_ai_template(kubeconfig, cluster_components_data)
+    template = create_krkn_ai_template(
+        kubeconfig, cluster_components_data, health_check_urls
+    )
 
     with open(output, "w") as f:
         f.write(template)

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -5,6 +5,7 @@ JSON Summary Reporter for generating unified results.json files.
 import json
 import os
 import datetime
+from collections import defaultdict
 from typing import Any, Dict, List, Optional
 
 from krkn_ai.models.app import CommandRunResult
@@ -34,6 +35,7 @@ class JSONSummaryReporter:
         end_time: Optional[datetime.datetime] = None,
         completed_generations: int = 0,
         seed: Optional[int] = None,
+        stopping_reason: Optional[str] = None,
     ):
         """
         Initialize the JSON summary reporter.
@@ -47,6 +49,7 @@ class JSONSummaryReporter:
             end_time: When the run ended.
             completed_generations: Number of generations completed.
             seed: Random seed used for the run (if any).
+            stopping_reason: Human-readable reason the algorithm stopped.
         """
         self.run_uuid = run_uuid
         self.config = config
@@ -57,6 +60,7 @@ class JSONSummaryReporter:
         self.end_time = end_time
         self.completed_generations = completed_generations
         self.seed = seed
+        self.stopping_reason = stopping_reason
         self.status = STATUS_COMPLETED
 
     def generate_summary(self) -> Dict[str, Any]:
@@ -88,6 +92,11 @@ class JSONSummaryReporter:
         if all_fitness_scores:
             best_fitness_score = max(all_fitness_scores)
 
+        # Get min fitness score
+        min_fitness_score = 0.0
+        if all_fitness_scores:
+            min_fitness_score = min(all_fitness_scores)
+
         # Count unique scenarios by their string representation
         unique_scenarios = set()
         for result in self.seen_population.values():
@@ -99,6 +108,9 @@ class JSONSummaryReporter:
         # Generate best scenarios list (sorted by fitness score, top 10)
         best_scenarios = self._build_best_scenarios()
 
+        # Generate worst scenarios list (sorted by fitness score, bottom 10)
+        worst_scenarios = self._build_worst_scenarios()
+
         # Build the results summary
         results_summary: Dict[str, Any] = {
             "run_id": self.run_uuid,
@@ -107,6 +119,7 @@ class JSONSummaryReporter:
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "duration_seconds": round(duration_seconds, 2),
             "status": self.status,
+            "stopping_reason": self.stopping_reason,
             "config": {
                 "generations": self.config.generations,
                 "population_size": self.config.population_size,
@@ -120,10 +133,14 @@ class JSONSummaryReporter:
                 "unique_scenarios": len(unique_scenarios),
                 "generations_completed": self.completed_generations,
                 "best_fitness_score": round(best_fitness_score, 4),
+                "min_fitness_score": round(min_fitness_score, 4),
                 "average_fitness_score": round(average_fitness_score, 4),
             },
             "best_scenarios": best_scenarios,
+            "worst_scenarios": worst_scenarios,
             "fitness_progression": fitness_progression,
+            "health_check_summary": self._build_health_check_summary(),
+            "slo_breakdown": self._build_slo_breakdown(),
         }
 
         if self.baseline_result is not None:
@@ -184,6 +201,95 @@ class JSONSummaryReporter:
                 }
             )
         return best_scenarios
+
+    def _build_worst_scenarios(self) -> List[Dict[str, Any]]:
+        """Build ranked list of worst scenarios (bottom 10)."""
+        sorted_results = sorted(
+            self.seen_population.values(),
+            key=lambda x: x.fitness_result.fitness_score,
+        )
+        worst_scenarios = []
+        for rank, result in enumerate(sorted_results[:10], start=1):
+            scenario_params = {}
+            if hasattr(result.scenario, "parameters"):
+                scenario_params = {
+                    param.get_name(): param.get_value()
+                    for param in result.scenario.parameters
+                }
+
+            worst_scenarios.append(
+                {
+                    "rank": rank,
+                    "scenario_id": result.scenario_id,
+                    "generation": result.generation_id,
+                    "fitness_score": result.fitness_result.fitness_score,
+                    "scenario_type": result.scenario.name,
+                    "parameters": scenario_params,
+                }
+            )
+        return worst_scenarios
+
+    def _build_health_check_summary(self) -> Optional[Dict[str, Any]]:
+        """Aggregate health check data across all scenarios, per component."""
+        component_data: Dict[str, List[Any]] = defaultdict(list)
+
+        for result in self.seen_population.values():
+            for component_results in result.health_check_results.values():
+                if not component_results:
+                    continue
+                component_name = component_results[0].name
+                component_data[component_name].extend(component_results)
+
+        if not component_data:
+            return None
+
+        summary: Dict[str, Any] = {}
+        for component_name, checks in component_data.items():
+            response_times = [c.response_time for c in checks]
+            success_count = sum(1 for c in checks if c.success)
+            failure_count = len(checks) - success_count
+            total_checks = len(checks)
+
+            summary[component_name] = {
+                "min_response_time": round(min(response_times), 4),
+                "max_response_time": round(max(response_times), 4),
+                "avg_response_time": round(
+                    sum(response_times) / len(response_times), 4
+                ),
+                "total_checks": total_checks,
+                "success_count": success_count,
+                "failure_count": failure_count,
+                "success_rate": round(success_count / total_checks, 4),
+            }
+
+        return summary
+
+    def _build_slo_breakdown(self) -> Optional[Dict[str, Any]]:
+        """Aggregate per-SLO fitness scores across all scenarios."""
+        slo_data: Dict[int, Dict[str, List[float]]] = defaultdict(
+            lambda: {"fitness_scores": [], "weighted_scores": []}
+        )
+
+        for result in self.seen_population.values():
+            for score in result.fitness_result.scores:
+                slo_data[score.id]["fitness_scores"].append(score.fitness_score)
+                slo_data[score.id]["weighted_scores"].append(score.weighted_score)
+
+        if not slo_data:
+            return None
+
+        breakdown: Dict[str, Any] = {}
+        for slo_id, data in slo_data.items():
+            breakdown[str(slo_id)] = {
+                "avg_fitness_score": round(
+                    sum(data["fitness_scores"]) / len(data["fitness_scores"]), 4
+                ),
+                "avg_weighted_score": round(
+                    sum(data["weighted_scores"]) / len(data["weighted_scores"]), 4
+                ),
+            }
+
+        return breakdown
 
     def save(self, output_dir: str):
         """

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -281,10 +281,10 @@ class JSONSummaryReporter:
         breakdown: Dict[str, Any] = {}
         for slo_id, data in slo_data.items():
             breakdown[str(slo_id)] = {
-                "avg_fitness_score": round(
+                "fitness_score": round(
                     sum(data["fitness_scores"]) / len(data["fitness_scores"]), 4
                 ),
-                "avg_weighted_score": round(
+                "weighted_score": round(
                     sum(data["weighted_scores"]) / len(data["weighted_scores"]), 4
                 ),
             }

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, List
 
 import jinja2
 import yaml
@@ -10,7 +11,9 @@ environment.globals["enumerate"] = enumerate
 
 
 def create_krkn_ai_template(
-    kubeconfig_file_path: str, cluster_component_data: dict
+    kubeconfig_file_path: str,
+    cluster_component_data: dict,
+    health_check_urls: List[Dict[str, str]] = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -36,7 +39,27 @@ def create_krkn_ai_template(
 
     cluster_components_indented = "\n".join(indented_lines)
 
+    # Build health_checks YAML block
+    health_checks_yaml = ""
+    if health_check_urls:
+        health_checks_data = {
+            "health_checks": {
+                "stop_watcher_on_failure": False,
+                "applications": [
+                    {"name": entry["name"], "url": entry["url"]}
+                    for entry in health_check_urls
+                ],
+            }
+        }
+        health_checks_yaml = yaml.dump(
+            health_checks_data,
+            default_flow_style=False,
+            indent=2,
+            allow_unicode=True,
+        ).strip()
+
     return template.render(
         kubeconfig_file_path=kubeconfig_file_path,
         cluster_components=cluster_components_indented,
+        health_checks=health_checks_yaml,
     )

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -44,6 +44,9 @@ fitness_function:
   include_health_check_failure: true
   include_health_check_response_time: true
 
+{% if health_checks %}
+{{ health_checks }}
+{% else %}
 # health_checks:
 #   stop_watcher_on_failure: false
 #   applications:
@@ -59,6 +62,7 @@ fitness_function:
 #     url: "$HOST/user/uniqueid"
 #   - name: ratings
 #     url: "$HOST/ratings/api/fetch/Watson"
+{% endif %}
 
 
 scenario:

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -82,10 +82,11 @@ class ClusterManager:
                     for path_obj in rule.http.paths:
                         path = path_obj.path or "/"
                         url = f"{scheme}://{host}{path}"
-                        results.append({"name": f"{ing_name}-{host}", "url": url})
+                        path_slug = path.strip("/").replace("/", "-") or "root"
+                        results.append({"name": f"{ing_name}-{host}-{path_slug}", "url": url})
                 else:
                     results.append(
-                        {"name": f"{ing_name}-{host}", "url": f"{scheme}://{host}/"}
+                        {"name": f"{ing_name}-{host}-root", "url": f"{scheme}://{host}/"}
                     )
         logger.debug(
             "Discovered %d Ingress URLs in namespace %s", len(results), namespace
@@ -95,6 +96,7 @@ class ClusterManager:
     def _discover_route_urls(self, namespace: str) -> List[Dict[str, str]]:
         """List OpenShift Route resources and extract URLs. Graceful no-op if CRD absent."""
         results: List[Dict[str, str]] = []
+        from kubernetes.client.exceptions import ApiException
         try:
             routes_response = self.custom_obj_api.list_namespaced_custom_object(
                 group="route.openshift.io",
@@ -102,8 +104,18 @@ class ClusterManager:
                 namespace=namespace,
                 plural="routes",
             )
-        except Exception:
-            # Route CRD not present or not accessible; skip silently
+        except ApiException as e:
+            if e.status == 404 or "doesn't have a resource type" in str(e.body or ""):
+                # Route CRD not present — expected on non-OpenShift clusters
+                return results
+            logger.warning(
+                "Failed to list OpenShift Routes in namespace %s: %s", namespace, e
+            )
+            return results
+        except Exception as e:
+            logger.warning(
+                "Unexpected error listing Routes in namespace %s: %s", namespace, e
+            )
             return results
 
         for route in routes_response.get("items", []):

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -59,9 +59,7 @@ class ClusterManager:
                 namespace=namespace
             ).items
         except Exception as e:
-            logger.warning(
-                "Failed to list Ingresses in namespace %s: %s", namespace, e
-            )
+            logger.warning("Failed to list Ingresses in namespace %s: %s", namespace, e)
             return results
 
         for ing in ingresses:
@@ -84,10 +82,15 @@ class ClusterManager:
                         path = path_obj.path or "/"
                         url = f"{scheme}://{host}{path}"
                         path_slug = path.strip("/").replace("/", "-") or "root"
-                        results.append({"name": f"{ing_name}-{host}-{path_slug}", "url": url})
+                        results.append(
+                            {"name": f"{ing_name}-{host}-{path_slug}", "url": url}
+                        )
                 else:
                     results.append(
-                        {"name": f"{ing_name}-{host}-root", "url": f"{scheme}://{host}/"}
+                        {
+                            "name": f"{ing_name}-{host}-root",
+                            "url": f"{scheme}://{host}/",
+                        }
                     )
         logger.debug(
             "Discovered %d Ingress URLs in namespace %s", len(results), namespace
@@ -98,6 +101,7 @@ class ClusterManager:
         """List OpenShift Route resources and extract URLs. Graceful no-op if CRD absent."""
         results: List[Dict[str, str]] = []
         from kubernetes.client.exceptions import ApiException
+
         try:
             routes_response = self.custom_obj_api.list_namespaced_custom_object(
                 group="route.openshift.io",
@@ -140,19 +144,19 @@ class ClusterManager:
         """List Services with type LoadBalancer and extract external URLs."""
         results: List[Dict[str, str]] = []
         try:
-            services = self.core_api.list_namespaced_service(
-                namespace=namespace
-            ).items
+            services = self.core_api.list_namespaced_service(namespace=namespace).items
         except Exception as e:
-            logger.warning(
-                "Failed to list Services in namespace %s: %s", namespace, e
-            )
+            logger.warning("Failed to list Services in namespace %s: %s", namespace, e)
             return results
 
         for svc in services:
             if svc.spec.type != "LoadBalancer":
                 continue
-            ingress_list = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
+            ingress_list = (
+                (svc.status.load_balancer.ingress or [])
+                if svc.status.load_balancer
+                else []
+            )
             if not ingress_list:
                 continue
             has_443 = any(p.port == 443 for p in (svc.spec.ports or []))

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,6 +1,7 @@
 import re
 from typing import Dict, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
+from kubernetes.client import NetworkingV1Api
 from kubernetes.client.models import V1PodSpec
 from krkn_ai.utils import run_shell
 from krkn_ai.utils.logger import get_logger
@@ -30,7 +31,97 @@ class ClusterManager:
         self.api_client = self.krkn_k8s.api_client
         self.core_api = self.krkn_k8s.cli
         self.custom_obj_api = self.krkn_k8s.custom_object_client
+        self.networking_api = NetworkingV1Api(self.api_client)
         logger.debug("ClusterManager initialized with kubeconfig: %s", kubeconfig)
+
+    def discover_health_check_urls(
+        self, namespaces: List[Namespace]
+    ) -> List[Dict[str, str]]:
+        """
+        Discover health check URLs from Kubernetes Ingresses and OpenShift Routes
+        in the given namespaces.
+
+        Returns a list of dicts with 'name' and 'url' keys suitable for
+        populating health_checks.applications in the config.
+        """
+        urls: List[Dict[str, str]] = []
+        for ns in namespaces:
+            urls.extend(self._discover_ingress_urls(ns.name))
+            urls.extend(self._discover_route_urls(ns.name))
+        return urls
+
+    def _discover_ingress_urls(self, namespace: str) -> List[Dict[str, str]]:
+        """List Ingress resources and extract host+path URLs."""
+        results: List[Dict[str, str]] = []
+        try:
+            ingresses = self.networking_api.list_namespaced_ingress(
+                namespace=namespace
+            ).items
+        except Exception as e:
+            logger.warning(
+                "Failed to list Ingresses in namespace %s: %s", namespace, e
+            )
+            return results
+
+        for ing in ingresses:
+            ing_name = ing.metadata.name
+            tls_hosts = set()
+            if ing.spec.tls:
+                for tls in ing.spec.tls:
+                    if tls.hosts:
+                        tls_hosts.update(tls.hosts)
+
+            if not ing.spec.rules:
+                continue
+            for rule in ing.spec.rules:
+                host = rule.host
+                if not host:
+                    continue
+                scheme = "https" if host in tls_hosts else "http"
+                if rule.http and rule.http.paths:
+                    for path_obj in rule.http.paths:
+                        path = path_obj.path or "/"
+                        url = f"{scheme}://{host}{path}"
+                        results.append({"name": f"{ing_name}-{host}", "url": url})
+                else:
+                    results.append(
+                        {"name": f"{ing_name}-{host}", "url": f"{scheme}://{host}/"}
+                    )
+        logger.debug(
+            "Discovered %d Ingress URLs in namespace %s", len(results), namespace
+        )
+        return results
+
+    def _discover_route_urls(self, namespace: str) -> List[Dict[str, str]]:
+        """List OpenShift Route resources and extract URLs. Graceful no-op if CRD absent."""
+        results: List[Dict[str, str]] = []
+        try:
+            routes_response = self.custom_obj_api.list_namespaced_custom_object(
+                group="route.openshift.io",
+                version="v1",
+                namespace=namespace,
+                plural="routes",
+            )
+        except Exception:
+            # Route CRD not present or not accessible; skip silently
+            return results
+
+        for route in routes_response.get("items", []):
+            route_name = route["metadata"]["name"]
+            spec = route.get("spec", {})
+            host = spec.get("host")
+            if not host:
+                continue
+            tls = spec.get("tls")
+            scheme = "https" if tls else "http"
+            path = spec.get("path", "/")
+            url = f"{scheme}://{host}{path}"
+            results.append({"name": route_name, "url": url})
+
+        logger.debug(
+            "Discovered %d Route URLs in namespace %s", len(results), namespace
+        )
+        return results
 
     def discover_components(
         self,

--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -48,6 +48,7 @@ class ClusterManager:
         for ns in namespaces:
             urls.extend(self._discover_ingress_urls(ns.name))
             urls.extend(self._discover_route_urls(ns.name))
+            urls.extend(self._discover_loadbalancer_urls(ns.name))
         return urls
 
     def _discover_ingress_urls(self, namespace: str) -> List[Dict[str, str]]:
@@ -132,6 +133,38 @@ class ClusterManager:
 
         logger.debug(
             "Discovered %d Route URLs in namespace %s", len(results), namespace
+        )
+        return results
+
+    def _discover_loadbalancer_urls(self, namespace: str) -> List[Dict[str, str]]:
+        """List Services with type LoadBalancer and extract external URLs."""
+        results: List[Dict[str, str]] = []
+        try:
+            services = self.core_api.list_namespaced_service(
+                namespace=namespace
+            ).items
+        except Exception as e:
+            logger.warning(
+                "Failed to list Services in namespace %s: %s", namespace, e
+            )
+            return results
+
+        for svc in services:
+            if svc.spec.type != "LoadBalancer":
+                continue
+            ingress_list = (svc.status.load_balancer.ingress or []) if svc.status.load_balancer else []
+            if not ingress_list:
+                continue
+            has_443 = any(p.port == 443 for p in (svc.spec.ports or []))
+            scheme = "https" if has_443 else "http"
+            for entry in ingress_list:
+                host = entry.ip or entry.hostname
+                if not host:
+                    continue
+                results.append({"name": svc.metadata.name, "url": f"{scheme}://{host}"})
+
+        logger.debug(
+            "Discovered %d LoadBalancer URLs in namespace %s", len(results), namespace
         )
         return results
 

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -6,7 +6,14 @@ import datetime
 
 from krkn_ai.reporter.json_summary_reporter import JSONSummaryReporter
 from krkn_ai.models.app import CommandRunResult, FitnessResult, FitnessScoreResult
-from krkn_ai.models.config import ConfigFile, FitnessFunction, FitnessFunctionType, ScenarioConfig, PodScenarioConfig, HealthCheckResult
+from krkn_ai.models.config import (
+    ConfigFile,
+    FitnessFunction,
+    FitnessFunctionType,
+    ScenarioConfig,
+    PodScenarioConfig,
+    HealthCheckResult,
+)
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 from krkn_ai.models.cluster_components import ClusterComponents
 
@@ -93,8 +100,12 @@ class TestJSONSummaryReporterHealthCheckSummary:
             scenario=s1,
             health_check_results={
                 "app1": [
-                    HealthCheckResult(name="app1", response_time=0.1, status_code=200, success=True),
-                    HealthCheckResult(name="app1", response_time=0.3, status_code=200, success=True),
+                    HealthCheckResult(
+                        name="app1", response_time=0.1, status_code=200, success=True
+                    ),
+                    HealthCheckResult(
+                        name="app1", response_time=0.3, status_code=200, success=True
+                    ),
                 ]
             },
         )
@@ -104,7 +115,9 @@ class TestJSONSummaryReporterHealthCheckSummary:
             scenario=s2,
             health_check_results={
                 "app1": [
-                    HealthCheckResult(name="app1", response_time=0.5, status_code=500, success=False),
+                    HealthCheckResult(
+                        name="app1", response_time=0.5, status_code=500, success=False
+                    ),
                 ]
             },
         )
@@ -153,8 +166,12 @@ class TestJSONSummaryReporterSLOBreakdown:
         ]
         s1 = _make_scenario(end_value=100)
         s2 = _make_scenario(end_value=200)
-        r1 = _make_result(scenario_id=1, fitness_score=5.0, slo_scores=scores1, scenario=s1)
-        r2 = _make_result(scenario_id=2, fitness_score=8.0, slo_scores=scores2, scenario=s2)
+        r1 = _make_result(
+            scenario_id=1, fitness_score=5.0, slo_scores=scores1, scenario=s1
+        )
+        r2 = _make_result(
+            scenario_id=2, fitness_score=8.0, slo_scores=scores2, scenario=s2
+        )
         seen = {s1: r1, s2: r2}
 
         reporter = JSONSummaryReporter(

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -1,0 +1,278 @@
+"""
+JSONSummaryReporter unit tests
+"""
+
+import datetime
+
+from krkn_ai.reporter.json_summary_reporter import JSONSummaryReporter
+from krkn_ai.models.app import CommandRunResult, FitnessResult, FitnessScoreResult
+from krkn_ai.models.config import ConfigFile, FitnessFunction, FitnessFunctionType, ScenarioConfig, PodScenarioConfig, HealthCheckResult
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
+from krkn_ai.models.cluster_components import ClusterComponents
+
+
+def _make_config():
+    return ConfigFile(
+        kubeconfig_file_path="/tmp/test",
+        generations=5,
+        population_size=4,
+        fitness_function=FitnessFunction(query="q", type=FitnessFunctionType.point),
+        scenario=ScenarioConfig(pod_scenarios=PodScenarioConfig(enable=True)),
+        cluster_components=ClusterComponents(),
+    )
+
+
+def _make_scenario(end_value=10):
+    """Create a DummyScenario with a unique end value for dict key uniqueness."""
+    s = DummyScenario(cluster_components=ClusterComponents())
+    s.end.value = end_value
+    return s
+
+
+def _make_result(
+    generation_id=0,
+    scenario_id=1,
+    fitness_score=10.0,
+    health_check_results=None,
+    slo_scores=None,
+    scenario=None,
+):
+    if scenario is None:
+        scenario = _make_scenario(end_value=scenario_id)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    scores = slo_scores or []
+    return CommandRunResult(
+        generation_id=generation_id,
+        scenario_id=scenario_id,
+        scenario=scenario,
+        cmd="cmd",
+        log="log",
+        returncode=0,
+        start_time=now,
+        end_time=now,
+        fitness_result=FitnessResult(fitness_score=fitness_score, scores=scores),
+        health_check_results=health_check_results or {},
+    )
+
+
+class TestJSONSummaryReporterStoppingReason:
+    def test_stopping_reason_included(self):
+        config = _make_config()
+        result = _make_result()
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={result.scenario: result},
+            best_of_generation=[result],
+            stopping_reason="Completed 5 generations",
+        )
+        summary = reporter.generate_summary()
+        assert summary["stopping_reason"] == "Completed 5 generations"
+
+    def test_stopping_reason_none_when_not_set(self):
+        config = _make_config()
+        result = _make_result()
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={result.scenario: result},
+            best_of_generation=[result],
+        )
+        summary = reporter.generate_summary()
+        assert summary["stopping_reason"] is None
+
+
+class TestJSONSummaryReporterHealthCheckSummary:
+    def test_health_check_summary_aggregates_across_scenarios(self):
+        config = _make_config()
+        s1 = _make_scenario(end_value=100)
+        s2 = _make_scenario(end_value=200)
+        r1 = _make_result(
+            scenario_id=1,
+            fitness_score=5.0,
+            scenario=s1,
+            health_check_results={
+                "app1": [
+                    HealthCheckResult(name="app1", response_time=0.1, status_code=200, success=True),
+                    HealthCheckResult(name="app1", response_time=0.3, status_code=200, success=True),
+                ]
+            },
+        )
+        r2 = _make_result(
+            scenario_id=2,
+            fitness_score=8.0,
+            scenario=s2,
+            health_check_results={
+                "app1": [
+                    HealthCheckResult(name="app1", response_time=0.5, status_code=500, success=False),
+                ]
+            },
+        )
+        seen = {s1: r1, s2: r2}
+
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population=seen,
+            best_of_generation=[r2],
+        )
+        summary = reporter.generate_summary()
+        hc = summary["health_check_summary"]
+        assert hc is not None
+        assert "app1" in hc
+        assert hc["app1"]["min_response_time"] == 0.1
+        assert hc["app1"]["max_response_time"] == 0.5
+        assert hc["app1"]["total_checks"] == 3
+        assert hc["app1"]["success_count"] == 2
+        assert hc["app1"]["failure_count"] == 1
+        assert hc["app1"]["success_rate"] == round(2 / 3, 4)
+
+    def test_health_check_summary_none_when_no_data(self):
+        config = _make_config()
+        result = _make_result(health_check_results={})
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={result.scenario: result},
+            best_of_generation=[result],
+        )
+        summary = reporter.generate_summary()
+        assert summary["health_check_summary"] is None
+
+
+class TestJSONSummaryReporterSLOBreakdown:
+    def test_slo_breakdown_aggregates_per_id(self):
+        config = _make_config()
+        scores1 = [
+            FitnessScoreResult(id=1, fitness_score=0.8, weighted_score=0.4),
+            FitnessScoreResult(id=2, fitness_score=0.6, weighted_score=0.3),
+        ]
+        scores2 = [
+            FitnessScoreResult(id=1, fitness_score=0.9, weighted_score=0.45),
+            FitnessScoreResult(id=2, fitness_score=0.7, weighted_score=0.35),
+        ]
+        s1 = _make_scenario(end_value=100)
+        s2 = _make_scenario(end_value=200)
+        r1 = _make_result(scenario_id=1, fitness_score=5.0, slo_scores=scores1, scenario=s1)
+        r2 = _make_result(scenario_id=2, fitness_score=8.0, slo_scores=scores2, scenario=s2)
+        seen = {s1: r1, s2: r2}
+
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population=seen,
+            best_of_generation=[r2],
+        )
+        summary = reporter.generate_summary()
+        slo = summary["slo_breakdown"]
+        assert slo is not None
+        assert "1" in slo
+        assert "2" in slo
+        assert slo["1"]["avg_fitness_score"] == round((0.8 + 0.9) / 2, 4)
+        assert slo["1"]["avg_weighted_score"] == round((0.4 + 0.45) / 2, 4)
+        assert slo["2"]["avg_fitness_score"] == round((0.6 + 0.7) / 2, 4)
+        assert slo["2"]["avg_weighted_score"] == round((0.3 + 0.35) / 2, 4)
+
+    def test_slo_breakdown_none_when_no_scores(self):
+        config = _make_config()
+        result = _make_result(slo_scores=[])
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={result.scenario: result},
+            best_of_generation=[result],
+        )
+        summary = reporter.generate_summary()
+        assert summary["slo_breakdown"] is None
+
+
+class TestJSONSummaryReporterWorstScenarios:
+    def test_worst_scenarios_returns_bottom_10(self):
+        config = _make_config()
+        results = {}
+        for i in range(15):
+            s = _make_scenario(end_value=i + 1)
+            r = _make_result(scenario_id=i, fitness_score=float(i), scenario=s)
+            results[s] = r
+
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population=results,
+            best_of_generation=[list(results.values())[-1]],
+        )
+        summary = reporter.generate_summary()
+        worst = summary["worst_scenarios"]
+        assert len(worst) == 10
+        # Worst should be sorted ascending (lowest fitness first)
+        assert worst[0]["fitness_score"] == 0.0
+        assert worst[9]["fitness_score"] == 9.0
+        assert worst[0]["rank"] == 1
+
+    def test_worst_scenarios_empty_population(self):
+        config = _make_config()
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={},
+            best_of_generation=[],
+        )
+        summary = reporter.generate_summary()
+        assert summary["worst_scenarios"] == []
+
+
+class TestJSONSummaryReporterMinFitness:
+    def test_min_fitness_score_included(self):
+        config = _make_config()
+        results = {}
+        for i, score in enumerate([3.0, 1.5, 7.0]):
+            s = _make_scenario(end_value=i + 1)
+            r = _make_result(scenario_id=i, fitness_score=score, scenario=s)
+            results[s] = r
+
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population=results,
+            best_of_generation=[list(results.values())[-1]],
+        )
+        summary = reporter.generate_summary()
+        assert summary["summary"]["min_fitness_score"] == 1.5
+
+    def test_min_fitness_score_zero_when_empty(self):
+        config = _make_config()
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={},
+            best_of_generation=[],
+        )
+        summary = reporter.generate_summary()
+        assert summary["summary"]["min_fitness_score"] == 0.0
+
+
+class TestJSONSummaryReporterSave:
+    def test_save_writes_json_file(self, temp_output_dir):
+        import json
+        import os
+
+        config = _make_config()
+        result = _make_result()
+        reporter = JSONSummaryReporter(
+            run_uuid="test",
+            config=config,
+            seen_population={result.scenario: result},
+            best_of_generation=[result],
+            stopping_reason="Completed 5 generations",
+        )
+        reporter.save(temp_output_dir)
+
+        path = os.path.join(temp_output_dir, "results.json")
+        assert os.path.exists(path)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["stopping_reason"] == "Completed 5 generations"
+        assert "health_check_summary" in data
+        assert "slo_breakdown" in data
+        assert "worst_scenarios" in data
+        assert "min_fitness_score" in data["summary"]

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -168,10 +168,10 @@ class TestJSONSummaryReporterSLOBreakdown:
         assert slo is not None
         assert "1" in slo
         assert "2" in slo
-        assert slo["1"]["avg_fitness_score"] == round((0.8 + 0.9) / 2, 4)
-        assert slo["1"]["avg_weighted_score"] == round((0.4 + 0.45) / 2, 4)
-        assert slo["2"]["avg_fitness_score"] == round((0.6 + 0.7) / 2, 4)
-        assert slo["2"]["avg_weighted_score"] == round((0.3 + 0.35) / 2, 4)
+        assert slo["1"]["fitness_score"] == round((0.8 + 0.9) / 2, 4)
+        assert slo["1"]["weighted_score"] == round((0.4 + 0.45) / 2, 4)
+        assert slo["2"]["fitness_score"] == round((0.6 + 0.7) / 2, 4)
+        assert slo["2"]["weighted_score"] == round((0.3 + 0.35) / 2, 4)
 
     def test_slo_breakdown_none_when_no_scores(self):
         config = _make_config()

--- a/tests/unit/utils/test_health_check_discovery.py
+++ b/tests/unit/utils/test_health_check_discovery.py
@@ -218,9 +218,7 @@ class TestLoadBalancerDiscovery:
             "krkn_ai.utils.cluster_manager.KrknKubernetes",
             return_value=mock_krkn_k8s,
         ):
-            with patch(
-                "krkn_ai.utils.cluster_manager.NetworkingV1Api"
-            ):
+            with patch("krkn_ai.utils.cluster_manager.NetworkingV1Api"):
                 mgr = ClusterManager(kubeconfig="/tmp/test-kubeconfig")
                 return mgr
 
@@ -249,8 +247,9 @@ class TestLoadBalancerDiscovery:
     def test_discover_loadbalancer_urls_with_ip(self, cluster_manager):
         """Test LoadBalancer with IP address."""
         svc = self._make_lb_service(
-            "my-lb", [self._make_ingress_entry(ip="1.2.3.4")],
-            ports=[self._make_port(80)]
+            "my-lb",
+            [self._make_ingress_entry(ip="1.2.3.4")],
+            ports=[self._make_port(80)],
         )
         cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
 
@@ -262,8 +261,9 @@ class TestLoadBalancerDiscovery:
     def test_discover_loadbalancer_urls_with_hostname(self, cluster_manager):
         """Test LoadBalancer with hostname."""
         svc = self._make_lb_service(
-            "aws-lb", [self._make_ingress_entry(hostname="abc.elb.amazonaws.com")],
-            ports=[self._make_port(80)]
+            "aws-lb",
+            [self._make_ingress_entry(hostname="abc.elb.amazonaws.com")],
+            ports=[self._make_port(80)],
         )
         cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
 
@@ -275,8 +275,9 @@ class TestLoadBalancerDiscovery:
     def test_discover_loadbalancer_urls_https_on_port_443(self, cluster_manager):
         """Test that port 443 triggers https scheme."""
         svc = self._make_lb_service(
-            "secure-lb", [self._make_ingress_entry(ip="10.0.0.1")],
-            ports=[self._make_port(443)]
+            "secure-lb",
+            [self._make_ingress_entry(ip="10.0.0.1")],
+            ports=[self._make_port(443)],
         )
         cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
 

--- a/tests/unit/utils/test_health_check_discovery.py
+++ b/tests/unit/utils/test_health_check_discovery.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for Ingress and OpenShift Route health check URL discovery.
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from krkn_ai.utils.cluster_manager import ClusterManager
+from krkn_ai.models.cluster_components import Namespace
+
+
+class TestHealthCheckDiscovery:
+    """Test health check URL discovery from Ingresses and Routes."""
+
+    @pytest.fixture
+    def mock_krkn_k8s(self):
+        mock_k8s = Mock()
+        mock_k8s.apps_api = Mock()
+        mock_k8s.api_client = Mock()
+        mock_k8s.cli = Mock()
+        mock_k8s.custom_object_client = Mock()
+        mock_k8s.list_namespaces = Mock(return_value=["default"])
+        return mock_k8s
+
+    @pytest.fixture
+    def cluster_manager(self, mock_krkn_k8s):
+        with patch(
+            "krkn_ai.utils.cluster_manager.KrknKubernetes",
+            return_value=mock_krkn_k8s,
+        ):
+            with patch(
+                "krkn_ai.utils.cluster_manager.NetworkingV1Api"
+            ) as mock_net_api_cls:
+                mock_net_api = Mock()
+                mock_net_api_cls.return_value = mock_net_api
+                mgr = ClusterManager(kubeconfig="/tmp/test-kubeconfig")
+                mgr.networking_api = mock_net_api
+                return mgr
+
+    def _make_ingress(self, name, rules, tls=None):
+        ing = Mock()
+        ing.metadata.name = name
+        ing.spec.tls = tls
+        ing.spec.rules = rules
+        return ing
+
+    def _make_rule(self, host, paths=None):
+        rule = Mock()
+        rule.host = host
+        if paths is not None:
+            rule.http = Mock()
+            rule.http.paths = paths
+        else:
+            rule.http = None
+        return rule
+
+    def _make_path(self, path):
+        p = Mock()
+        p.path = path
+        return p
+
+    def test_discover_ingress_urls_extracts_host_and_path(self, cluster_manager):
+        """Test that Ingress hosts and paths are correctly extracted as URLs."""
+        rule = self._make_rule("app.example.com", [self._make_path("/api")])
+        ingress = self._make_ingress("my-ingress", [rule])
+        cluster_manager.networking_api.list_namespaced_ingress.return_value.items = [
+            ingress
+        ]
+
+        urls = cluster_manager._discover_ingress_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0]["name"] == "my-ingress-app.example.com"
+        assert urls[0]["url"] == "http://app.example.com/api"
+
+    def test_discover_ingress_urls_uses_https_for_tls_hosts(self, cluster_manager):
+        """Test that TLS-configured hosts get https scheme."""
+        rule = self._make_rule("secure.example.com", [self._make_path("/")])
+        tls = Mock()
+        tls.hosts = ["secure.example.com"]
+        ingress = self._make_ingress("tls-ingress", [rule], tls=[tls])
+        cluster_manager.networking_api.list_namespaced_ingress.return_value.items = [
+            ingress
+        ]
+
+        urls = cluster_manager._discover_ingress_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0]["url"] == "https://secure.example.com/"
+
+    def test_discover_ingress_urls_handles_no_paths(self, cluster_manager):
+        """Test Ingress rule with no HTTP paths defaults to /."""
+        rule = self._make_rule("bare.example.com")
+        ingress = self._make_ingress("bare-ingress", [rule])
+        cluster_manager.networking_api.list_namespaced_ingress.return_value.items = [
+            ingress
+        ]
+
+        urls = cluster_manager._discover_ingress_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0]["url"] == "http://bare.example.com/"
+
+    def test_discover_ingress_urls_skips_rules_without_host(self, cluster_manager):
+        """Test that rules without a host are skipped."""
+        rule = self._make_rule(None, [self._make_path("/")])
+        ingress = self._make_ingress("no-host", [rule])
+        cluster_manager.networking_api.list_namespaced_ingress.return_value.items = [
+            ingress
+        ]
+
+        urls = cluster_manager._discover_ingress_urls("default")
+
+        assert len(urls) == 0
+
+    def test_discover_ingress_urls_handles_api_error_gracefully(self, cluster_manager):
+        """Test that API errors return empty list."""
+        cluster_manager.networking_api.list_namespaced_ingress.side_effect = Exception(
+            "forbidden"
+        )
+
+        urls = cluster_manager._discover_ingress_urls("default")
+
+        assert urls == []
+
+    def test_discover_route_urls_extracts_openshift_routes(self, cluster_manager):
+        """Test that OpenShift Routes are discovered correctly."""
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "my-route"},
+                    "spec": {
+                        "host": "route.apps.example.com",
+                        "path": "/health",
+                        "tls": {"termination": "edge"},
+                    },
+                }
+            ]
+        }
+
+        urls = cluster_manager._discover_route_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0]["name"] == "my-route"
+        assert urls[0]["url"] == "https://route.apps.example.com/health"
+
+    def test_discover_route_urls_uses_http_when_no_tls(self, cluster_manager):
+        """Test that Routes without TLS use http scheme."""
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "plain-route"},
+                    "spec": {"host": "plain.apps.example.com"},
+                }
+            ]
+        }
+
+        urls = cluster_manager._discover_route_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0]["url"] == "http://plain.apps.example.com/"
+
+    def test_discover_route_urls_graceful_when_crd_absent(self, cluster_manager):
+        """Test that missing Route CRD returns empty list without error."""
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.side_effect = (
+            Exception("the server doesn't have a resource type 'routes'")
+        )
+
+        urls = cluster_manager._discover_route_urls("default")
+
+        assert urls == []
+
+    def test_discover_health_check_urls_combines_ingresses_and_routes(
+        self, cluster_manager
+    ):
+        """Test that discover_health_check_urls aggregates from all namespaces."""
+        rule = self._make_rule("app.example.com", [self._make_path("/")])
+        ingress = self._make_ingress("web", [rule])
+        cluster_manager.networking_api.list_namespaced_ingress.return_value.items = [
+            ingress
+        ]
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.return_value = {
+            "items": [
+                {
+                    "metadata": {"name": "api-route"},
+                    "spec": {"host": "api.apps.example.com", "tls": {}},
+                }
+            ]
+        }
+
+        namespaces = [Namespace(name="default")]
+        urls = cluster_manager.discover_health_check_urls(namespaces)
+
+        assert len(urls) == 2
+        names = {u["name"] for u in urls}
+        assert "web-app.example.com" in names
+        assert "api-route" in names

--- a/tests/unit/utils/test_health_check_discovery.py
+++ b/tests/unit/utils/test_health_check_discovery.py
@@ -70,7 +70,7 @@ class TestHealthCheckDiscovery:
         urls = cluster_manager._discover_ingress_urls("default")
 
         assert len(urls) == 1
-        assert urls[0]["name"] == "my-ingress-app.example.com"
+        assert urls[0]["name"] == "my-ingress-app.example.com-api"
         assert urls[0]["url"] == "http://app.example.com/api"
 
     def test_discover_ingress_urls_uses_https_for_tls_hosts(self, cluster_manager):
@@ -193,5 +193,5 @@ class TestHealthCheckDiscovery:
 
         assert len(urls) == 2
         names = {u["name"] for u in urls}
-        assert "web-app.example.com" in names
+        assert "web-app.example.com-root" in names
         assert "api-route" in names

--- a/tests/unit/utils/test_health_check_discovery.py
+++ b/tests/unit/utils/test_health_check_discovery.py
@@ -187,6 +187,8 @@ class TestHealthCheckDiscovery:
                 }
             ]
         }
+        # No LoadBalancer services
+        cluster_manager.core_api.list_namespaced_service.return_value.items = []
 
         namespaces = [Namespace(name="default")]
         urls = cluster_manager.discover_health_check_urls(namespaces)
@@ -195,3 +197,109 @@ class TestHealthCheckDiscovery:
         names = {u["name"] for u in urls}
         assert "web-app.example.com-root" in names
         assert "api-route" in names
+
+
+class TestLoadBalancerDiscovery:
+    """Test LoadBalancer Service URL discovery."""
+
+    @pytest.fixture
+    def mock_krkn_k8s(self):
+        mock_k8s = Mock()
+        mock_k8s.apps_api = Mock()
+        mock_k8s.api_client = Mock()
+        mock_k8s.cli = Mock()
+        mock_k8s.custom_object_client = Mock()
+        mock_k8s.list_namespaces = Mock(return_value=["default"])
+        return mock_k8s
+
+    @pytest.fixture
+    def cluster_manager(self, mock_krkn_k8s):
+        with patch(
+            "krkn_ai.utils.cluster_manager.KrknKubernetes",
+            return_value=mock_krkn_k8s,
+        ):
+            with patch(
+                "krkn_ai.utils.cluster_manager.NetworkingV1Api"
+            ):
+                mgr = ClusterManager(kubeconfig="/tmp/test-kubeconfig")
+                return mgr
+
+    def _make_lb_service(self, name, ingress_entries, ports=None):
+        svc = Mock()
+        svc.metadata.name = name
+        svc.spec.type = "LoadBalancer"
+        svc.spec.ports = ports or []
+        if ingress_entries is not None:
+            svc.status.load_balancer.ingress = ingress_entries
+        else:
+            svc.status.load_balancer.ingress = None
+        return svc
+
+    def _make_ingress_entry(self, ip=None, hostname=None):
+        entry = Mock()
+        entry.ip = ip
+        entry.hostname = hostname
+        return entry
+
+    def _make_port(self, port):
+        p = Mock()
+        p.port = port
+        return p
+
+    def test_discover_loadbalancer_urls_with_ip(self, cluster_manager):
+        """Test LoadBalancer with IP address."""
+        svc = self._make_lb_service(
+            "my-lb", [self._make_ingress_entry(ip="1.2.3.4")],
+            ports=[self._make_port(80)]
+        )
+        cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
+
+        urls = cluster_manager._discover_loadbalancer_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0] == {"name": "my-lb", "url": "http://1.2.3.4"}
+
+    def test_discover_loadbalancer_urls_with_hostname(self, cluster_manager):
+        """Test LoadBalancer with hostname."""
+        svc = self._make_lb_service(
+            "aws-lb", [self._make_ingress_entry(hostname="abc.elb.amazonaws.com")],
+            ports=[self._make_port(80)]
+        )
+        cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
+
+        urls = cluster_manager._discover_loadbalancer_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0] == {"name": "aws-lb", "url": "http://abc.elb.amazonaws.com"}
+
+    def test_discover_loadbalancer_urls_https_on_port_443(self, cluster_manager):
+        """Test that port 443 triggers https scheme."""
+        svc = self._make_lb_service(
+            "secure-lb", [self._make_ingress_entry(ip="10.0.0.1")],
+            ports=[self._make_port(443)]
+        )
+        cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
+
+        urls = cluster_manager._discover_loadbalancer_urls("default")
+
+        assert len(urls) == 1
+        assert urls[0] == {"name": "secure-lb", "url": "https://10.0.0.1"}
+
+    def test_discover_loadbalancer_urls_empty_status(self, cluster_manager):
+        """Test LoadBalancer with no ingress status returns nothing."""
+        svc = self._make_lb_service("pending-lb", None)
+        cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
+
+        urls = cluster_manager._discover_loadbalancer_urls("default")
+
+        assert urls == []
+
+    def test_discover_loadbalancer_urls_api_error(self, cluster_manager):
+        """Test that API errors return empty list with warning."""
+        cluster_manager.core_api.list_namespaced_service.side_effect = Exception(
+            "forbidden"
+        )
+
+        urls = cluster_manager._discover_loadbalancer_urls("default")
+
+        assert urls == []


### PR DESCRIPTION
## Summary

Closes #150

Enriches `results.json` with five new data points that are already computed in the codebase but were not included in the unified JSON output:

### New fields

| Field | Type | Description |
|-------|------|-------------|
| `stopping_reason` | `string \| null` | Human-readable reason from `should_stop()` |
| `health_check_summary` | `object \| null` | Per-component min/max/avg response time, total/success/failure counts, success_rate |
| `slo_breakdown` | `object \| null` | Per-SLO id: avg_fitness_score, avg_weighted_score |
| `worst_scenarios` | `list` | Bottom-10 scenarios (mirrors existing top-10 best) |
| `summary.min_fitness_score` | `float` | Min fitness across all scenarios |

### Design decisions

- All new fields are optional/nullable: if data is unavailable, they are `null` or empty
- No breaking changes to existing `results.json` schema
- `stopping_reason` is persisted on `GeneticAlgorithm.stopping_reason` when `_check_and_stop()` fires, then passed to `JSONSummaryReporter`
- Health check summary aggregates across all scenarios in `seen_population`, grouping by component name
- SLO breakdown iterates `fitness_result.scores` across all scenarios, grouping by SLO id

### Testing

- 11 new unit tests covering all new code paths and edge cases
- Full test suite passes (261 tests, 0 failures)
- `ruff check` and `mypy` clean on all modified files

### Files changed

- `krkn_ai/algorithm/genetic.py`: store `stopping_reason` on instance, pass to reporter
- `krkn_ai/reporter/json_summary_reporter.py`: add new constructor param and 3 new builder methods
- `tests/unit/reporter/test_json_summary_reporter.py`: new dedicated test file