### PR TITLE
fix: remove global root logger level override to allow third-party logs

### DIFF
--- a/krkn_ai/utils/logger.py
+++ b/krkn_ai/utils/logger.py
@@ -23,9 +23,6 @@ def init_logger(output_dir: Optional[str] = None, verbose: bool = False):
     parent_name = "krkn-ai"
     parent = logging.getLogger(parent_name)
 
-    # Set root logger to critical level to avoid logging to console
-    logging.getLogger().setLevel(logging.CRITICAL)
-
     # Avoid re-adding handlers if already configured
     if parent.handlers:
         _LOGGER_INITIALIZED = True


### PR DESCRIPTION
## Summary
This PR removes the invasive global root logger configuration in `init_logger` that was suppressing diagnostic output from third-party libraries.

## Rationale
Currently, `krkn_ai/utils/logger.py` sets the root logger level to `CRITICAL`. This is problematic because:
1. It silences all `INFO`, `DEBUG`, and `WARNING` logs from critical dependencies like `kubernetes`, `urllib3`, and `requests`.
2. It makes it impossible to debug connection issues, API timeouts, or SSL errors occurring within the underlying cluster communication layers.
3. It interferes with the logging configuration of any application that imports `krkn-ai`.

By removing this override, the logging system follows standard Python practices, allowing `krkn-ai` to maintain its own loggers while letting the global environment manage root logging.

## Changes
- **Modified:** `krkn_ai/utils/logger.py`
- **Action:** Deleted `logging.getLogger().setLevel(logging.CRITICAL)`.

## Verification Results
- [x] Verified that `krkn-ai` loggers still initialize correctly and output to the console/file as configured.
- [x] Confirmed that third-party logs (e.g., `urllib3` connection pools) are now visible when running in verbose mode.
- [x] Ran existing unit tests to ensure no regressions in logging utility functions.

## Related Issue
Fixes #290 
