### PR TITLE
fix(health_check): replace early return with continue in summarize_response_time loop

### DIFF
--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -138,7 +138,7 @@ class HealthCheckWatcher:
     ) -> float:
         score: float = 0.0
         total = 0
-        for _, results in health_check_results.items():
+        for url, results in health_check_results.items():
             response_times = []
             for result in results:
                 if result.success:
@@ -146,8 +146,10 @@ class HealthCheckWatcher:
 
             if len(response_times) < 4:  # Not enough data to calculate outliers
                 logger.debug(
-                    f"Skipping URL with insufficient data points "
-                    f"({len(response_times)} < 4)"
+                    "Skipping response time outlier calculation for %s "
+                    "(%d successful checks, need at least 4)",
+                    url,
+                    len(response_times),
                 )
                 continue
 

--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -145,7 +145,11 @@ class HealthCheckWatcher:
                     response_times.append(result.response_time)
 
             if len(response_times) < 4:  # Not enough data to calculate outliers
-                return 0
+                logger.debug(
+                    f"Skipping URL with insufficient data points "
+                    f"({len(response_times)} < 4)"
+                )
+                continue
 
             q1 = np.percentile(response_times, 25)
             q3 = np.percentile(response_times, 75)

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -236,6 +236,67 @@ class TestHealthCheckWatcherResults:
                 assert result.error is not None
 
 
+class TestSummarizeResponseTimeContinue:
+    """Regression tests for issue #259: continue instead of early return"""
+
+    def test_skips_insufficient_url_processes_remaining(self):
+        """First URL has <4 data points, second has outliers -> score > 0"""
+        config = HealthCheckConfig(applications=[])
+        watcher = HealthCheckWatcher(config)
+
+        results = {
+            "http://short.example.com": [
+                HealthCheckResult(
+                    name="short", response_time=0.1, status_code=200, success=True
+                ),
+            ],
+            "http://long.example.com": [
+                HealthCheckResult(
+                    name="long", response_time=0.1, status_code=200, success=True
+                ),
+                HealthCheckResult(
+                    name="long", response_time=0.12, status_code=200, success=True
+                ),
+                HealthCheckResult(
+                    name="long", response_time=0.11, status_code=200, success=True
+                ),
+                HealthCheckResult(
+                    name="long", response_time=0.13, status_code=200, success=True
+                ),
+                HealthCheckResult(
+                    name="long", response_time=5.0, status_code=200, success=True
+                ),
+            ],
+        }
+
+        score = watcher.summarize_response_time(results)
+        assert score > 0
+
+    def test_all_urls_insufficient_returns_zero(self):
+        """All URLs have <4 data points -> returns 0.0"""
+        config = HealthCheckConfig(applications=[])
+        watcher = HealthCheckWatcher(config)
+
+        results = {
+            "http://a.example.com": [
+                HealthCheckResult(
+                    name="a", response_time=0.1, status_code=200, success=True
+                ),
+            ],
+            "http://b.example.com": [
+                HealthCheckResult(
+                    name="b", response_time=0.2, status_code=200, success=True
+                ),
+                HealthCheckResult(
+                    name="b", response_time=0.3, status_code=200, success=True
+                ),
+            ],
+        }
+
+        score = watcher.summarize_response_time(results)
+        assert score == 0.0
+
+
 class TestHealthCheckWatcherHeaders:
     """Test header merging and env-var resolution"""
 


### PR DESCRIPTION
Fixes #259

## Problem

`summarize_response_time()` in `health_check_watcher.py` had `return 0` inside the `for` loop iterating over URLs. When any URL had fewer than 4 data points, the method exited entirely instead of skipping that URL, silently discarding outlier data from all remaining URLs.

## Fix

- Replaced `return 0` with `continue` so the loop skips URLs with insufficient data and processes the rest.
- Added `logger.debug()` when skipping a URL for observability.
- Added two regression tests:
  1. Multi-URL where first URL has <4 checks but second has outliers: score > 0
  2. All URLs insufficient: returns 0.0

## Verification

- `ruff check` and `ruff format`: clean
- Full test suite: all 241 tests pass

Signed-off-by: Md Thoriqul Islam Thonmay <thonmay.work@gmail.com>