### PR TITLE
Validate range-mode fitness queries before execution

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -121,6 +121,18 @@ class SelectionStrategy(str, Enum):
 auto_id = id_generator()
 
 
+def _validate_fitness_query_range_token(
+    query: str, fitness_type: FitnessFunctionType
+) -> None:
+    if fitness_type == FitnessFunctionType.range and "$range$" not in query:
+        raise ValueError("Range fitness functions must include '$range$' in query.")
+    if fitness_type != FitnessFunctionType.range and "$range$" in query:
+        raise ValueError(
+            "Fitness query includes '$range$' but type is not 'range'. "
+            "Set type to 'range' or remove '$range$'."
+        )
+
+
 class FitnessFunctionItem(BaseModel):
     id: int = Field(default_factory=lambda: next(auto_id))  # Auto-increment ID
     query: str  # PromQL
@@ -133,6 +145,11 @@ class FitnessFunctionItem(BaseModel):
         if value < 0 or value > 1:
             raise ValueError(f"{value} is outside the range [0.0, 1.0]")
         return value
+
+    @model_validator(mode="after")
+    def check_range_query_has_range_token(self):
+        _validate_fitness_query_range_token(self.query, self.type)
+        return self
 
 
 class FitnessFunction(BaseModel):
@@ -150,6 +167,8 @@ class FitnessFunction(BaseModel):
             raise ValueError(
                 "Please define at least one fitness function in query or items."
             )
+        if self.query is not None:
+            _validate_fitness_query_range_token(self.query, self.type)
         return self
 
 

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -72,7 +72,7 @@ class TestConfigFile:
             namespaces=[Namespace(name="test-ns")], nodes=[Node(name="test-node")]
         )
         fitness = FitnessFunction(
-            query="up{job='test'}",
+            query="avg_over_time(up{job='test'}[$range$])",
             type=FitnessFunctionType.range,
             include_krkn_failure=False,
         )
@@ -134,19 +134,53 @@ class TestFitnessFunction:
         fitness_items = FitnessFunction(
             items=[
                 FitnessFunctionItem(
-                    query="cpu_usage", type=FitnessFunctionType.range, weight=0.5
+                    query="cpu_usage[$range$]",
+                    type=FitnessFunctionType.range,
+                    weight=0.5,
                 ),
                 FitnessFunctionItem(query="memory_usage", weight=0.3),
             ]
         )
         assert len(fitness_items.items) == 2
-        assert fitness_items.items[0].query == "cpu_usage"
+        assert fitness_items.items[0].query == "cpu_usage[$range$]"
         assert fitness_items.items[0].weight == 0.5
 
     def test_fitness_function_requires_query_or_items(self):
         """Test that FitnessFunction requires at least query or items"""
         with pytest.raises(ValidationError, match="at least one fitness function"):
             FitnessFunction()
+
+    def test_range_fitness_function_requires_range_token(self):
+        """Test range fitness query must declare the dynamic range placeholder"""
+        with pytest.raises(ValidationError, match=r"\$range\$"):
+            FitnessFunction(
+                query="max_over_time(container_cpu_usage_seconds_total[5m])",
+                type=FitnessFunctionType.range,
+            )
+
+    def test_range_fitness_function_item_requires_range_token(self):
+        """Test range fitness items must declare the dynamic range placeholder"""
+        with pytest.raises(ValidationError, match=r"\$range\$"):
+            FitnessFunctionItem(
+                query="max_over_time(container_cpu_usage_seconds_total[5m])",
+                type=FitnessFunctionType.range,
+            )
+
+    def test_point_fitness_function_rejects_range_token(self):
+        """Test point fitness query rejects the dynamic range placeholder"""
+        with pytest.raises(ValidationError, match="type is not 'range'"):
+            FitnessFunction(
+                query="max_over_time(container_cpu_usage_seconds_total[$range$])",
+                type=FitnessFunctionType.point,
+            )
+
+    def test_point_fitness_function_item_rejects_range_token(self):
+        """Test point fitness items reject the dynamic range placeholder"""
+        with pytest.raises(ValidationError, match="type is not 'range'"):
+            FitnessFunctionItem(
+                query="max_over_time(container_cpu_usage_seconds_total[$range$])",
+                type=FitnessFunctionType.point,
+            )
 
     def test_fitness_function_item_weight_validation(self):
         """Test FitnessFunctionItem weight must be between 0 and 1"""


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

Range-mode fitness queries were allowed to run even when the query did not include the `$range$` placeholder. In that case, `krkn-ai` only logged a warning inside the runner and still sent the query to Prometheus. That could produce a valid-looking but incorrect fitness score, which is hard for users to notice during a run.

This PR moves that check to config validation so invalid range fitness definitions fail fast before the GA run starts.

This PR makes the behavior safer by:

- Requiring `$range$` in top-level `fitness_function.query` when `type: range`
- Applying the same validation to weighted `fitness_function.items`
- Keeping the runner-side warning as a defensive fallback for direct method calls
- Adding regression tests for both top-level and item-based range fitness configs

# Documentation

- [ ] Is documentation needed for this update?

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Unit test added for the changed behavior
- [x] Changes are consistent with the project's code style
- [x] Existing tests pass

# Testing performed

```bash
./.venv/bin/pytest tests/unit/models/test_config.py -q
./.venv/bin/pytest -q
./.venv/bin/ruff check .
./.venv/bin/ruff format --check .
./.venv/bin/mypy --config-file mypy.ini krkn_ai
```
<img width="1470" height="495" alt="image" src="https://github.com/user-attachments/assets/84a39bad-5106-4cdb-bdf7-0a0cb61330cf" />