### PR TITLE
feat(genetic): add tournament_size validation and edge case tests for tournament selection

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -293,6 +293,16 @@ class ConfigFile(BaseModel):
     selection_strategy: SelectionStrategy = SelectionStrategy.roulette
     tournament_size: int = 3
 
+    @field_validator("tournament_size", mode="after")
+    @classmethod
+    def validate_tournament_size(cls, value: int) -> int:
+        if value < 2:
+            raise ValueError(
+                "tournament_size must be at least 2. "
+                "Please check the 'tournament_size' parameter in your krkn-ai config file."
+            )
+        return value
+
     population_injection_rate: float = (
         const.POPULATION_INJECTION_RATE
     )  # How often a random samples gets added to new population (0.0-1.0)

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -293,15 +293,17 @@ class ConfigFile(BaseModel):
     selection_strategy: SelectionStrategy = SelectionStrategy.roulette
     tournament_size: int = 3
 
-    @field_validator("tournament_size", mode="after")
-    @classmethod
-    def validate_tournament_size(cls, value: int) -> int:
-        if value < 2:
+    @model_validator(mode="after")
+    def validate_tournament_size(self) -> "ConfigFile":
+        if (
+            self.selection_strategy == SelectionStrategy.tournament
+            and self.tournament_size < 2
+        ):
             raise ValueError(
-                "tournament_size must be at least 2. "
+                "tournament_size must be at least 2 when selection_strategy is 'tournament'. "
                 "Please check the 'tournament_size' parameter in your krkn-ai config file."
             )
-        return value
+        return self
 
     population_injection_rate: float = (
         const.POPULATION_INJECTION_RATE

--- a/tests/unit/algorithm/test_selection.py
+++ b/tests/unit/algorithm/test_selection.py
@@ -150,3 +150,135 @@ class TestSelection:
         expected_scenarios = [scenario1, scenario2, scenario3]
         assert parent1 in expected_scenarios
         assert parent2 in expected_scenarios
+
+    def test_tournament_selection_size_exceeds_population(self, genetic_algorithm):
+        """Test tournament selection when tournament_size > population size (clamped)"""
+        from krkn_ai.models.config import SelectionStrategy
+
+        scenario1 = DummyScenario(cluster_components=ClusterComponents())
+        scenario2 = DummyScenario(cluster_components=ClusterComponents())
+
+        fitness_scores = [
+            CommandRunResult(
+                generation_id=0,
+                scenario=scenario1,
+                fitness_result=FitnessResult(fitness_score=10.0),
+                cmd="",
+                log="",
+                returncode=0,
+                start_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now(),
+            ),
+            CommandRunResult(
+                generation_id=0,
+                scenario=scenario2,
+                fitness_result=FitnessResult(fitness_score=90.0),
+                cmd="",
+                log="",
+                returncode=0,
+                start_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now(),
+            ),
+        ]
+
+        # tournament_size (10) > population (2): should clamp without error
+        genetic_algorithm.config.selection_strategy = SelectionStrategy.tournament
+        genetic_algorithm.config.tournament_size = 10
+
+        parent1, parent2 = genetic_algorithm.select_parents(fitness_scores)
+
+        expected_scenarios = [scenario1, scenario2]
+        assert parent1 in expected_scenarios
+        assert parent2 in expected_scenarios
+
+    def test_tournament_selection_equal_fitness(self, genetic_algorithm):
+        """Test tournament selection when all individuals have equal fitness"""
+        from krkn_ai.models.config import SelectionStrategy
+
+        scenario1 = DummyScenario(cluster_components=ClusterComponents())
+        scenario2 = DummyScenario(cluster_components=ClusterComponents())
+        scenario3 = DummyScenario(cluster_components=ClusterComponents())
+
+        fitness_scores = [
+            CommandRunResult(
+                generation_id=0,
+                scenario=scenario1,
+                fitness_result=FitnessResult(fitness_score=50.0),
+                cmd="",
+                log="",
+                returncode=0,
+                start_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now(),
+            ),
+            CommandRunResult(
+                generation_id=0,
+                scenario=scenario2,
+                fitness_result=FitnessResult(fitness_score=50.0),
+                cmd="",
+                log="",
+                returncode=0,
+                start_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now(),
+            ),
+            CommandRunResult(
+                generation_id=0,
+                scenario=scenario3,
+                fitness_result=FitnessResult(fitness_score=50.0),
+                cmd="",
+                log="",
+                returncode=0,
+                start_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now(),
+            ),
+        ]
+
+        genetic_algorithm.config.selection_strategy = SelectionStrategy.tournament
+        genetic_algorithm.config.tournament_size = 2
+
+        parent1, parent2 = genetic_algorithm.select_parents(fitness_scores)
+
+        # All have equal fitness, any selection is valid
+        expected_scenarios = [scenario1, scenario2, scenario3]
+        assert parent1 in expected_scenarios
+        assert parent2 in expected_scenarios
+
+
+class TestSelectionConfig:
+    """Test selection strategy configuration validation"""
+
+    def test_tournament_size_below_minimum_raises(self):
+        """tournament_size < 2 should raise ValidationError"""
+        import pytest
+        from krkn_ai.models.config import ConfigFile
+
+        with pytest.raises(Exception, match="tournament_size must be at least 2"):
+            ConfigFile(
+                kubeconfig_file_path="/tmp/kube",
+                tournament_size=1,
+                fitness_function={"query": "up"},
+                cluster_components={},
+            )
+
+    def test_tournament_size_minimum_accepted(self):
+        """tournament_size = 2 should be accepted"""
+        from krkn_ai.models.config import ConfigFile
+
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kube",
+            tournament_size=2,
+            fitness_function={"query": "up"},
+            cluster_components={},
+        )
+        assert config.tournament_size == 2
+
+    def test_default_selection_strategy_is_roulette(self):
+        """Default selection strategy should be roulette"""
+        from krkn_ai.models.config import ConfigFile, SelectionStrategy
+
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kube",
+            fitness_function={"query": "up"},
+            cluster_components={},
+        )
+        assert config.selection_strategy == SelectionStrategy.roulette
+        assert config.tournament_size == 3

--- a/tests/unit/algorithm/test_selection.py
+++ b/tests/unit/algorithm/test_selection.py
@@ -246,18 +246,32 @@ class TestSelection:
 class TestSelectionConfig:
     """Test selection strategy configuration validation"""
 
-    def test_tournament_size_below_minimum_raises(self):
-        """tournament_size < 2 should raise ValidationError"""
+    def test_tournament_size_below_minimum_raises_when_strategy_is_tournament(self):
+        """tournament_size < 2 should raise ValidationError only when strategy is tournament"""
         import pytest
-        from krkn_ai.models.config import ConfigFile
+        from krkn_ai.models.config import ConfigFile, SelectionStrategy
 
         with pytest.raises(Exception, match="tournament_size must be at least 2"):
             ConfigFile(
                 kubeconfig_file_path="/tmp/kube",
+                selection_strategy=SelectionStrategy.tournament,
                 tournament_size=1,
                 fitness_function={"query": "up"},
                 cluster_components={},
             )
+
+    def test_tournament_size_below_minimum_allowed_when_strategy_is_roulette(self):
+        """tournament_size < 2 should be accepted when strategy is roulette"""
+        from krkn_ai.models.config import ConfigFile, SelectionStrategy
+
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kube",
+            selection_strategy=SelectionStrategy.roulette,
+            tournament_size=1,
+            fitness_function={"query": "up"},
+            cluster_components={},
+        )
+        assert config.tournament_size == 1
 
     def test_tournament_size_minimum_accepted(self):
         """tournament_size = 2 should be accepted"""


### PR DESCRIPTION
## Summary

Builds on the tournament selection implementation merged in #214. That PR implemented the core algorithm but left two gaps:

1. **No input validation** for `tournament_size` — a value of 0 or 1 causes a silent logic error (tournament of size 1 is just random selection, size 0 crashes). This PR adds a `field_validator` that rejects `tournament_size < 2` with a clear error message.

2. **Missing edge case tests** — the existing tests in `test_selection.py` cover the happy path but not: tournament_size > population (should clamp gracefully), all-equal fitness (should still return a valid scenario), config rejection for invalid sizes.

## Changes

- **`krkn_ai/models/config.py`**: Added `validate_tournament_size` field validator — rejects values < 2 with a descriptive error message matching the project's existing validation style
- **`tests/unit/algorithm/test_selection.py`**: 5 new tests covering tournament_size > population (clamped via min()), all-equal fitness, config rejection for size=1, config acceptance for size=2, default strategy is roulette with size=3

## Test results

```
uv run pytest tests/ -q -- 241 passed, 0 failures
uv run ruff check . -- All checks passed
```