### PR TITLE
 fix(utils): prevent file descriptor and thread resource leak under timeout in run_shell

### DIFF
--- a/krkn_ai/utils/__init__.py
+++ b/krkn_ai/utils/__init__.py
@@ -53,15 +53,13 @@ def run_shell(command, do_not_log=False, timeout=None):
             # Forcefully terminate
             process.kill()
             process.wait()
-        reader.join(timeout=5)
         raise ShellCommandTimeoutError(
             f"Command '{command[0]}' timed out after {timeout} seconds"
         )
-
-    reader.join(timeout=5)
-
-    if process.stdout:
-        process.stdout.close()
+    finally:
+        if process.stdout:
+            process.stdout.close()
+        reader.join(timeout=5)
 
     logs = "".join(output_lines)
 

--- a/tests/unit/utils/test_run_shell.py
+++ b/tests/unit/utils/test_run_shell.py
@@ -13,4 +13,34 @@ class TestRunShell:
 
     def test_timeout_raises_shell_command_timeout_error(self):
         with pytest.raises(ShellCommandTimeoutError):
-            run_shell("sleep 10", timeout=5)
+            run_shell("sleep 1", timeout=0.05)
+
+    def test_run_shell_timeout_no_fd_leak(self):
+        import os
+        import sys
+        import gc
+
+        fd_dir = "/dev/fd" if sys.platform == "darwin" else "/proc/self/fd"
+        if not os.path.exists(fd_dir):
+            pytest.skip("System does not support FD list directory check")
+
+        # Clear garbage collection first to start clean
+        gc.collect()
+        initial_fds = len(os.listdir(fd_dir))
+
+        exceptions = []
+        for _ in range(5):
+            try:
+                run_shell("sleep 1", timeout=0.05)
+            except ShellCommandTimeoutError as e:
+                exceptions.append(e)
+
+        # Assert that the active FD count did not grow significantly.
+        # We allow a small tolerance (+1) to avoid flakiness from unrelated FDs,
+        # but a real leak would easily fail this test as it would leak 5+ FDs.
+        final_fds = len(os.listdir(fd_dir))
+        assert final_fds <= initial_fds + 1, (
+            f"FD leak detected: {initial_fds} -> {final_fds}"
+        )
+
+        exceptions.clear()


### PR DESCRIPTION
## Desription
Under timeout conditions in the run_shell command executor, the underlying process's stdout pipe stream (process.stdout) is left open when ShellCommandTimeoutError is raised. This causes a file descriptor leak, which over long-running genetic algorithm runs involving numerous generations and command execution timeouts will exhaust the system file descriptor limit, leading to OSError: [Errno 24] Too many open files.

This PR refactors run_shell by enclosing the execution flow in a standard try...finally block, ensuring that process.stdout.close() is always called on all return and exception paths.
**Fix**: #328 
## Type of Change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Other (please describe)
  
  ## Testing
  - Executed the full unit test suite pytest tests/ locally to ensure no regressions.
  - Added a dedicated regression test test_run_shell_timeout_no_fd_leak in tests/unit/utils/test_run_shell.py that repeatedly   executes timed-out processes and asserts that the count of active file descriptors in /dev/fd (or /proc/self/fd) does not grow.
  
 ## Checklist
   - [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
   - [x] My code follows the project's style guidelines
   - [x] I have added tests that prove my fix is effective or that my feature works
   - [x] New and existing unit tests pass locally with my changes
   - [x] I have updated the documentation accordingly
   - [x] My changes generate no new warnings or errors
## Additional Notes
This fix ensures stability and prevents premature crashes of the distributed chaos orchestrator under realistic testing environments subject to transient latencies or timeouts.