### PR TITLE
fix: handle None config when yaml file is empty

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -110,7 +110,7 @@ def run(
     except KeyError as err:
         logger.error("Unable to parse config file due to missing key: %s", err)
         exit(1)
-    except ValidationError as err:
+    except (ValueError, ValidationError) as err:
         logger.error("Unable to parse config file: %s", err)
         exit(1)
 

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -31,6 +31,15 @@ def read_config_from_file(
     """
     with open(file_path, "r", encoding="utf-8") as stream:
         config = yaml.safe_load(stream)
+    if config is None:
+        config = {}
+
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"Config file {file_path} must be a mapping (dictionary), "
+            f"but found {type(config).__name__}."
+        )
+
     if kubeconfig is not None and kubeconfig != "" and os.path.exists(kubeconfig):
         config["kubeconfig_file_path"] = kubeconfig
 
@@ -48,7 +57,8 @@ def read_config_from_file(
 
         # Replace parameter in health check url string
         for app in config.get("health_checks", {}).get("applications", []):
-            app["url"] = preprocess_param_string(app["url"], raw)
+            if "url" in app:
+                app["url"] = preprocess_param_string(app["url"], raw)
 
         # Replace parameter in elastic configuration
         if "elastic" in config and "server" in config["elastic"]:
@@ -76,7 +86,7 @@ def read_config_from_file(
 
         config["parameters"] = params
 
-    return ConfigFile(**config)
+    return ConfigFile.model_validate(config)
 
 
 def env_is_truthy(var: str):

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,6 +1,8 @@
 """Tests for utils/fs.py"""
 
+import pytest
 import yaml
+from pydantic import ValidationError
 
 from krkn_ai.utils.fs import read_config_from_file
 
@@ -108,3 +110,29 @@ class TestReadConfigFromFileHeaders:
         result = read_config_from_file(config_file, param=["KEY=value"])
         assert result.health_checks.headers is None
         assert result.health_checks.applications[0].headers is None
+
+
+class TestReadConfigValidation:
+    def test_read_config_empty_file(self, tmp_path):
+        """Empty YAML file should raise ValidationError from Pydantic (missing required fields)"""
+        config_file = str(tmp_path / "empty.yaml")
+        with open(config_file, "w") as f:
+            f.write("")
+        with pytest.raises(ValidationError):
+            read_config_from_file(config_file)
+
+    def test_read_config_non_dict_root(self, tmp_path):
+        """YAML with non-dict root (e.g. list) should raise ValueError"""
+        config_file = str(tmp_path / "list.yaml")
+        with open(config_file, "w") as f:
+            f.write("- item1\n- item2")
+        with pytest.raises(ValueError, match="must be a mapping"):
+            read_config_from_file(config_file)
+
+    def test_read_config_string_root(self, tmp_path):
+        """YAML with string root should raise ValueError"""
+        config_file = str(tmp_path / "string.yaml")
+        with open(config_file, "w") as f:
+            f.write("just a string")
+        with pytest.raises(ValueError, match="must be a mapping"):
+            read_config_from_file(config_file)


### PR DESCRIPTION
## Problem
If a user provides an empty configuration file, `yaml.safe_load()` 
returns `None`. The subsequent line attempts to assign a key to this 
`None` object, raising:
`TypeError: 'NoneType' object does not support item assignment`

## Solution
Added a `None` check immediately after `yaml.safe_load()`. If the 
result is `None`, it is replaced with an empty dict `{}`, allowing 
Pydantic validation to handle the missing fields gracefully.

## Testing
- `ruff check .` ✅
- `ruff format .` ✅
- `mypy --config-file mypy.ini krkn_ai` ✅
- `pre-commit run --all-files` ✅
