### PR TITLE
fix(scenario): correct inverted container_name logic and disruption_count bound in ContainerScenario

### DIFF
--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -74,8 +74,9 @@ class ContainerScenario(Scenario):
         ]
         self.disruption_count.value = rng.randint(1, max(1, len(matching_pods)))
 
-        # Randomly decide whether to target all containers or a specific one
-        if rng.choice([True, False]):
+        # Randomly decide whether to target all containers or a specific one.
+        # Always use ".*" when the pod has no containers to avoid IndexError.
+        if not pod.containers or rng.choice([True, False]):
             self.container_name.value = ".*"
         else:
             self.container_name.value = rng.choice([x.name for x in pod.containers])

--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -66,13 +66,18 @@ class ContainerScenario(Scenario):
         # pod_label is a string of the form "key=value"
         self.label_selector.value = "{}={}".format(label, labels[label])
 
-        self.disruption_count.value = rng.randint(1, len(pod.containers))
+        # Count pods matching the selected label in this namespace
+        matching_pods = [
+            p
+            for p in namespace.pods
+            if label in p.labels and p.labels[label] == labels[label]
+        ]
+        self.disruption_count.value = rng.randint(1, max(1, len(matching_pods)))
 
-        if self.disruption_count.value == 1:
-            # TODO: Verify whether we need to keep it empty or use regex pattern to match all container
+        # Randomly decide whether to target all containers or a specific one
+        if rng.choice([True, False]):
             self.container_name.value = ".*"
         else:
-            # Select specific container to kill in the pod
             self.container_name.value = rng.choice([x.name for x in pod.containers])
 
         self.action.value = rng.choice(["1", "9"])

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -92,7 +92,6 @@ class TestContainerScenario:
         assert scenario.name == "container-scenarios"
         assert scenario.namespace.value == "test-ns"
         assert scenario.disruption_count.value >= 1
-        assert scenario.disruption_count.value <= len(pod.containers)
 
     def test_container_scenario_raises_error_when_no_pods_with_labels(self):
         """Test that ContainerScenario raises error when no pods have labels"""
@@ -104,6 +103,65 @@ class TestContainerScenario:
             ScenarioParameterInitError, match="No pods found with labels"
         ):
             ContainerScenario(cluster_components=cluster)
+
+    def test_container_name_is_valid_choice(self):
+        """Test that container_name is either '.*' or a valid container name"""
+        pod = Pod(
+            name="test-pod",
+            labels={"app": "web"},
+            containers=[
+                Container(name="nginx"),
+                Container(name="sidecar"),
+                Container(name="init"),
+            ],
+        )
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        valid_names = {".*", "nginx", "sidecar", "init"}
+        for _ in range(50):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.container_name.value in valid_names
+
+    def test_disruption_count_bounded_by_matching_pods(self):
+        """Test that disruption_count is bounded by number of pods matching the label"""
+        pods = [
+            Pod(
+                name=f"pod-{i}",
+                labels={"app": "web"},
+                containers=[Container(name="c1")],
+            )
+            for i in range(5)
+        ]
+        namespace = Namespace(name="test-ns", pods=pods)
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        for _ in range(50):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.disruption_count.value >= 1
+            assert scenario.disruption_count.value <= 5
+
+    def test_disruption_count_not_bounded_by_container_count(self):
+        """Test that disruption_count can exceed the number of containers in a pod"""
+        # 1 container per pod, but 3 pods matching the label
+        pods = [
+            Pod(
+                name=f"pod-{i}",
+                labels={"app": "web"},
+                containers=[Container(name="only-container")],
+            )
+            for i in range(3)
+        ]
+        namespace = Namespace(name="test-ns", pods=pods)
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        saw_gt_1 = False
+        for _ in range(50):
+            scenario = ContainerScenario(cluster_components=cluster)
+            if scenario.disruption_count.value > 1:
+                saw_gt_1 = True
+        # With 3 matching pods, disruption_count can be 2 or 3
+        assert saw_gt_1
 
 
 class TestNodeCPUHogScenario:

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -163,6 +163,16 @@ class TestContainerScenario:
         # With 3 matching pods, disruption_count can be 2 or 3
         assert saw_gt_1
 
+    def test_container_name_uses_wildcard_when_pod_has_no_containers(self):
+        """Test that container_name defaults to '.*' when pod has no containers (no IndexError)."""
+        pod = Pod(name="empty-pod", labels={"app": "web"}, containers=[])
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        for _ in range(20):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.container_name.value == ".*"
+
 
 class TestNodeCPUHogScenario:
     """Test NodeCPUHogScenario class"""


### PR DESCRIPTION
Fixes #277

## Problem

`ContainerScenario.mutate()` had two bugs:

1. **Inverted container_name logic**: when `disruption_count == 1`, it set `container_name = ".*"` (targeting ALL containers). When `disruption_count > 1`, it picked a single specific container. This is backwards.

2. **Wrong disruption_count bound**: `disruption_count` was bounded by `len(pod.containers)` but it represents the number of pods to disrupt, not containers. It should be bounded by the number of pods matching the selected label in the namespace.

## Fix

- `container_name`: randomly choose between `".*"` (all containers) and a specific container name via `rng.choice()`, independent of `disruption_count`.
- `disruption_count`: bounded by the count of pods in the namespace that match the selected label selector.

## Tests

Added 3 new unit tests:
- `test_container_name_is_valid_choice`: verifies container_name is always either `".*"` or a valid container name from the pod
- `test_disruption_count_bounded_by_matching_pods`: verifies the upper bound is the number of matching pods
- `test_disruption_count_not_bounded_by_container_count`: verifies disruption_count can exceed the number of containers in a single pod

All 239 tests pass. Ruff check and format clean.