### PR TITLE
Fix run_shell timeout test for Windows compatibility

### DIFF
--- a/tests/unit/utils/test_run_shell.py
+++ b/tests/unit/utils/test_run_shell.py
@@ -15,8 +15,9 @@ class TestRunShell:
     def test_timeout_raises_shell_command_timeout_error(self):
         # Use sys.executable to run a portable Python sleep so the test
         # works on Windows and Unix (avoids relying on external 'sleep').
-        # Quote the executable path so backslashes are preserved on Windows.
-        exe = sys.executable
-        cmd = f'"{exe}" -c "import time; time.sleep(10)"'
+        # Convert backslashes to forward slashes so POSIX shlex parsing
+        # does not corrupt Windows paths.
+        exe = sys.executable.replace("\\", "/")
+        cmd = f'{exe} -c "import time; time.sleep(10)"'
         with pytest.raises(ShellCommandTimeoutError):
             run_shell(cmd, timeout=5)

--- a/tests/unit/utils/test_run_shell.py
+++ b/tests/unit/utils/test_run_shell.py
@@ -3,6 +3,7 @@ run_shell unit tests
 """
 
 import pytest
+import sys
 
 from krkn_ai.models.custom_errors import ShellCommandTimeoutError
 from krkn_ai.utils import run_shell
@@ -12,5 +13,10 @@ class TestRunShell:
     """Test run_shell timeout behavior"""
 
     def test_timeout_raises_shell_command_timeout_error(self):
+        # Use sys.executable to run a portable Python sleep so the test
+        # works on Windows and Unix (avoids relying on external 'sleep').
+        # Quote the executable path so backslashes are preserved on Windows.
+        exe = sys.executable
+        cmd = f'"{exe}" -c "import time; time.sleep(10)"'
         with pytest.raises(ShellCommandTimeoutError):
-            run_shell("sleep 10", timeout=5)
+            run_shell(cmd, timeout=5)


### PR DESCRIPTION
## Summary

This PR fixes Windows compatibility for `test_run_shell`.

Previously the test relied on:

`run_shell("sleep 10", timeout=5)`

This depended on the external Linux `sleep` command and failed on Windows environments.

The test now uses a Python-based sleep command executed through `sys.executable`, preserving timeout behavior while improving portability.

## Changes

* Removed Linux-specific dependency
* Added cross-platform timeout test behavior
* Preserved existing validation logic
* No production code changes

## Validation

* Focused test passes on Windows
* Ruff checks pass
* Only test file modified