### PR TITLE
fix: unconditionally close stdout pipe to prevent thread and fd leak

### DIFF
--- a/krkn_ai/utils/__init__.py
+++ b/krkn_ai/utils/__init__.py
@@ -60,7 +60,7 @@ def run_shell(command, do_not_log=False, timeout=None):
 
     reader.join(timeout=5)
 
-    if not reader.is_alive() and process.stdout:
+    if process.stdout:
         process.stdout.close()
 
     logs = "".join(output_lines)


### PR DESCRIPTION
Fixes #284

## Problem

In `run_shell`, `process.stdout` is only closed when the reader thread
has exited. If a child process inherits the pipe and keeps it open,
the thread stays alive and the pipe is never closed — leaking both
the thread and the file descriptor.

## Fix

Remove the `not reader.is_alive()` guard so `process.stdout` is
unconditionally closed after the join timeout.

Note: for the edge case where a grandchild holds the pipe open,
`.close()` may block on the buffer lock. A root-cause fix (process
group kill) is available as a follow-up if maintainers prefer it.