### PR TITLE
fix(fitness): reject multi-series Prometheus queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ output:
 
 # Fitness function configuration
 fitness_function:
+  # Query must return exactly one Prometheus series; aggregate fan-out metrics.
   query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
   type: point  # or 'range'
   include_krkn_failure: true

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ output:
 
 # Fitness function configuration
 fitness_function:
-  # Query must return exactly one Prometheus series; aggregate fan-out metrics.
+  # Aggregate the query so it returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
   type: point  # or 'range'
   include_krkn_failure: true

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ output:
 
 # Fitness function configuration
 fitness_function:
-  # Aggregate the query so it returns one Prometheus series.
+  # Use an aggregate query that returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
   type: point  # or 'range'
   include_krkn_failure: true

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -508,8 +508,8 @@ class KrknRunner:
             raise FitnessFunctionCalculationError(
                 f"Prometheus returned {len(series_with_values)} series for query "
                 f"'{query}' during {context}. Fitness queries must return exactly "
-                "one series. Aggregate fan-out queries with PromQL functions such "
-                "as sum(), max(), or avg()."
+                "one series. Use sum(), max(), avg(), or another PromQL aggregate "
+                "before using this query as a fitness function."
             )
         return series_with_values[0]["values"][-1][1]
 
@@ -520,8 +520,6 @@ class KrknRunner:
 
         config.fitness_function.query can specify a dynamic "$range$" parameter that will be replaced
         when calling below function.
-        Fitness queries must return exactly one Prometheus series. Aggregate metrics
-        that fan out by labels with PromQL functions such as sum(), max(), or avg().
         """
         logger.debug("Calculating Range Fitness")
 
@@ -551,7 +549,7 @@ class KrknRunner:
             self._extract_single_prometheus_value(
                 result,
                 query,
-                f"range fitness in range [{start}, {end}]",
+                f"range fitness [{start}, {end}]",
                 no_data_error,
             )
         )

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -13,7 +13,10 @@ from krkn_ai.models.app import (
     KrknRunnerType,
 )
 from krkn_ai.models.config import ConfigFile, FitnessFunctionType
-from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
+from krkn_ai.models.custom_errors import (
+    FitnessFunctionCalculationError,
+    FitnessFunctionConfigurationError,
+)
 from krkn_ai.models.scenario.base import (
     Scenario,
     BaseScenario,
@@ -411,6 +414,8 @@ class KrknRunner:
                     return self.calculate_point_fitness(start, end, query)
                 elif fitness_type == FitnessFunctionType.range:
                     return self.calculate_range_fitness(start, end, query)
+            except FitnessFunctionConfigurationError:
+                raise
             except Exception as error:
                 logger.error(f"Fitness function calculation failed: {error}")
                 logger.info(
@@ -474,11 +479,11 @@ class KrknRunner:
             context: Description of where this is called from (for error messages)
 
         Returns:
-            The metric value as a string from a single Prometheus series
+            The Prometheus value as a string
 
         Raises:
             FitnessFunctionCalculationError: If Prometheus returns no data or
-                more than one non-empty series
+                more than one series
         """
         result = self.prom_client.process_prom_query_in_range(
             query,
@@ -501,17 +506,18 @@ class KrknRunner:
     def _extract_single_prometheus_value(
         self, result, query: str, context: str, no_data_error: str
     ) -> str:
-        series_with_values = [series for series in result or [] if series.get("values")]
-        if not series_with_values:
-            raise FitnessFunctionCalculationError(no_data_error)
-        if len(series_with_values) > 1:
-            raise FitnessFunctionCalculationError(
-                f"Prometheus returned {len(series_with_values)} series for query "
+        series_list = result or []
+        if len(series_list) > 1:
+            raise FitnessFunctionConfigurationError(
+                f"Prometheus returned {len(series_list)} series for query "
                 f"'{query}' during {context}. Fitness queries must return exactly "
                 "one series. Use sum(), max(), avg(), or another PromQL aggregate "
                 "before using this query as a fitness function."
             )
-        return series_with_values[0]["values"][-1][1]
+
+        if not series_list or not series_list[0].get("values"):
+            raise FitnessFunctionCalculationError(no_data_error)
+        return series_list[0]["values"][-1][1]
 
     def calculate_range_fitness(self, start, end, query):
         """

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -474,10 +474,11 @@ class KrknRunner:
             context: Description of where this is called from (for error messages)
 
         Returns:
-            The metric value as a string
+            The metric value as a string from a single Prometheus series
 
         Raises:
-            FitnessFunctionCalculationError: If Prometheus returns no data
+            FitnessFunctionCalculationError: If Prometheus returns no data or
+                more than one non-empty series
         """
         result = self.prom_client.process_prom_query_in_range(
             query,
@@ -485,20 +486,32 @@ class KrknRunner:
             end_time=timestamp,
             granularity=100,
         )
-        if not result:
-            raise FitnessFunctionCalculationError(
-                f"Prometheus returned no data for query '{query}' at {timestamp} "
-                f"during {context}. This may indicate the metric does not exist "
-                f"in the requested time range or Prometheus has not yet scraped data."
-            )
-        for series in result:
-            if series.get("values"):
-                return series["values"][-1][1]
-        raise FitnessFunctionCalculationError(
+        no_data_error = (
             f"Prometheus returned no data for query '{query}' at {timestamp} "
             f"during {context}. This may indicate the metric does not exist "
             f"in the requested time range or Prometheus has not yet scraped data."
         )
+        return self._extract_single_prometheus_value(
+            result,
+            query,
+            context,
+            no_data_error,
+        )
+
+    def _extract_single_prometheus_value(
+        self, result, query: str, context: str, no_data_error: str
+    ) -> str:
+        series_with_values = [series for series in result or [] if series.get("values")]
+        if not series_with_values:
+            raise FitnessFunctionCalculationError(no_data_error)
+        if len(series_with_values) > 1:
+            raise FitnessFunctionCalculationError(
+                f"Prometheus returned {len(series_with_values)} series for query "
+                f"'{query}' during {context}. Fitness queries must return exactly "
+                "one series. Aggregate fan-out queries with PromQL functions such "
+                "as sum(), max(), or avg()."
+            )
+        return series_with_values[0]["values"][-1][1]
 
     def calculate_range_fitness(self, start, end, query):
         """
@@ -507,6 +520,8 @@ class KrknRunner:
 
         config.fitness_function.query can specify a dynamic "$range$" parameter that will be replaced
         when calling below function.
+        Fitness queries must return exactly one Prometheus series. Aggregate metrics
+        that fan out by labels with PromQL functions such as sum(), max(), or avg().
         """
         logger.debug("Calculating Range Fitness")
 
@@ -527,19 +542,18 @@ class KrknRunner:
             end_time=end,
             granularity=100,
         )
-        if not result:
-            raise FitnessFunctionCalculationError(
-                f"Prometheus returned no data for query '{query}' in range "
-                f"[{start}, {end}]. This may indicate the metric does not exist "
-                f"in the requested time range or Prometheus has not yet scraped data."
-            )
-        for series in result:
-            if series.get("values"):
-                return float(series["values"][-1][1])
-        raise FitnessFunctionCalculationError(
+        no_data_error = (
             f"Prometheus returned no data for query '{query}' in range "
             f"[{start}, {end}]. This may indicate the metric does not exist "
             f"in the requested time range or Prometheus has not yet scraped data."
+        )
+        return float(
+            self._extract_single_prometheus_value(
+                result,
+                query,
+                f"range fitness in range [{start}, {end}]",
+                no_data_error,
+            )
         )
 
     def __extract_returncode_from_run(

--- a/krkn_ai/models/custom_errors.py
+++ b/krkn_ai/models/custom_errors.py
@@ -30,6 +30,14 @@ class FitnessFunctionCalculationError(Exception):
     pass
 
 
+class FitnessFunctionConfigurationError(FitnessFunctionCalculationError):
+    """
+    Exception raised when a fitness query returns an invalid result.
+    """
+
+    pass
+
+
 class ScenarioParameterInitError(Exception):
     """
     Exception raised when there is an error initializing a scenario parameter.

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -38,7 +38,7 @@ elastic:
 
 
 fitness_function:
-  # Query must return exactly one Prometheus series; aggregate fan-out metrics.
+  # Aggregate the query so it returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total)'
   type: point
   include_krkn_failure: true

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -38,6 +38,7 @@ elastic:
 
 
 fitness_function:
+  # Query must return exactly one Prometheus series; aggregate fan-out metrics.
   query: 'sum(kube_pod_container_status_restarts_total)'
   type: point
   include_krkn_failure: true

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -38,7 +38,7 @@ elastic:
 
 
 fitness_function:
-  # Aggregate the query so it returns one Prometheus series.
+  # Use an aggregate query that returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total)'
   type: point
   include_krkn_failure: true

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -387,6 +387,47 @@ class TestCalculatePointFitness:
             assert "up" in str(exc_info.value)
             assert "2024-01-01 12:00:00" in str(exc_info.value)
 
+    def test_query_prometheus_single_point_multiple_series_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test point fitness rejects Prometheus results with multiple series"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {"container": "cart"}, "values": [[1000, "5"]]},
+            {"metric": {"container": "payment"}, "values": [[1000, "3"]]},
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            ts = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner._query_prometheus_single_point(
+                    "kube_pod_container_status_restarts_total",
+                    ts,
+                    "point fitness (start)",
+                )
+
+            assert "Prometheus returned 2 series" in str(exc_info.value)
+            assert "Fitness queries must return exactly one series" in str(
+                exc_info.value
+            )
+            assert "sum()" in str(exc_info.value)
+
 
 class TestCalculateRangeFitness:
     """Test calculate_range_fitness"""
@@ -425,6 +466,46 @@ class TestCalculateRangeFitness:
             call_str = str(mock_prom_client.process_prom_query_in_range.call_args)
             assert "10m" in call_str
             assert score == 15.5
+
+    def test_calculate_range_fitness_multiple_series_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test range fitness rejects Prometheus results with multiple series"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max_over_time(container_cpu_usage_seconds_total{$range$})",
+            type=FitnessFunctionType.range,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {"container": "cart"}, "values": [[1000, "15.5"]]},
+            {"metric": {"container": "payment"}, "values": [[1000, "8.0"]]},
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 10, 0)
+
+            with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+                runner.calculate_range_fitness(
+                    start,
+                    end,
+                    "max_over_time(container_cpu_usage_seconds_total{$range$})",
+                )
+
+            assert "Prometheus returned 2 series" in str(exc_info.value)
+            assert "range fitness" in str(exc_info.value)
+            assert "sum()" in str(exc_info.value)
 
     def test_calculate_range_fitness_empty_values_raises_error(
         self, minimal_config, temp_output_dir

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -14,7 +14,10 @@ from krkn_ai.models.config import (
     FitnessFunctionType,
     HealthCheckConfig,
 )
-from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
+from krkn_ai.models.custom_errors import (
+    FitnessFunctionCalculationError,
+    FitnessFunctionConfigurationError,
+)
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
 from krkn_ai.models.cluster_components import ClusterComponents
@@ -428,6 +431,43 @@ class TestCalculatePointFitness:
             )
             assert "sum()" in str(exc_info.value)
 
+    def test_query_prometheus_single_point_counts_empty_series(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test an extra empty series is still rejected"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {"container": "cart"}, "values": [[1000, "5"]]},
+            {"metric": {"container": "payment"}, "values": []},
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            ts = datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+            with pytest.raises(FitnessFunctionConfigurationError) as exc_info:
+                runner._query_prometheus_single_point(
+                    "kube_pod_container_status_restarts_total",
+                    ts,
+                    "point fitness (start)",
+                )
+
+            assert "Prometheus returned 2 series" in str(exc_info.value)
+
 
 class TestCalculateRangeFitness:
     """Test calculate_range_fitness"""
@@ -579,6 +619,50 @@ class TestCalculateRangeFitness:
 
 class TestCalculateFitnessValueRetries:
     """Test calculate_fitness_value retry behavior with empty Prometheus data"""
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    def test_calculate_fitness_value_does_not_retry_multi_series_error(
+        self, mock_env, mock_sleep, minimal_config, temp_output_dir
+    ):
+        """Test multi-series errors are not retried"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {"container": "cart"}, "values": [[1000, "5"]]},
+            {"metric": {"container": "payment"}, "values": [[1000, "3"]]},
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(2024, 1, 1, 12, 5, 0)
+
+            with pytest.raises(FitnessFunctionConfigurationError) as exc_info:
+                runner.calculate_fitness_value(
+                    start,
+                    end,
+                    "kube_pod_container_status_restarts_total",
+                    FitnessFunctionType.point,
+                )
+
+            assert "Prometheus returned 2 series" in str(exc_info.value)
+            assert "sum()" in str(exc_info.value)
+            assert mock_prom_client.process_prom_query_in_range.call_count == 1
+            mock_sleep.assert_not_called()
 
     @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
     @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)


### PR DESCRIPTION


## Summary

I fixed the fitness calculation so it does not silently pick only the first Prometheus series.

Earlier, if a query like `kube_pod_container_status_restarts_total` returned one series per container, the code used the first series with values and ignored the rest. Now the query must return one Prometheus series. If it returns more than one, Krkn-AI raises a clear error asking the user to aggregate the query with `sum()`, `max()`, `avg()`, or another PromQL aggregate.

## How I found it

I checked `calculate_range_fitness()` and `_query_prometheus_single_point()` in `krkn_ai/chaos_engines/krkn_runner.py`.

Both functions were looping over the Prometheus result and returning from the first series that had values. Then I checked the README and config template. The examples already use `sum(...)`, so it made sense to enforce that the fitness query should produce a single series.

## What I changed

- Added a shared helper to read one Prometheus fitness value.
- Kept the existing no-data error behavior.
- Added an error when Prometheus returns multiple non-empty series.
- Made that multi-series error skip retries, so the user sees the aggregation guidance directly.
- Added tests for point and range fitness with multi-series Prometheus results.
- Added a test for one populated series plus one empty series.
- Added a small config comment telling users to aggregate the query.

## Why this is legit

This fixes the silent discard bug without guessing the user's intent.

I did not add automatic `sum` or `max` in Python because different users may want different scoring. It is better to make the PromQL query explicit.

## Tests


- `python -m pytest tests/unit/chaos_engines/test_krkn_runner.py -q` - Passed, 23 tests.
- ` ruff check krkn_ai/chaos_engines/krkn_runner.py tests/unit/chaos_engines/test_krkn_runner.py` - Passed.
- ` ruff format --check krkn_ai/chaos_engines/krkn_runner.py tests/unit/chaos_engines/test_krkn_runner.py` - Passed.
- ` python -m pytest -q` - Passed, 254 tests.
- ` pre-commit run --from-ref main --to-ref HEAD` - Passed.


