### PR TITLE
Fix wildcard handling for list-based PatternMatcher parsing

### DIFF
--- a/krkn_ai/utils/pattern_matcher.py
+++ b/krkn_ai/utils/pattern_matcher.py
@@ -68,15 +68,30 @@ class PatternMatcher:
         """
         # Handle list input (pass through)
         if isinstance(pattern_string, list):
+            has_any = any(pat and pat.strip() for pat in pattern_string)
+            if not has_any:
+                return cls([], [], match_all=default_match_all)
+
             list_include: List[re.Pattern] = []
             list_exclude: List[re.Pattern] = []
+            has_wildcard = any(pat.strip() == "*" for pat in pattern_string if pat)
+
             for pat in pattern_string:
+                if not pat:
+                    continue
+                pat = pat.strip()
+                if pat == "*":
+                    continue
                 if pat.startswith("!"):
                     actual = pat[1:]
                     if actual:
                         list_exclude.append(cls._compile_pattern(actual))
-                else:
+                elif not has_wildcard:
                     list_include.append(cls._compile_pattern(pat))
+
+            if has_wildcard:
+                return cls([], list_exclude, match_all=True)
+
             list_match_all = len(list_include) == 0 and len(list_exclude) > 0
             return cls(list_include, list_exclude, match_all=list_match_all)
 

--- a/tests/unit/utils/test_pattern_matcher.py
+++ b/tests/unit/utils/test_pattern_matcher.py
@@ -73,6 +73,31 @@ class TestPatternMatcherCreation:
         assert matcher.matches("kube-system")
         assert not matcher.matches("test-ns")
 
+    def test_list_input_empty_respects_default_match_all_true(self):
+        """Test empty list honors default_match_all=True"""
+        matcher = PatternMatcher.from_string([], default_match_all=True)
+        assert matcher.match_all
+        assert matcher.matches("anything")
+
+    def test_list_input_empty_respects_default_match_all_false(self):
+        """Test empty list honors default_match_all=False"""
+        matcher = PatternMatcher.from_string([], default_match_all=False)
+        assert matcher.is_empty()
+        assert not matcher.matches("anything")
+
+    def test_list_input_wildcard_matches_all(self):
+        """Test list input wildcard matches everything"""
+        matcher = PatternMatcher.from_string(["*"])
+        assert matcher.match_all
+        assert matcher.matches("default")
+        assert matcher.matches("kube-system")
+
+    def test_list_input_wildcard_with_exclusion(self):
+        """Test list input wildcard supports exclusions"""
+        matcher = PatternMatcher.from_string(["*", "!kube-system"])
+        assert matcher.matches("default")
+        assert not matcher.matches("kube-system")
+
 
 class TestPatternMatcherExclusion:
     """Test PatternMatcher exclusion patterns"""


### PR DESCRIPTION
This PR fixes wildcard handling in PatternMatcher when parsing list inputs. Previously, using wildcard patterns such as ["*"] resulted in PatternValidationError because the wildcard was interpreted as an invalid regex pattern. The fix updates list parsing behavior and adds regression tests to verify fail-before / pass-after behavior while preserving existing matching logic.