### PR TITLE
fix: handle failed scenario execution in calculate_fitness

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -8,7 +8,7 @@ from typing_extensions import Dict
 import yaml
 from typing import List, Optional, Tuple
 
-from krkn_ai.models.app import CommandRunResult, KrknRunnerType
+from krkn_ai.models.app import CommandRunResult, FitnessResult, KrknRunnerType
 
 from krkn_ai.models.scenario.base import (
     Scenario,
@@ -549,7 +549,28 @@ class GeneticAlgorithm:
         # This is a new scenario - track it for exploration limit
         self.new_scenarios_in_generation += 1
 
-        scenario_result = self.krkn_client.run(scenario, generation_id)
+        start_time = datetime.datetime.now()
+        try:
+            scenario_result = self.krkn_client.run(scenario, generation_id)
+        except Exception as e:
+            logger.error(
+                "Scenario %s failed during execution, assigning penalty fitness: %s",
+                scenario,
+                e,
+            )
+            end_time = datetime.datetime.now()
+            scenario_result = CommandRunResult(
+                generation_id=generation_id,
+                scenario=scenario,
+                cmd="",
+                log=f"Scenario execution failed: {e}",
+                returncode=1,
+                start_time=start_time,
+                end_time=end_time,
+                duration_seconds=(end_time - start_time).total_seconds(),
+                fitness_result=FitnessResult(fitness_score=-1.0),
+                health_check_results={},
+            )
 
         # Add scenario to seen population
         self.seen_population[scenario] = scenario_result

--- a/tests/unit/algorithm/test_fitness_calculation.py
+++ b/tests/unit/algorithm/test_fitness_calculation.py
@@ -91,3 +91,69 @@ class TestFitnessCalculation:
         assert result.generation_id == new_generation_id
         # Should not call krkn_client.run (using cache)
         genetic_algorithm_with_mock_runner.krkn_client.run.assert_not_called()
+
+    def test_calculate_fitness_handles_run_exception(
+        self, genetic_algorithm_with_mock_runner
+    ):
+        """A scenario that raises during execution gets a penalty result
+        instead of crashing the genetic run."""
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        generation_id = 0
+
+        genetic_algorithm_with_mock_runner.krkn_client.run = Mock(
+            side_effect=Exception("simulated timeout")
+        )
+
+        with patch.object(genetic_algorithm_with_mock_runner, "save_scenario_result"):
+            with patch.object(
+                genetic_algorithm_with_mock_runner.health_check_reporter, "plot_report"
+            ):
+                with patch.object(
+                    genetic_algorithm_with_mock_runner.health_check_reporter,
+                    "write_fitness_result",
+                ):
+                    result = genetic_algorithm_with_mock_runner.calculate_fitness(
+                        scenario, generation_id
+                    )
+
+                    assert isinstance(result, CommandRunResult)
+                    assert result.fitness_result.fitness_score == -1.0
+                    assert result.returncode != 0
+                    assert result.generation_id == generation_id
+                    assert (
+                        scenario in genetic_algorithm_with_mock_runner.seen_population
+                    )
+                    genetic_algorithm_with_mock_runner.krkn_client.run.assert_called_once_with(
+                        scenario, generation_id
+                    )
+
+    def test_calculate_fitness_caches_failed_scenario(
+        self, genetic_algorithm_with_mock_runner
+    ):
+        """A failed scenario is cached so an identical scenario is not re-run."""
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+
+        genetic_algorithm_with_mock_runner.krkn_client.run = Mock(
+            side_effect=Exception("simulated timeout")
+        )
+
+        with patch.object(genetic_algorithm_with_mock_runner, "save_scenario_result"):
+            with patch.object(
+                genetic_algorithm_with_mock_runner.health_check_reporter, "plot_report"
+            ):
+                with patch.object(
+                    genetic_algorithm_with_mock_runner.health_check_reporter,
+                    "write_fitness_result",
+                ):
+                    genetic_algorithm_with_mock_runner.calculate_fitness(scenario, 0)
+                    result = genetic_algorithm_with_mock_runner.calculate_fitness(
+                        scenario, 1
+                    )
+
+        # Second call returns the cached fallback with the updated generation_id
+        assert result.fitness_result.fitness_score == -1.0
+        assert result.generation_id == 1
+        # krkn_client.run was only attempted once (failure cached, not retried)
+        genetic_algorithm_with_mock_runner.krkn_client.run.assert_called_once_with(
+            scenario, 0
+        )


### PR DESCRIPTION
Fixes #288

## Problem

`calculate_fitness()` calls `self.krkn_client.run()` with no error handling.
Any exception (timeout, network error, etc.) propagates out of the list
comprehension in `simulate()` and crashes the entire GA run on a single
failed scenario.

## Fix

Wrapped `krkn_client.run()` in a try/except. On failure:
- Logs the error (existing logger.error style)
- Builds a fallback `CommandRunResult` with `FitnessResult(fitness_score=-1.0)`
- Existing downstream code caches, persists, and reports it unchanged
- The -1.0 penalty naturally sinks the scenario in both tournament and
  roulette selection

No other files or logic paths are modified — the fix is confined to the
except block in `calculate_fitness()`.

## Tests

Two new tests in `test_fitness_calculation.py`:
- `test_calculate_fitness_handles_run_exception` — failure produces penalty
  result without crashing
- `test_calculate_fitness_caches_failed_scenario` — failure is cached and
  not retried

All 4 tests in the file pass. Full suite: 251 passed, 2 pre-existing
Windows-environment failures in unrelated modules.