### PR TITLE
fix(genetic): track completed generations

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -135,6 +135,7 @@ class GeneticAlgorithm:
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
         start_time = time.time()
         cur_generation = 0
+        self.completed_generations = cur_generation
 
         # Establish baseline by running dummy scenario to evaluate cluster health, fitness score before chaos testing
         self.run_baseline()
@@ -193,6 +194,7 @@ class GeneticAlgorithm:
 
             # Increment generation counter after evaluation
             cur_generation += 1
+            self.completed_generations = cur_generation
 
             # Check stopping criteria after fitness evaluation (for fitness threshold, saturation, and exploration)
             elapsed_after_eval = time.time() - start_time

--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -135,7 +135,6 @@ class GeneticAlgorithm:
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
         start_time = time.time()
         cur_generation = 0
-        self.completed_generations = cur_generation
 
         # Establish baseline by running dummy scenario to evaluate cluster health, fitness score before chaos testing
         self.run_baseline()
@@ -194,7 +193,6 @@ class GeneticAlgorithm:
 
             # Increment generation counter after evaluation
             cur_generation += 1
-            self.completed_generations = cur_generation
 
             # Check stopping criteria after fitness evaluation (for fitness threshold, saturation, and exploration)
             elapsed_after_eval = time.time() - start_time

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -83,6 +83,53 @@ class TestGeneticAlgorithmInitialization:
 class TestGeneticAlgorithmCoreMethods:
     """Test GeneticAlgorithm core methods"""
 
+    def test_simulate_updates_completed_generations(self, genetic_algorithm):
+        """Test simulate tracks completed generations after evaluation"""
+        genetic_algorithm.config.generations = 2
+        genetic_algorithm.config.population_size = 2
+        genetic_algorithm.config.baseline.enable = False
+        genetic_algorithm.config.population_injection_rate = 0.0
+
+        initial_population = [Mock(name="scenario-1"), Mock(name="scenario-2")]
+        next_population = [Mock(name="scenario-3"), Mock(name="scenario-4")]
+
+        fitness_results = []
+        for score in [10.0, 20.0, 30.0, 40.0]:
+            result = Mock()
+            result.fitness_result.fitness_score = score
+            fitness_results.append(result)
+
+        with patch.object(genetic_algorithm, "run_baseline") as mock_baseline:
+            with patch.object(
+                genetic_algorithm, "create_population", return_value=initial_population
+            ):
+                with patch.object(
+                    genetic_algorithm,
+                    "calculate_fitness",
+                    side_effect=fitness_results,
+                ) as mock_calculate:
+                    with patch.object(
+                        genetic_algorithm,
+                        "select_parents",
+                        return_value=(initial_population[0], initial_population[1]),
+                    ):
+                        with patch.object(
+                            genetic_algorithm,
+                            "crossover",
+                            return_value=(next_population[0], next_population[1]),
+                        ):
+                            with patch.object(
+                                genetic_algorithm,
+                                "mutate",
+                                side_effect=lambda scenario: scenario,
+                            ):
+                                genetic_algorithm.simulate()
+
+        assert genetic_algorithm.completed_generations == 2
+        assert len(genetic_algorithm.best_of_generation) == 2
+        assert mock_calculate.call_count == 4
+        mock_baseline.assert_called_once()
+
     def test_save_method_calls_reporters(self, genetic_algorithm):
         """Test save method calls all reporters"""
         with patch.object(
@@ -109,6 +156,7 @@ class TestGeneticAlgorithmCoreMethods:
                             genetic_algorithm.current_scenario_mutation_rate = (
                                 final_rate
                             )
+                            genetic_algorithm.completed_generations = 2
                             genetic_algorithm.save()
 
                             # Verify all reporter methods are called
@@ -122,5 +170,11 @@ class TestGeneticAlgorithmCoreMethods:
                                     "scenario_mutation_rate"
                                 ]
                                 == final_rate
+                            )
+                            assert (
+                                mock_summary_reporter.call_args.kwargs[
+                                    "completed_generations"
+                                ]
+                                == 2
                             )
                             assert mock_reporter_instance.save.called

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -84,39 +84,42 @@ class TestGeneticAlgorithmCoreMethods:
     """Test GeneticAlgorithm core methods"""
 
     def test_simulate_updates_completed_generations(self, genetic_algorithm):
-        """Test simulate tracks completed generations after evaluation"""
+        """Track completed generations after simulate evaluates populations."""
         genetic_algorithm.config.generations = 2
         genetic_algorithm.config.population_size = 2
         genetic_algorithm.config.baseline.enable = False
         genetic_algorithm.config.population_injection_rate = 0.0
 
-        initial_population = [Mock(name="scenario-1"), Mock(name="scenario-2")]
-        next_population = [Mock(name="scenario-3"), Mock(name="scenario-4")]
+        first_generation = [Mock(name="scenario-1"), Mock(name="scenario-2")]
+        offspring_generation = [Mock(name="scenario-3"), Mock(name="scenario-4")]
 
-        fitness_results = []
+        generation_results = []
         for score in [10.0, 20.0, 30.0, 40.0]:
             result = Mock()
             result.fitness_result.fitness_score = score
-            fitness_results.append(result)
+            generation_results.append(result)
 
         with patch.object(genetic_algorithm, "run_baseline") as mock_baseline:
             with patch.object(
-                genetic_algorithm, "create_population", return_value=initial_population
+                genetic_algorithm, "create_population", return_value=first_generation
             ):
                 with patch.object(
                     genetic_algorithm,
                     "calculate_fitness",
-                    side_effect=fitness_results,
+                    side_effect=generation_results,
                 ) as mock_calculate:
                     with patch.object(
                         genetic_algorithm,
                         "select_parents",
-                        return_value=(initial_population[0], initial_population[1]),
+                        return_value=(first_generation[0], first_generation[1]),
                     ):
                         with patch.object(
                             genetic_algorithm,
                             "crossover",
-                            return_value=(next_population[0], next_population[1]),
+                            return_value=(
+                                offspring_generation[0],
+                                offspring_generation[1],
+                            ),
                         ):
                             with patch.object(
                                 genetic_algorithm,
@@ -159,7 +162,6 @@ class TestGeneticAlgorithmCoreMethods:
                             genetic_algorithm.completed_generations = 2
                             genetic_algorithm.save()
 
-                            # Verify all reporter methods are called
                             assert mock_save_gen.called
                             assert mock_graph.called
                             assert mock_save_report.called

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -83,56 +83,6 @@ class TestGeneticAlgorithmInitialization:
 class TestGeneticAlgorithmCoreMethods:
     """Test GeneticAlgorithm core methods"""
 
-    def test_simulate_updates_completed_generations(self, genetic_algorithm):
-        """Track completed generations after simulate evaluates populations."""
-        genetic_algorithm.config.generations = 2
-        genetic_algorithm.config.population_size = 2
-        genetic_algorithm.config.baseline.enable = False
-        genetic_algorithm.config.population_injection_rate = 0.0
-
-        first_generation = [Mock(name="scenario-1"), Mock(name="scenario-2")]
-        offspring_generation = [Mock(name="scenario-3"), Mock(name="scenario-4")]
-
-        generation_results = []
-        for score in [10.0, 20.0, 30.0, 40.0]:
-            result = Mock()
-            result.fitness_result.fitness_score = score
-            generation_results.append(result)
-
-        with patch.object(genetic_algorithm, "run_baseline") as mock_baseline:
-            with patch.object(
-                genetic_algorithm, "create_population", return_value=first_generation
-            ):
-                with patch.object(
-                    genetic_algorithm,
-                    "calculate_fitness",
-                    side_effect=generation_results,
-                ) as mock_calculate:
-                    with patch.object(
-                        genetic_algorithm,
-                        "select_parents",
-                        return_value=(first_generation[0], first_generation[1]),
-                    ):
-                        with patch.object(
-                            genetic_algorithm,
-                            "crossover",
-                            return_value=(
-                                offspring_generation[0],
-                                offspring_generation[1],
-                            ),
-                        ):
-                            with patch.object(
-                                genetic_algorithm,
-                                "mutate",
-                                side_effect=lambda scenario: scenario,
-                            ):
-                                genetic_algorithm.simulate()
-
-        assert genetic_algorithm.completed_generations == 2
-        assert len(genetic_algorithm.best_of_generation) == 2
-        assert mock_calculate.call_count == 4
-        mock_baseline.assert_called_once()
-
     def test_save_method_calls_reporters(self, genetic_algorithm):
         """Test save method calls all reporters"""
         with patch.object(


### PR DESCRIPTION
## Summary

I added coverage for the completed generation count in `results.json`.

The runtime path is already fixed in `main`: `_check_and_stop()` copies `cur_generation` into `self.completed_generations` before the run exits. The missing part was that the save test only checked that `JSONSummaryReporter` was called, not that it received the completed generation count.

## How I found it

I checked `simulate()`, `_check_and_stop()`, and `save()` in `krkn_ai/algorithm/genetic.py`.

The generation count is already updated when the algorithm stops. Then `save()` passes `self.completed_generations` to `JSONSummaryReporter`. So the useful fix here is test coverage for that handoff.

## What I changed

- Set `completed_generations` in the save test.
- Added an assertion that `JSONSummaryReporter` receives that value.
- Removed a generic comment in the same test block.

## Why this is legit

This matches the actual remaining gap.

I did not change production code because `main` already updates `completed_generations`. The test now protects the summary reporter path so future changes do not silently drop the value again.

## Validation

- `python -m pytest tests/unit/algorithm/test_genetic_algorithm.py` - Passed.
- `ruff check tests/unit/algorithm/test_genetic_algorithm.py` - Passed.
- `ruff format --check tests/unit/algorithm/test_genetic_algorithm.py` - Passed.
- `pre-commit run --from-ref main --to-ref HEAD` - Passed.