### PR TITLE
fix(runner): handle FileNotFoundError in binary availability check

### DIFF
--- a/krkn_ai/utils/__init__.py
+++ b/krkn_ai/utils/__init__.py
@@ -27,9 +27,17 @@ def run_shell(command, do_not_log=False, timeout=None):
     command = shlex.split(command)
     logger.debug("Running command: %s", command[0])
 
-    process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
+    try:
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
+    except OSError as e:
+        if not do_not_log:
+            logger.error("Failed to execute '%s': %s", command[0], e)
+        else:
+            logger.debug("Failed to execute '%s': %s", command[0], e)
+        return "", 127
+
 
     output_lines = []
 

--- a/tests/unit/utils/test_run_shell.py
+++ b/tests/unit/utils/test_run_shell.py
@@ -3,6 +3,7 @@ run_shell unit tests
 """
 
 import pytest
+from unittest.mock import patch
 
 from krkn_ai.models.custom_errors import ShellCommandTimeoutError
 from krkn_ai.utils import run_shell
@@ -14,3 +15,19 @@ class TestRunShell:
     def test_timeout_raises_shell_command_timeout_error(self):
         with pytest.raises(ShellCommandTimeoutError):
             run_shell("sleep 10", timeout=5)
+
+    @patch("krkn_ai.utils.subprocess.Popen")
+    def test_oserror_returns_empty_string_and_127(self, mock_popen):
+        """Test that run_shell catches OSError (like FileNotFoundError) and returns empty string and 127"""
+        mock_popen.side_effect = FileNotFoundError("Mocked file not found error")
+        logs, returncode = run_shell("krknctl --version")
+        assert returncode == 127
+        assert logs == ""
+
+    @patch("krkn_ai.utils.subprocess.Popen")
+    def test_permission_error_returns_empty_string_and_127(self, mock_popen):
+        """Test that run_shell catches OSError (like PermissionError) and returns empty string and 127"""
+        mock_popen.side_effect = PermissionError("Mocked permission error")
+        logs, returncode = run_shell("podman --version")
+        assert returncode == 127
+        assert logs == ""


### PR DESCRIPTION
This PR fixes a critical crash during the Krkn-AI startup process. The KrknRunner was attempting to check for the availability of podman and krknctl by running their version commands. If a binary was missing from the system's PATH, the subprocess call would raise an unhandled FileNotFoundError, causing the entire application to terminate with a traceback.
Fixes #287 
<img width="237" height="596" alt="Screenshot 2026-05-14 at 1 51 56 PM" src="https://github.com/user-attachments/assets/67e7bf87-8209-406e-95ed-f0359257fbea" />
