### PR TITLE
fix(discover): correct PromQL selector construction in suggest_fitness_queries

### DIFF
--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -1,4 +1,5 @@
 import os
+import re
 from typing import List
 from kubernetes import client, config
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
@@ -17,33 +18,62 @@ def _build_selector(*filters: str) -> str:
     return "{" + ",".join(parts) + "}"
 
 
-def suggest_fitness_queries(namespaces: List[str]) -> List[str]:
+def suggest_fitness_queries(
+    prom_client: KrknPrometheus, namespaces: List[str]
+) -> List[str]:
     """
-    Return a list of suggested PromQL queries scoped to the given namespaces.
+    Return PromQL queries scoped to *namespaces* for metrics that actually
+    exist in Prometheus.
 
-    When *namespaces* is empty the queries cover all namespaces.  The function
-    never produces selectors with a leading comma (e.g. ``{,phase!="Running"}``),
-    which would be invalid PromQL.
+    Queries are only included when the backing metric is present in the
+    cluster's Prometheus instance, preventing suggestions that would return
+    no data.  If the metric list cannot be fetched for any reason the
+    function returns ``[]`` rather than raising.
 
     Args:
-        namespaces: Namespace names to scope the queries.  Pass ``[]`` for
-                    cluster-wide queries.
+        prom_client: Live Prometheus client (``KrknPrometheus``).
+        namespaces:  Namespace names to scope the queries.  Pass ``[]`` for
+                     cluster-wide queries.
 
     Returns:
         List of PromQL query strings suitable for use as fitness functions.
     """
-    ns_filter = f'namespace=~"{"|".join(namespaces)}"' if namespaces else ""
+    try:
+        available: List[str] = prom_client.prom_cli.all_metrics()
+    except Exception:
+        logger.warning(
+            "Unable to fetch metric list from Prometheus; skipping suggestions"
+        )
+        return []
+
+    clean = [re.escape(ns.strip()) for ns in namespaces if ns.strip()]
+    if len(clean) == 1:
+        ns_filter = f'namespace="{clean[0]}"'
+    elif len(clean) > 1:
+        ns_filter = f'namespace=~"^({"|".join(clean)})$"'
+    else:
+        ns_filter = ""
 
     restarts_sel = _build_selector(ns_filter)
     non_running_sel = _build_selector(ns_filter, 'phase!="Running"')
     waiting_sel = _build_selector(ns_filter)
 
-    queries = [
-        f"sum(kube_pod_container_status_restarts_total{restarts_sel})",
-        f"count(kube_pod_status_phase{non_running_sel} or vector(0)) - 1",
-        f"sum(kube_pod_container_status_waiting{waiting_sel})",
+    candidates = [
+        (
+            "kube_pod_container_status_restarts_total",
+            f"sum(kube_pod_container_status_restarts_total{restarts_sel})",
+        ),
+        (
+            "kube_pod_status_phase",
+            f"count(kube_pod_status_phase{non_running_sel} == 1)",
+        ),
+        (
+            "kube_pod_container_status_waiting",
+            f"sum(kube_pod_container_status_waiting{waiting_sel})",
+        ),
     ]
-    return queries
+
+    return [query for metric, query in candidates if metric in available]
 
 
 def is_openshift(kubeconfig: str) -> bool:

--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 from kubernetes import client, config
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
 from krkn_ai.utils.fs import env_is_truthy
@@ -6,6 +7,43 @@ from krkn_ai.utils.logger import get_logger
 from krkn_ai.models.custom_errors import PrometheusConnectionError
 
 logger = get_logger(__name__)
+
+
+def _build_selector(*filters: str) -> str:
+    """Build a PromQL label selector, omitting empty filter strings."""
+    parts = [f for f in filters if f]
+    if not parts:
+        return ""
+    return "{" + ",".join(parts) + "}"
+
+
+def suggest_fitness_queries(namespaces: List[str]) -> List[str]:
+    """
+    Return a list of suggested PromQL queries scoped to the given namespaces.
+
+    When *namespaces* is empty the queries cover all namespaces.  The function
+    never produces selectors with a leading comma (e.g. ``{,phase!="Running"}``),
+    which would be invalid PromQL.
+
+    Args:
+        namespaces: Namespace names to scope the queries.  Pass ``[]`` for
+                    cluster-wide queries.
+
+    Returns:
+        List of PromQL query strings suitable for use as fitness functions.
+    """
+    ns_filter = f'namespace=~"{"|".join(namespaces)}"' if namespaces else ""
+
+    restarts_sel = _build_selector(ns_filter)
+    non_running_sel = _build_selector(ns_filter, 'phase!="Running"')
+    waiting_sel = _build_selector(ns_filter)
+
+    queries = [
+        f"sum(kube_pod_container_status_restarts_total{restarts_sel})",
+        f"count(kube_pod_status_phase{non_running_sel} or vector(0)) - 1",
+        f"sum(kube_pod_container_status_waiting{waiting_sel})",
+    ]
+    return queries
 
 
 def is_openshift(kubeconfig: str) -> bool:

--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -3,6 +3,7 @@ Unit tests for Prometheus utility functions and client creation logic using Kube
 """
 
 import os
+import re
 import pytest
 from unittest.mock import Mock, patch
 from krkn_ai.utils.prometheus import (
@@ -150,24 +151,66 @@ class TestPrometheusUtils:
 class TestSuggestFitnessQueries:
     """Tests for suggest_fitness_queries()."""
 
-    def test_empty_namespaces_no_leading_comma(self):
-        """Every query must be valid PromQL when no namespaces are given."""
-        queries = suggest_fitness_queries([])
-        assert queries, "Expected at least one suggested query"
+    ALL_METRICS = [
+        "kube_pod_container_status_restarts_total",
+        "kube_pod_status_phase",
+        "kube_pod_container_status_waiting",
+    ]
+
+    def _make_client(self, metrics=None, raises=False):
+        prom_cli = Mock()
+        if raises:
+            prom_cli.all_metrics.side_effect = Exception("connection refused")
+        else:
+            prom_cli.all_metrics.return_value = (
+                metrics if metrics is not None else self.ALL_METRICS
+            )
+        client = Mock()
+        client.prom_cli = prom_cli
+        return client
+
+    def test_all_metrics_empty_namespaces_no_leading_comma(self):
+        """All 3 queries returned; no {, in any selector when namespaces=[]."""
+        queries = suggest_fitness_queries(self._make_client(), [])
+        assert len(queries) == 3
         for q in queries:
             assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
 
-    def test_namespaces_scoped_queries(self):
-        """Queries should contain a namespace regex selector when namespaces provided."""
-        queries = suggest_fitness_queries(["default", "kube-system"])
+    def test_all_metrics_namespaces_scoped(self):
+        """Queries contain anchored namespace=~'^(...)$' filter when multiple namespaces given."""
+        namespaces = ["default", "kube-system"]
+        queries = suggest_fitness_queries(self._make_client(), namespaces)
+        assert len(queries) == 3
         for q in queries:
             assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
-        scoped = [q for q in queries if 'namespace=~"default|kube-system"' in q]
-        assert scoped, "Expected at least one namespace-scoped query"
+        escaped = "|".join(re.escape(ns) for ns in namespaces)
+        expected = f'namespace=~"^({escaped})$"'
+        assert any(expected in q for q in queries)
 
-    def test_single_namespace(self):
-        """Single-namespace list should produce valid PromQL selectors."""
-        queries = suggest_fitness_queries(["my-app"])
-        for q in queries:
-            assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
-        assert any('namespace=~"my-app"' in q for q in queries)
+    def test_single_namespace_exact_match(self):
+        """Single namespace produces an exact-match selector, not a regex."""
+        queries = suggest_fitness_queries(self._make_client(), ["default"])
+        assert len(queries) == 3
+        expected = f'namespace="{re.escape("default")}"'
+        assert all(expected in q for q in queries)
+        assert all("=~" not in q for q in queries)
+
+    def test_namespace_metachar_escaped(self):
+        """Namespace names with regex metacharacters are escaped before use."""
+        queries = suggest_fitness_queries(self._make_client(), ["team[1]"])
+        assert len(queries) == 3
+        expected = f'namespace="{re.escape("team[1]")}"'
+        assert all(expected in q for q in queries)
+
+    def test_only_one_metric_available(self):
+        """Only the query whose metric is present in Prometheus is returned."""
+        queries = suggest_fitness_queries(
+            self._make_client(metrics=["kube_pod_status_phase"]), []
+        )
+        assert len(queries) == 1
+        assert "kube_pod_status_phase" in queries[0]
+
+    def test_all_metrics_raises_returns_empty(self):
+        """Returns [] without raising when all_metrics() fails."""
+        queries = suggest_fitness_queries(self._make_client(raises=True), [])
+        assert queries == []

--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -5,7 +5,11 @@ Unit tests for Prometheus utility functions and client creation logic using Kube
 import os
 import pytest
 from unittest.mock import Mock, patch
-from krkn_ai.utils.prometheus import is_openshift, create_prometheus_client
+from krkn_ai.utils.prometheus import (
+    is_openshift,
+    create_prometheus_client,
+    suggest_fitness_queries,
+)
 from krkn_ai.models.custom_errors import PrometheusConnectionError
 
 
@@ -141,3 +145,29 @@ class TestPrometheusUtils:
             create_prometheus_client("/tmp/test-kubeconfig")
             args, _ = mock_prom_class.call_args
             assert args[0] == "https://my-prom"
+
+
+class TestSuggestFitnessQueries:
+    """Tests for suggest_fitness_queries()."""
+
+    def test_empty_namespaces_no_leading_comma(self):
+        """Every query must be valid PromQL when no namespaces are given."""
+        queries = suggest_fitness_queries([])
+        assert queries, "Expected at least one suggested query"
+        for q in queries:
+            assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
+
+    def test_namespaces_scoped_queries(self):
+        """Queries should contain a namespace regex selector when namespaces provided."""
+        queries = suggest_fitness_queries(["default", "kube-system"])
+        for q in queries:
+            assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
+        scoped = [q for q in queries if 'namespace=~"default|kube-system"' in q]
+        assert scoped, "Expected at least one namespace-scoped query"
+
+    def test_single_namespace(self):
+        """Single-namespace list should produce valid PromQL selectors."""
+        queries = suggest_fitness_queries(["my-app"])
+        for q in queries:
+            assert "{," not in q, f"Invalid selector with leading comma in: {q!r}"
+        assert any('namespace=~"my-app"' in q for q in queries)


### PR DESCRIPTION
## Description

Implements `suggest_fitness_queries()` for Bullet 2 of #188, with correct label selector construction.

**Problem:** Constructing PromQL selectors by direct string-interpolation of `ns_filter` produces invalid selectors like `{,phase!="Running"}` when namespaces is empty - a leading comma that breaks PromQL parsing at runtime.

**Fix:** Added `_build_selector(*filters)` helper that joins only non-empty matchers with commas and wraps the result in `{}`. Selectors degrade cleanly when namespace list is empty.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

Added `TestSuggestFitnessQueries` with three tests:
- Empty namespace list → no `{,` in any returned query
- Multiple namespaces → queries contain correct `namespace=~"..."` filter  
- Single namespace → same

Note: pytest segfaults on this machine due to a pre-existing numpy/Windows incompatibility unrelated to this change. Ruff passes clean. Logic manually verified. CI will confirm.

**Update:** Following review feedback, also added:
- Dynamic metric inspection via `prom_client.prom_cli.all_metrics()`
- `re.escape()` on namespace strings with anchored regex for multi-namespace 
  and exact match for single namespace
- 3 additional tests (6 total)

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] My changes generate no new warnings or errors

Ref #188