### PR TITLE
feat: pre-validate PromQL fitness queries before GA run

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -120,6 +120,9 @@ class GeneticAlgorithm:
         # logger.debug("--------------------------------------------------------")
         # logger.debug("%s", json.dumps(self.config.model_dump(), indent=2))
 
+    def validate_fitness_queries(self):
+        self.krkn_client.validate_fitness_queries()
+
     def simulate(self):
         try:
             results_path = os.path.join(self.output_dir, "results.json")

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -3,6 +3,7 @@ import json
 import datetime
 import tempfile
 import time
+from typing import Any, Optional
 
 from krkn_ai.chaos_engines.health_check_watcher import HealthCheckWatcher
 from krkn_ai.models.app import (
@@ -89,6 +90,75 @@ class KrknRunner:
         if podman_available:
             logger.debug("Using krknhub as runner.")
             return KrknRunnerType.HUB_RUNNER
+
+    def validate_fitness_queries(self, window_minutes: int = 5) -> None:
+        """Pre-flight check that active PromQL fitness queries return samples.
+
+        This verifies recent metric availability before the genetic algorithm
+        starts. It follows the same query/items precedence used during runtime
+        fitness calculation.
+
+        Args:
+            window_minutes: Size of the lookback window in minutes.
+
+        Raises:
+            FitnessFunctionCalculationError: If any active query returns no samples.
+        """
+        if env_is_truthy("MOCK_FITNESS"):
+            logger.info("MOCK_FITNESS is set, skipping fitness query validation.")
+            return
+
+        end = datetime.datetime.now()
+        start = end - datetime.timedelta(minutes=window_minutes)
+        fitness = self.config.fitness_function
+
+        if fitness.query is not None:
+            queries_to_check = [("query", fitness.query, fitness.type)]
+        else:
+            queries_to_check = [
+                (f"items[{item.id}]", item.query, item.type) for item in fitness.items
+            ]
+
+        for label, query, fitness_type in queries_to_check:
+            resolved = query
+            if fitness_type == FitnessFunctionType.range and "$range$" in resolved:
+                resolved = resolved.replace("$range$", f"{window_minutes}m")
+            query_description = f"query '{query}'"
+            if resolved != query:
+                query_description = f"query '{query}' (resolved to '{resolved}')"
+            try:
+                result = self.prom_client.process_prom_query_in_range(
+                    resolved,
+                    start_time=start,
+                    end_time=end,
+                    # krkn-lib maps granularity to the Prometheus query_range step in seconds.
+                    granularity=100,
+                )
+                if not self._has_prometheus_samples(result):
+                    raise FitnessFunctionCalculationError(
+                        f"Pre-flight validation failed for {label}: "
+                        f"{query_description} returned no samples. "
+                        f"Verify the metric exists in Prometheus."
+                    )
+            except FitnessFunctionCalculationError:
+                raise
+            except Exception as e:
+                raise FitnessFunctionCalculationError(
+                    f"Pre-flight validation failed for {label}: "
+                    f"{query_description} caused an error: {e}"
+                ) from e
+
+        logger.info(
+            "Fitness query validation passed (%d quer%s checked).",
+            len(queries_to_check),
+            "y" if len(queries_to_check) == 1 else "ies",
+        )
+
+    @staticmethod
+    def _has_prometheus_samples(result: Optional[list[dict[str, Any]]]) -> bool:
+        if not result:
+            return False
+        return any(series.get("values") for series in result)
 
     def run(self, scenario: BaseScenario, generation_id: int) -> CommandRunResult:
         logger.info("Running scenario: %s", scenario)

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -79,6 +79,12 @@ def main():
     help="Port to run Streamlit server on when monitoring is enabled.",
     default=8501,
 )
+@click.option(
+    "--validate-queries",
+    is_flag=True,
+    default=False,
+    help="Pre-validate PromQL fitness queries using a live Prometheus connection before running.",
+)
 @click.pass_context
 def run(
     ctx,
@@ -92,6 +98,7 @@ def run(
     verbose: int = 0,  # Default to INFO level
     monitoring: bool = False,
     port: int = 8501,
+    validate_queries: bool = False,
 ):
     run_uuid = str(uuid.uuid4())
     new_output_path = os.path.join(output, run_uuid)
@@ -154,6 +161,8 @@ def run(
                 format=format,
                 runner_type=enum_runner_type,
             )
+            if validate_queries:
+                genetic.validate_fitness_queries()
             genetic.simulate()
 
             genetic.save()

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -79,6 +79,25 @@ class TestGeneticAlgorithmInitialization:
                 )
                 assert ga.config.population_size == 6
 
+    def test_validate_fitness_queries_delegates_to_runner(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test query validation is explicit and delegated to KrknRunner"""
+        with patch("krkn_ai.algorithm.genetic.KrknRunner") as mock_runner_class:
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+                mock_runner = Mock()
+                mock_runner_class.return_value = mock_runner
+
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                ga.validate_fitness_queries()
+
+                mock_runner.validate_fitness_queries.assert_called_once_with()
+
 
 class TestGeneticAlgorithmCoreMethods:
     """Test GeneticAlgorithm core methods"""

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -11,6 +11,7 @@ from krkn_ai.chaos_engines.krkn_runner import KrknRunner
 from krkn_ai.models.app import KrknRunnerType
 from krkn_ai.models.config import (
     FitnessFunction,
+    FitnessFunctionItem,
     FitnessFunctionType,
     HealthCheckConfig,
 )
@@ -749,3 +750,249 @@ class TestCalculateFitnessValueRetries:
             # Each retry calls calculate_point_fitness which calls _query_prometheus_single_point
             # for the start point. The guard fails immediately, so 1 Prometheus call per retry = 3 total.
             assert mock_prom_client.process_prom_query_in_range.call_count == 3
+
+
+class TestValidateFitnessQueries:
+    """Test validate_fitness_queries pre-flight check"""
+
+    def _make_runner(self, minimal_config, temp_output_dir, mock_prom_client):
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            return KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+
+    def test_valid_single_query_passes(self, minimal_config, temp_output_dir):
+        """Valid single fitness query passes validation without error"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "5"]]}
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        # Should not raise
+        runner.validate_fitness_queries()
+
+        assert mock_prom_client.process_prom_query_in_range.call_count == 1
+
+    def test_invalid_single_query_raises_error(self, minimal_config, temp_output_dir):
+        """Invalid fitness query raises FitnessFunctionCalculationError"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(made_up_metric_that_does_not_exist)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = []
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        assert "Pre-flight validation failed" in str(exc_info.value)
+        assert "made_up_metric_that_does_not_exist" in str(exc_info.value)
+
+    def test_query_with_empty_values_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
+        """Prometheus series without samples fails validation"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(metric_without_samples)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [{"values": []}]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        assert "returned no samples" in str(exc_info.value)
+        assert "metric_without_samples" in str(exc_info.value)
+
+    def test_query_with_any_non_empty_series_passes(
+        self, minimal_config, temp_output_dir
+    ):
+        """Validation passes when at least one returned series has samples"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(metric_with_partial_samples)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": []},
+            {"values": [[1000, "1"]]},
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        assert mock_prom_client.process_prom_query_in_range.call_count == 1
+
+    def test_mock_fitness_skips_validation(self, minimal_config, temp_output_dir):
+        """MOCK_FITNESS env var causes validation to be skipped"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="bad_query",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=True
+        ):
+            runner.validate_fitness_queries()
+
+        # Prometheus should never have been called
+        mock_prom_client.process_prom_query_in_range.assert_not_called()
+
+    def test_multi_slo_validates_all_items(self, minimal_config, temp_output_dir):
+        """Multi-SLO config validates each item's query"""
+        minimal_config.fitness_function = FitnessFunction(
+            items=[
+                FitnessFunctionItem(
+                    id=1,
+                    query="sum(metric_a)",
+                    type=FitnessFunctionType.point,
+                    weight=0.6,
+                ),
+                FitnessFunctionItem(
+                    id=2,
+                    query="sum(metric_b)",
+                    type=FitnessFunctionType.point,
+                    weight=0.4,
+                ),
+            ]
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "1"]]}
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        assert mock_prom_client.process_prom_query_in_range.call_count == 2
+
+    def test_multi_slo_second_item_fails(self, minimal_config, temp_output_dir):
+        """Multi-SLO validation reports which item failed"""
+        minimal_config.fitness_function = FitnessFunction(
+            items=[
+                FitnessFunctionItem(
+                    id=1,
+                    query="sum(metric_a)",
+                    type=FitnessFunctionType.point,
+                    weight=0.6,
+                ),
+                FitnessFunctionItem(
+                    id=2,
+                    query="sum(missing_metric)",
+                    type=FitnessFunctionType.point,
+                    weight=0.4,
+                ),
+            ]
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.side_effect = [
+            [{"values": [[1000, "1"]]}],  # first item succeeds
+            [],  # second item fails
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        assert "items[2]" in str(exc_info.value)
+        assert "missing_metric" in str(exc_info.value)
+
+    def test_range_query_substitutes_range(self, minimal_config, temp_output_dir):
+        """Range queries have $range$ replaced with window_minutes"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max(some_gauge{$range$})",
+            type=FitnessFunctionType.range,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "42"]]}
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries(window_minutes=7)
+
+        call_args = mock_prom_client.process_prom_query_in_range.call_args
+        assert "7m" in call_args[0][0] or "7m" in str(call_args)
+
+    def test_top_level_query_takes_precedence_over_items(
+        self, minimal_config, temp_output_dir
+    ):
+        """Validation follows runtime query/items precedence"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(top_level_metric)",
+            type=FitnessFunctionType.point,
+            items=[
+                FitnessFunctionItem(
+                    id=1,
+                    query="sum(item_metric)",
+                    type=FitnessFunctionType.point,
+                    weight=1.0,
+                ),
+            ],
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "1"]]}
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        assert mock_prom_client.process_prom_query_in_range.call_count == 1
+        call_args = mock_prom_client.process_prom_query_in_range.call_args
+        assert "top_level_metric" in call_args[0][0]
+
+    def test_prometheus_exception_wrapped(self, minimal_config, temp_output_dir):
+        """Non-fitness Prometheus exceptions are wrapped in FitnessFunctionCalculationError"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(some_metric)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        original_error = ConnectionError("network timeout")
+        mock_prom_client.process_prom_query_in_range.side_effect = original_error
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        assert "Pre-flight validation failed" in str(exc_info.value)
+        assert "network timeout" in str(exc_info.value)
+        assert exc_info.value.__cause__ is original_error
+
+    def test_items_only_config(self, minimal_config, temp_output_dir):
+        """Config with only items (no top-level query) validates correctly"""
+        minimal_config.fitness_function = FitnessFunction(
+            items=[
+                FitnessFunctionItem(
+                    id=1,
+                    query="sum(only_item_metric)",
+                    type=FitnessFunctionType.point,
+                    weight=1.0,
+                ),
+            ]
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "1"]]}
+        ]
+        runner = self._make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        assert mock_prom_client.process_prom_query_in_range.call_count == 1

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -4,7 +4,7 @@ CLI command tests
 
 import os
 import tempfile
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -66,6 +66,57 @@ class TestRunCommand:
                     )
                     mock_ga.simulate.assert_called_once()
                     mock_ga.save.assert_called_once()
+                    mock_ga.validate_fitness_queries.assert_not_called()
+        finally:
+            os.unlink(config_path)
+
+    def test_run_validates_queries_when_flag_is_set(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test --validate-queries runs pre-flight validation before simulation"""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            import yaml
+
+            config_dict = {
+                "kubeconfig_file_path": minimal_config.kubeconfig_file_path,
+                "generations": minimal_config.generations,
+                "population_size": minimal_config.population_size,
+                "fitness_function": {
+                    "query": minimal_config.fitness_function.query,
+                    "type": minimal_config.fitness_function.type.value,
+                },
+                "scenario": {"pod_scenarios": {"enable": True}},
+            }
+            yaml.dump(config_dict, f)
+            config_path = f.name
+
+        try:
+            with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
+                with patch("krkn_ai.cli.cmd.GeneticAlgorithm") as mock_ga_class:
+                    mock_read.return_value = minimal_config
+                    mock_ga = Mock()
+                    mock_ga_class.return_value = mock_ga
+
+                    result = runner.invoke(
+                        main,
+                        [
+                            "run",
+                            "--config",
+                            config_path,
+                            "--output",
+                            temp_output_dir,
+                            "--validate-queries",
+                        ],
+                    )
+
+                    assert result.exit_code == 0
+                    assert mock_ga.method_calls[:3] == [
+                        call.validate_fitness_queries(),
+                        call.simulate(),
+                        call.save(),
+                    ]
         finally:
             os.unlink(config_path)
 


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization

## Description

A mistyped PromQL metric in `krkn-ai.yaml` currently shows up late: krkn-ai can start the GA flow, run a scenario, wait for fitness collection, retry the query, and only then fail with `FitnessFunctionCalculationError`. This PR adds an opt-in preflight check so users can catch bad or empty fitness queries before the GA simulation starts.

The new `--validate-queries` flag checks the active fitness query source against Prometheus over a recent 5-minute window. It follows the same precedence as runtime fitness calculation:

- validate `fitness_function.query` when it is set
- otherwise validate each weighted item in `fitness_function.items`

Validation requires at least one returned Prometheus series with non-empty `values`, so responses like `[{"values": []}]` now fail preflight the same way runtime fitness calculation would. Range-mode queries with `$range$` are resolved using the validation window, and validation is skipped when `MOCK_FITNESS` is enabled.

The flag is opt-in, so existing runs continue to behave as before.

## Files changed

- `krkn_ai/chaos_engines/krkn_runner.py` - adds active fitness query validation, shared Prometheus sample detection, and clearer error handling
- `krkn_ai/algorithm/genetic.py` - exposes explicit fitness query validation before simulation
- `krkn_ai/cli/cmd.py` - adds `--validate-queries` and runs validation before `simulate()`
- `tests/unit/chaos_engines/test_krkn_runner.py` - covers valid queries, missing data, empty values, range substitution, multi-SLO items, and exception wrapping
- `tests/unit/cli/test_cmd.py` - covers CLI validation flow
- `tests/unit/algorithm/test_genetic_algorithm.py` - covers GA validation delegation

## Checklist

- [x] Self-reviewed
- [x] Tests added for new behavior
- [x] Follows project code style
- [x] Existing tests pass

## Testing

```bash
uv run pytest -q
uv run ruff check .
uv run ruff format --check krkn_ai/chaos_engines/krkn_runner.py krkn_ai/algorithm/genetic.py krkn_ai/cli/cmd.py tests/unit/chaos_engines/test_krkn_runner.py tests/unit/cli/test_cmd.py tests/unit/algorithm/test_genetic_algorithm.py
uv run mypy --config-file mypy.ini krkn_ai/chaos_engines/krkn_runner.py krkn_ai/algorithm/genetic.py krkn_ai/cli/cmd.py
```

Results:

```text
263 passed
All checks passed! (ruff)
6 files already formatted
Success: no issues found in 3 source files (mypy)
```
