### PR TITLE
fix: handle non-string boolean input in is_truthy function

### DIFF
--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -79,7 +79,7 @@ def read_config_from_file(
     return ConfigFile(**config)
 
 
-def env_is_truthy(var: str):
+def env_is_truthy(var: str) -> bool:
     """
     Checks whether a environment variable is set to truthy value.
     """
@@ -87,11 +87,11 @@ def env_is_truthy(var: str):
     return is_truthy(value)
 
 
-def is_truthy(value: str):
+def is_truthy(value: Union[str, bool, int]) -> bool:
     """
     Checks whether a value is set to truthy value.
     """
-    value = value.lower().strip()
+    value = str(value).lower().strip()
     return value in ["yes", "y", "true", "1"]
 
 


### PR DESCRIPTION
## Problem
The `is_truthy` function calls `.lower().strip()` directly on the 
input value. When YAML parses an unquoted boolean (e.g. `enable: true`),
Python receives a `bool` object. Calling `.lower()` on a `bool` raises:
`AttributeError: 'bool' object has no attribute 'lower'`

## Solution
Cast the input value to `str` before calling `.lower().strip()`. 
Updated the type hint from `str` to `Any` to reflect the actual 
accepted input types.

## Testing
- `ruff check .` ✅
- `ruff format .` ✅
- `mypy --config-file mypy.ini krkn_ai` ✅
- `pre-commit run --all-files` ✅