### PR TITLE
fix: prevent silent connection pool poisoning on Elasticsearch connection failure

### DIFF
--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -43,7 +43,8 @@ class ElasticSearchClient:
                     password=self.config.password,
                     verify_certs=self.config.verify_certs,
                 )
-                self.__test_connection()
+                if not self.__test_connection():
+                    raise Exception("Elasticsearch connection test failed")
                 logger.info(
                     "Elasticsearch client initialized: %s:%s",
                     self.config.server,

--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -44,7 +44,10 @@ class ElasticSearchClient:
                     verify_certs=self.config.verify_certs,
                 )
                 if not self.__test_connection():
-    raise ConnectionError("Elasticsearch connection test failed: ping returned no version info")
+                    raise ConnectionError(
+                        "Elasticsearch connection test failed:"
+                        " ping returned no version info"
+                    )
                 logger.info(
                     "Elasticsearch client initialized: %s:%s",
                     self.config.server,

--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -44,7 +44,7 @@ class ElasticSearchClient:
                     verify_certs=self.config.verify_certs,
                 )
                 if not self.__test_connection():
-                    raise Exception("Elasticsearch connection test failed")
+    raise ConnectionError("Elasticsearch connection test failed: ping returned no version info")
                 logger.info(
                     "Elasticsearch client initialized: %s:%s",
                     self.config.server,

--- a/tests/unit/utils/test_elastic_client.py
+++ b/tests/unit/utils/test_elastic_client.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock, patch
+from krkn_ai.utils.elastic_client import ElasticSearchClient
+from krkn_ai.models.config import ElasticConfig
+
+
+class TestElasticSearchClient:
+    def setup_method(self):
+        self.config = ElasticConfig(
+            server="https://example.com",
+            port=9200,
+            username="admin",
+            password="password",
+            enable=True,
+            verify_certs=True,
+        )
+
+    @patch(
+        "krkn_ai.utils.elastic_client.ElasticSearchClient._ElasticSearchClient__test_connection"
+    )
+    @patch("krkn_ai.utils.elastic_client.KrknElastic")
+    def test_successful_connection_initializes_client(
+        self, mock_krkn_elastic, mock_test_connection
+    ):
+        """Test that a successful connection initializes self.client"""
+        mock_test_connection.return_value = True
+        mock_instance = Mock()
+        mock_krkn_elastic.return_value = mock_instance
+
+        client = ElasticSearchClient(self.config)
+
+        assert client.client is mock_instance
+        mock_krkn_elastic.assert_called_once()
+
+    @patch(
+        "krkn_ai.utils.elastic_client.ElasticSearchClient._ElasticSearchClient__test_connection"
+    )
+    @patch("krkn_ai.utils.elastic_client.KrknElastic")
+    def test_failed_connection_leaves_client_none(
+        self, mock_krkn_elastic, mock_test_connection
+    ):
+        """Test that a failed connection ping leaves self.client as None"""
+        mock_test_connection.return_value = False
+        mock_krkn_elastic.return_value = Mock()
+
+        client = ElasticSearchClient(self.config)
+
+        # Client must be None — a failed ping must not silently retain the instance
+        assert client.client is None


### PR DESCRIPTION
# fix: prevent silent connection pool poisoning on Elasticsearch connection failure

## Summary

This PR fixes a silent but high-impact bug in `ElasticSearchClient.__init__` where the return value of `self.__test_connection()` was completely ignored. This caused a broken `KrknElastic` instance to be silently admitted into `_connection_pool`, poisoning the shared pool for all subsequent indexing operations.

## Problem

During initialization, after instantiating a `KrknElastic` client, `ElasticSearchClient` calls `self.__test_connection()` to validate connectivity. However, the return value (a `bool`) was **never checked**. When the connection ping failed — due to invalid credentials, wrong host, or a network issue — the code silently continued and cached the broken client into `_connection_pool`.

All subsequent callers that reused this pooled instance would encounter failures in `index_config()` or `index_run_result()`, making Elasticsearch telemetry silently unreliable for the entire duration of a Krkn-AI run.

**Fix**:#315

**Before (broken):**
```python
self.__test_connection()  # return value ignored

# Add to pool — even on failure!
self._connection_pool[pool_key] = self.client
```
**Fix:**
The fix evaluates the return value of __test_connection(). If it returns False, an explicit exception is raised. This causes the existing except block to catch it, log the failure, set self.client = None, and skip the pool insertion — exactly as intended.

After(Fixed)
```python
if not self.__test_connection():
    raise Exception("Elasticsearch connection test failed")

# Add to pool — only on verified success
self._connection_pool[pool_key] = self.client
```