### PR TITLE
fix(reporter): accurate fitness progression averages including cached scenarios`

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -83,6 +83,9 @@ class GeneticAlgorithm:
         self.seen_population: Dict[
             BaseScenario, CommandRunResult
         ] = {}  # Map between scenario and its result
+        self.all_evaluations: List[
+            CommandRunResult
+        ] = []  # Track all evaluations including cache hits
         self.best_of_generation: List[BaseScenario] = []
 
         self.health_check_reporter = HealthCheckReporter(
@@ -544,6 +547,7 @@ class GeneticAlgorithm:
             result = self.seen_population[scenario]
             result = copy.deepcopy(result)
             result.generation_id = generation_id
+            self.all_evaluations.append(result)
             return result
 
         # This is a new scenario - track it for exploration limit
@@ -561,6 +565,7 @@ class GeneticAlgorithm:
         if self.elastic_client is not None:
             self.elastic_client.index_run_result(scenario_result, self.run_uuid)
 
+        self.all_evaluations.append(scenario_result)
         return scenario_result
 
     def mutate(self, scenario: BaseScenario):
@@ -782,6 +787,7 @@ class GeneticAlgorithm:
             completed_generations=self.completed_generations,
             seed=self.seed,
             scenario_mutation_rate=self.current_scenario_mutation_rate,
+            all_evaluations=self.all_evaluations,
         )
         summary_reporter.save(self.output_dir)
 

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -55,7 +55,11 @@ class JSONSummaryReporter:
         self.run_uuid = run_uuid
         self.config = config
         self.seen_population = seen_population
-        self.all_evaluations = all_evaluations if all_evaluations is not None else list(seen_population.values())
+        self.all_evaluations = (
+            all_evaluations
+            if all_evaluations is not None
+            else list(seen_population.values())
+        )
         self.best_of_generation = best_of_generation
         self.baseline_result = baseline_result
         self.start_time = start_time
@@ -84,8 +88,7 @@ class JSONSummaryReporter:
 
         # Get all fitness scores for statistics
         all_fitness_scores = [
-            result.fitness_result.fitness_score
-            for result in self.all_evaluations
+            result.fitness_result.fitness_score for result in self.all_evaluations
         ]
 
         # Calculate average fitness score

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -35,6 +35,7 @@ class JSONSummaryReporter:
         completed_generations: int = 0,
         seed: Optional[int] = None,
         scenario_mutation_rate: Optional[float] = None,
+        all_evaluations: Optional[List[CommandRunResult]] = None,
     ):
         """
         Initialize the JSON summary reporter.
@@ -54,6 +55,7 @@ class JSONSummaryReporter:
         self.run_uuid = run_uuid
         self.config = config
         self.seen_population = seen_population
+        self.all_evaluations = all_evaluations if all_evaluations is not None else list(seen_population.values())
         self.best_of_generation = best_of_generation
         self.baseline_result = baseline_result
         self.start_time = start_time
@@ -83,7 +85,7 @@ class JSONSummaryReporter:
         # Get all fitness scores for statistics
         all_fitness_scores = [
             result.fitness_result.fitness_score
-            for result in self.seen_population.values()
+            for result in self.all_evaluations
         ]
 
         # Calculate average fitness score
@@ -124,7 +126,7 @@ class JSONSummaryReporter:
                 "composition_rate": self.config.composition_rate,
             },
             "summary": {
-                "total_scenarios_executed": len(self.seen_population),
+                "total_scenarios_executed": len(self.all_evaluations),
                 "unique_scenarios": len(unique_scenarios),
                 "generations_completed": self.completed_generations,
                 "best_fitness_score": round(best_fitness_score, 4),
@@ -146,10 +148,10 @@ class JSONSummaryReporter:
         """Build fitness progression data from best_of_generation."""
         fitness_progression = []
         for i, result in enumerate(self.best_of_generation):
-            # Calculate average fitness for this generation from seen_population
+            # Calculate average fitness for this generation from all_evaluations
             gen_fitness_scores = [
                 r.fitness_result.fitness_score
-                for r in self.seen_population.values()
+                for r in self.all_evaluations
                 if r.generation_id == i
             ]
             gen_average = 0.0

--- a/tests/unit/algorithm/test_fitness_calculation.py
+++ b/tests/unit/algorithm/test_fitness_calculation.py
@@ -54,6 +54,8 @@ class TestFitnessCalculation:
                     assert (
                         scenario in genetic_algorithm_with_mock_runner.seen_population
                     )
+                    assert result in genetic_algorithm_with_mock_runner.all_evaluations
+                    assert len(genetic_algorithm_with_mock_runner.all_evaluations) == 1
                     genetic_algorithm_with_mock_runner.krkn_client.run.assert_called_once_with(
                         scenario, generation_id
                     )
@@ -89,5 +91,7 @@ class TestFitnessCalculation:
         # Should return cached result but with updated generation_id
         assert result.fitness_result.fitness_score == 20.0
         assert result.generation_id == new_generation_id
+        assert result in genetic_algorithm_with_mock_runner.all_evaluations
+        assert len(genetic_algorithm_with_mock_runner.all_evaluations) == 1
         # Should not call krkn_client.run (using cache)
         genetic_algorithm_with_mock_runner.krkn_client.run.assert_not_called()

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -38,10 +38,10 @@ class TestJSONSummaryReporter:
         now = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
         cc = minimal_config.cluster_components
         scenario = DummyScenario(cluster_components=cc)
-        
+
         gen0 = self._create_results(0, 0, 3, scenario, now)
         gen1 = self._create_results(1, 40, 3, scenario, now)
-        
+
         pop = {**gen0, **gen1}
         best = [gen0[2], gen1[102]]
 
@@ -53,24 +53,24 @@ class TestJSONSummaryReporter:
             start_time=now,
             end_time=now + datetime.timedelta(seconds=100),
             completed_generations=2,
-            seed=123
+            seed=123,
         )
-        
+
         summary = reporter.generate_summary()
 
         assert summary["run_id"] == "test-run"
         assert summary["seed"] == 123
         assert summary["start_time"] == now.isoformat()
         assert summary["duration_seconds"] == 100.0
-        
+
         assert summary["config"]["generations"] == minimal_config.generations
         assert summary["config"]["population_size"] == minimal_config.population_size
-        
+
         assert summary["summary"]["total_scenarios_executed"] == 6
         assert summary["summary"]["best_fitness_score"] == 60.0
         assert summary["summary"]["average_fitness_score"] == 30.0
         assert summary["summary"]["generations_completed"] == 2
-        
+
         assert len(summary["fitness_progression"]) == 2
         assert summary["fitness_progression"][0]["average"] == 10.0
         assert summary["fitness_progression"][0]["best"] == 20.0
@@ -82,19 +82,19 @@ class TestJSONSummaryReporter:
         now = datetime.datetime.now(datetime.timezone.utc)
         cc = minimal_config.cluster_components
         scenario = DummyScenario(cluster_components=cc)
-        
+
         pop = self._create_results(0, 0, 15, scenario, now)
-        
+
         reporter = JSONSummaryReporter(
             run_uuid="test",
             config=minimal_config,
             seen_population=pop,
             best_of_generation=[],
         )
-        
+
         best = reporter.generate_summary()["best_scenarios"]
         assert len(best) == 10
-        
+
         for i in range(10):
             item = best[i]
             assert item["rank"] == i + 1
@@ -117,7 +117,7 @@ class TestJSONSummaryReporter:
             config=minimal_config,
             seen_population=gen0,
             best_of_generation=[gen0[1]],
-            completed_generations=1
+            completed_generations=1,
         )
         summary = reporter.generate_summary()
         assert len(summary["fitness_progression"]) == 1
@@ -171,10 +171,10 @@ class TestJSONSummaryReporter:
             seen_population=pop,
             best_of_generation=[],
         )
-        
+
         expected_summary = reporter.generate_summary()
         reporter.save(temp_output_dir)
-        
+
         path = os.path.join(temp_output_dir, "results.json")
         assert os.path.exists(path)
         with open(path, "r") as f:
@@ -191,30 +191,59 @@ class TestJSONSummaryReporter:
         scenario1.__str__ = lambda: "scenario1"
         scenario2.__str__ = lambda: "scenario2"
         scenario3.__str__ = lambda: "scenario3"
-        
+
         # Gen 0 has 2 scenarios
-        gen0 = self._create_results(0, 10, 2, scenario1, now)  # scores 10, 20
         # Wait, _create_results uses the same scenario for all count. Let's make it 1 by 1.
-        res0 = CommandRunResult(generation_id=0, scenario_id=0, scenario=scenario1, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=10.0))
-        res1 = CommandRunResult(generation_id=0, scenario_id=1, scenario=scenario2, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=20.0))
-        
-        # Gen 1 has 1 new scenario and 1 cache hit from Gen 0 (score 20 copied to gen 1)
-        res2_new = CommandRunResult(generation_id=1, scenario_id=100, scenario=scenario3, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=40.0))
-        
-        cache_hit = CommandRunResult(
-            generation_id=1,
-            scenario_id=1, # cached from gen0
+        res0 = CommandRunResult(
+            generation_id=0,
+            scenario_id=0,
+            scenario=scenario1,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=10.0),
+        )
+        res1 = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
             scenario=scenario2,
             cmd="test",
             log="test",
             returncode=0,
             start_time=now,
             end_time=now,
-            fitness_result=FitnessResult(fitness_score=20.0), # cached score
+            fitness_result=FitnessResult(fitness_score=20.0),
+        )
+
+        # Gen 1 has 1 new scenario and 1 cache hit from Gen 0 (score 20 copied to gen 1)
+        res2_new = CommandRunResult(
+            generation_id=1,
+            scenario_id=100,
+            scenario=scenario3,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=40.0),
+        )
+
+        cache_hit = CommandRunResult(
+            generation_id=1,
+            scenario_id=1,  # cached from gen0
+            scenario=scenario2,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=20.0),  # cached score
         )
 
         all_evals = [res0, res1, res2_new, cache_hit]
-        
+
         # seen_population only has the first unique occurrences (gen0 and gen1_new)
         seen_pop = {0: res0, 1: res1, 100: res2_new}
 
@@ -222,15 +251,19 @@ class TestJSONSummaryReporter:
             run_uuid="cache-test",
             config=minimal_config,
             seen_population=seen_pop,
-            best_of_generation=[res1, res2_new], # best of gen0: 20, best of gen1: 40
-            all_evaluations=all_evals
+            best_of_generation=[res1, res2_new],  # best of gen0: 20, best of gen1: 40
+            all_evaluations=all_evals,
         )
 
         summary = reporter.generate_summary()
-        
-        assert summary["summary"]["total_scenarios_executed"] == 4 # 2 in gen0 + 2 in gen1
-        assert summary["summary"]["unique_scenarios"] == 1 # Since DummyScenario __str__ is same for all
-        
+
+        assert (
+            summary["summary"]["total_scenarios_executed"] == 4
+        )  # 2 in gen0 + 2 in gen1
+        assert (
+            summary["summary"]["unique_scenarios"] == 1
+        )  # Since DummyScenario __str__ is same for all
+
         progression = summary["fitness_progression"]
         assert len(progression) == 2
         # Gen 0 average: (10 + 20) / 2 = 15.0

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -180,3 +180,60 @@ class TestJSONSummaryReporter:
         with open(path, "r") as f:
             saved_content = json.load(f)
             assert saved_content == expected_summary
+
+    def test_fitness_progression_with_all_evaluations(self, minimal_config):
+        """Test fitness progression calculates averages using all_evaluations, not just unique seen_population"""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cc = minimal_config.cluster_components
+        scenario1 = DummyScenario(cluster_components=cc)
+        scenario2 = DummyScenario(cluster_components=cc)
+        scenario3 = DummyScenario(cluster_components=cc)
+        scenario1.__str__ = lambda: "scenario1"
+        scenario2.__str__ = lambda: "scenario2"
+        scenario3.__str__ = lambda: "scenario3"
+        
+        # Gen 0 has 2 scenarios
+        gen0 = self._create_results(0, 10, 2, scenario1, now)  # scores 10, 20
+        # Wait, _create_results uses the same scenario for all count. Let's make it 1 by 1.
+        res0 = CommandRunResult(generation_id=0, scenario_id=0, scenario=scenario1, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=10.0))
+        res1 = CommandRunResult(generation_id=0, scenario_id=1, scenario=scenario2, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=20.0))
+        
+        # Gen 1 has 1 new scenario and 1 cache hit from Gen 0 (score 20 copied to gen 1)
+        res2_new = CommandRunResult(generation_id=1, scenario_id=100, scenario=scenario3, cmd="test", log="test", returncode=0, start_time=now, end_time=now, fitness_result=FitnessResult(fitness_score=40.0))
+        
+        cache_hit = CommandRunResult(
+            generation_id=1,
+            scenario_id=1, # cached from gen0
+            scenario=scenario2,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=20.0), # cached score
+        )
+
+        all_evals = [res0, res1, res2_new, cache_hit]
+        
+        # seen_population only has the first unique occurrences (gen0 and gen1_new)
+        seen_pop = {0: res0, 1: res1, 100: res2_new}
+
+        reporter = JSONSummaryReporter(
+            run_uuid="cache-test",
+            config=minimal_config,
+            seen_population=seen_pop,
+            best_of_generation=[res1, res2_new], # best of gen0: 20, best of gen1: 40
+            all_evaluations=all_evals
+        )
+
+        summary = reporter.generate_summary()
+        
+        assert summary["summary"]["total_scenarios_executed"] == 4 # 2 in gen0 + 2 in gen1
+        assert summary["summary"]["unique_scenarios"] == 1 # Since DummyScenario __str__ is same for all
+        
+        progression = summary["fitness_progression"]
+        assert len(progression) == 2
+        # Gen 0 average: (10 + 20) / 2 = 15.0
+        assert progression[0]["average"] == 15.0
+        # Gen 1 average: (40 + 20) / 2 = 30.0 (would be 40.0 if cache miss happened!)
+        assert progression[1]["average"] == 30.0


### PR DESCRIPTION


### Description
This PR fixes a critical bug where cached scenario executions were omitted from the per-generation fitness average calculations in `results.json`. 

Previously, `GeneticAlgorithm` relied exclusively on `seen_population` (which stores only the first, unique occurrence of a scenario) to calculate averages for the `JSONSummaryReporter`. When scenarios were re-evaluated due to cache hits, their duplicate evaluations were skipped. This skewed fitness progression averages, causing artificial dips or zeros as generations converged and cache hits increased. 

**Changes:**
- `GeneticAlgorithm` now maintains an `all_evaluations` list that records every evaluation instance (including cache hits) with their appropriate `generation_id`.
- `JSONSummaryReporter` has been refactored to consume `all_evaluations` for all per-generation averaging metrics and `total_scenarios_executed`.
- `unique_scenarios` continues to accurately track only unique scenario strings using `seen_population`.

**Fix**: #324 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe)

### Testing
- Added `test_fitness_progression_with_all_evaluations` in `test_json_summary_reporter.py` to assert that cache hits contribute to generation averages properly.
- Added assertions in `test_fitness_calculation.py` to ensure both cache misses and cache hits correctly populate the `all_evaluations` array.
- Ran all existing `pytest` suites to ensure backward compatibility and zero regressions across the codebase.

### Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

### Additional Notes
This fix ensures that `average_fitness_score` in the final `results.json` accurately depicts the generation's true performance, directly resolving any visual anomalies where convergence triggered misleadingly low progression averages. Backward compatibility is maintained in `JSONSummaryReporter` for downstream consumers relying on `seen_population`.
