### PR TITLE
fix: increment self.completed_generations in simulate loop for accurate reports

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -193,6 +193,7 @@ class GeneticAlgorithm:
 
             # Increment generation counter after evaluation
             cur_generation += 1
+            self.completed_generations = cur_generation
 
             # Check stopping criteria after fitness evaluation (for fitness threshold, saturation, and exploration)
             elapsed_after_eval = time.time() - start_time


### PR DESCRIPTION
## Problem
`self.completed_generations` is initialized to 0 in `__init__` and 
passed to the final `JSONSummaryReporter`. However, only the local 
variable `cur_generation` is incremented inside the `simulate()` loop.
`self.completed_generations` is never updated, causing all run 
summary reports to incorrectly show 0 completed generations.

## Solution
Added `self.completed_generations = cur_generation` immediately after 
`cur_generation += 1` inside the simulate loop, so the instance 
variable stays in sync and reports reflect the actual number of 
completed generations.

## Testing
- `ruff check .` ✅
- `ruff format .` ✅
- `mypy --config-file mypy.ini krkn_ai` ✅
- `pre-commit run --all-files` ✅