### PR TITLE
Fix atomic writes for discover YAML output

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -19,7 +19,7 @@ from krkn_ai.models.custom_errors import (
     PrometheusConnectionError,
     UniqueScenariosError,
 )
-from krkn_ai.utils.fs import read_config_from_file
+from krkn_ai.utils.fs import atomic_write_text, read_config_from_file
 from krkn_ai.templates.generator import create_krkn_ai_template
 from krkn_ai.utils.cluster_manager import ClusterManager
 
@@ -273,7 +273,6 @@ def discover(
 
     template = create_krkn_ai_template(kubeconfig, cluster_components_data)
 
-    with open(output, "w") as f:
-        f.write(template)
+    atomic_write_text(output, template)
 
     logger.info("Saved component configuration to %s", output)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -1,12 +1,119 @@
 import json
 import os
+import stat
+import uuid
 import yaml
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Callable, Optional, cast
 
 from krkn_ai.models.config import ConfigFile, ParameterValue
 from krkn_ai.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _fsync_directory(dir_path: str):
+    try:
+        dir_fd = os.open(dir_path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
+def _existing_file_mode(file_path: str) -> int:
+    try:
+        return stat.S_IMODE(os.stat(file_path).st_mode)
+    except FileNotFoundError:
+        return 0o666
+
+
+def _preserve_existing_metadata(source_path: str, target_path: str):
+    try:
+        source_stat = os.stat(source_path)
+    except FileNotFoundError:
+        return
+
+    if hasattr(os, "chown"):
+        try:
+            os.chown(target_path, source_stat.st_uid, source_stat.st_gid)
+        except OSError:
+            logger.debug("Unable to preserve ownership for %s", target_path)
+
+    try:
+        os.chmod(target_path, stat.S_IMODE(source_stat.st_mode))
+    except OSError:
+        logger.debug("Unable to preserve mode for %s", target_path)
+
+    _preserve_existing_xattrs(source_path, target_path)
+
+
+def _preserve_existing_xattrs(source_path: str, target_path: str):
+    listxattr = cast(
+        Optional[Callable[[str], List[str]]], getattr(os, "listxattr", None)
+    )
+    getxattr = cast(
+        Optional[Callable[[str, str], bytes]], getattr(os, "getxattr", None)
+    )
+    setxattr = cast(
+        Optional[Callable[[str, str, bytes], None]], getattr(os, "setxattr", None)
+    )
+    if listxattr is None or getxattr is None or setxattr is None:
+        return
+
+    try:
+        xattr_names = listxattr(source_path)
+    except OSError:
+        return
+
+    for name in xattr_names:
+        try:
+            setxattr(target_path, name, getxattr(source_path, name))
+        except OSError:
+            logger.debug(
+                "Unable to preserve extended attribute %s for %s", name, target_path
+            )
+
+
+def atomic_write_text(file_path: str, data: str):
+    """
+    Write text to a file using a same-directory temporary file and atomic replace.
+    """
+    target_path = os.path.realpath(file_path)
+    output_dir = os.path.dirname(target_path)
+    base_name = os.path.basename(target_path)
+    tmp_path = os.path.join(output_dir, f".{base_name}.{uuid.uuid4().hex}.tmp")
+    tmp_mode = _existing_file_mode(target_path)
+
+    fd = None
+    tmp_created = False
+    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, tmp_mode)
+        tmp_created = True
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = None
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+
+        _preserve_existing_metadata(target_path, tmp_path)
+        os.replace(tmp_path, target_path)
+        _fsync_directory(output_dir)
+    except BaseException:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                logger.debug("Unable to close temporary file %s", tmp_path)
+        try:
+            if tmp_created and os.path.exists(tmp_path):
+                os.remove(tmp_path)
+        except OSError:
+            logger.debug("Unable to remove temporary file %s", tmp_path)
+        raise
 
 
 def preprocess_param_string(data: str, params: dict) -> str:

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -2,6 +2,7 @@
 CLI command tests
 """
 
+import builtins
 import os
 import tempfile
 from unittest.mock import Mock, patch
@@ -288,6 +289,71 @@ class TestDiscoverCommand:
                     assert os.path.exists(output_file)
                     with open(output_file, "r") as f:
                         assert f.read() == "generated_template_content"
+        finally:
+            os.unlink(kubeconfig_path)
+
+    def test_discover_uses_atomic_write_for_output(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """Test discover avoids in-place writes that can leave partial output"""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        output_file = os.path.join(temp_output_dir, "output.yaml")
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write("previous_config")
+
+        real_open = builtins.open
+
+        class FailingOutputWriter:
+            def __init__(self, file):
+                self.file = file
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.file.close()
+                return False
+
+            def write(self, data):
+                self.file.write(data[:7])
+                self.file.flush()
+                raise OSError("simulated partial in-place write")
+
+        def failing_output_open(file, mode="r", *args, **kwargs):
+            if file == output_file and "w" in mode:
+                return FailingOutputWriter(real_open(file, mode, *args, **kwargs))
+            return real_open(file, mode, *args, **kwargs)
+
+        try:
+            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_cluster_manager_class:
+                with patch("krkn_ai.cli.cmd.create_krkn_ai_template") as mock_template:
+                    with patch("builtins.open", side_effect=failing_output_open):
+                        mock_manager = Mock()
+                        mock_manager.discover_components.return_value = (
+                            mock_cluster_components
+                        )
+                        mock_cluster_manager_class.return_value = mock_manager
+                        mock_template.return_value = "generated_template_content"
+
+                        result = runner.invoke(
+                            main,
+                            [
+                                "discover",
+                                "--kubeconfig",
+                                kubeconfig_path,
+                                "--output",
+                                output_file,
+                            ],
+                        )
+
+            assert result.exit_code == 0
+            with open(output_file, "r", encoding="utf-8") as f:
+                assert f.read() == "generated_template_content"
         finally:
             os.unlink(kubeconfig_path)
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,10 +1,158 @@
 """Tests for utils/fs.py"""
 
+import os
+import stat
+from unittest.mock import patch
+
 import pytest
 import yaml
 from pydantic import ValidationError
 
-from krkn_ai.utils.fs import read_config_from_file
+from krkn_ai.utils.fs import atomic_write_text, read_config_from_file
+
+
+class TestAtomicWriteText:
+    def test_preserves_existing_output_on_write_failure(self, tmp_path):
+        """Failed atomic writes should leave the destination file untouched"""
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+
+        real_fdopen = os.fdopen
+
+        class FailingWriter:
+            def __init__(self, fd, mode, *args, **kwargs):
+                self.file = real_fdopen(fd, mode, *args, **kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.file.close()
+                return False
+
+            def write(self, data):
+                self.file.write(data[:7])
+                self.file.flush()
+                raise OSError("simulated write failure")
+
+        def failing_fdopen(fd, mode="r", *args, **kwargs):
+            return FailingWriter(fd, mode, *args, **kwargs)
+
+        with patch("krkn_ai.utils.fs.os.fdopen", side_effect=failing_fdopen):
+            with pytest.raises(OSError, match="simulated write failure"):
+                atomic_write_text(str(output_file), "generated_template_content")
+
+        assert output_file.read_text(encoding="utf-8") == "previous_config"
+        assert list(tmp_path.glob(".krkn-ai.yaml.*.tmp")) == []
+
+    def test_cleans_up_temp_file_on_keyboard_interrupt(self, tmp_path):
+        """Interrupted atomic writes should not leave temporary files behind"""
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+
+        real_fdopen = os.fdopen
+
+        class InterruptingWriter:
+            def __init__(self, fd, mode, *args, **kwargs):
+                self.file = real_fdopen(fd, mode, *args, **kwargs)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.file.close()
+                return False
+
+            def write(self, data):
+                self.file.write(data[:7])
+                self.file.flush()
+                raise KeyboardInterrupt
+
+        def interrupting_fdopen(fd, mode="r", *args, **kwargs):
+            return InterruptingWriter(fd, mode, *args, **kwargs)
+
+        with patch("krkn_ai.utils.fs.os.fdopen", side_effect=interrupting_fdopen):
+            with pytest.raises(KeyboardInterrupt):
+                atomic_write_text(str(output_file), "generated_template_content")
+
+        assert output_file.read_text(encoding="utf-8") == "previous_config"
+        assert list(tmp_path.glob(".krkn-ai.yaml.*.tmp")) == []
+
+    def test_does_not_remove_unowned_temp_file_when_open_fails(self, tmp_path):
+        """Cleanup should only remove a temp file created by the current write"""
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+        existing_temp_file = tmp_path / ".krkn-ai.yaml.collision.tmp"
+        existing_temp_file.write_text("other_process", encoding="utf-8")
+
+        with patch("krkn_ai.utils.fs.uuid.uuid4") as mock_uuid:
+            with patch("krkn_ai.utils.fs.os.open", side_effect=FileExistsError):
+                mock_uuid.return_value.hex = "collision"
+
+                with pytest.raises(FileExistsError):
+                    atomic_write_text(str(output_file), "generated_template_content")
+
+        assert existing_temp_file.read_text(encoding="utf-8") == "other_process"
+        assert output_file.read_text(encoding="utf-8") == "previous_config"
+
+    def test_preserves_existing_file_mode(self, tmp_path):
+        """Replacing an existing file should preserve its permission mode"""
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+        os.chmod(output_file, 0o600)
+
+        atomic_write_text(str(output_file), "generated_template_content")
+
+        assert output_file.read_text(encoding="utf-8") == "generated_template_content"
+        assert stat.S_IMODE(os.stat(output_file).st_mode) == 0o600
+
+    def test_chmod_failure_does_not_widen_existing_file_mode(self, tmp_path):
+        """Mode preservation failures should not make existing files more permissive"""
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+        os.chmod(output_file, 0o600)
+
+        with patch("krkn_ai.utils.fs.os.chmod", side_effect=OSError):
+            atomic_write_text(str(output_file), "generated_template_content")
+
+        assert output_file.read_text(encoding="utf-8") == "generated_template_content"
+        assert stat.S_IMODE(os.stat(output_file).st_mode) == 0o600
+
+    def test_follows_output_symlink(self, tmp_path):
+        """Atomic writes should follow symlinks like open(..., "w")"""
+        target_file = tmp_path / "target.yaml"
+        target_file.write_text("previous_config", encoding="utf-8")
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.symlink_to(target_file)
+
+        atomic_write_text(str(output_file), "generated_template_content")
+
+        assert output_file.is_symlink()
+        assert target_file.read_text(encoding="utf-8") == "generated_template_content"
+
+    def test_preserves_existing_extended_attributes(self, tmp_path):
+        """Replacing an existing file should preserve extended attributes"""
+        if not all(hasattr(os, attr) for attr in ("setxattr", "getxattr", "listxattr")):
+            pytest.skip("extended attributes are not available on this platform")
+
+        output_file = tmp_path / "krkn-ai.yaml"
+        output_file.write_text("previous_config", encoding="utf-8")
+
+        xattr_name = None
+        for name in ("user.krkn_test", "krkn_test"):
+            try:
+                os.setxattr(output_file, name, b"previous")
+                xattr_name = name
+                break
+            except OSError:
+                pass
+
+        if xattr_name is None:
+            pytest.skip("extended attributes are not supported by this filesystem")
+
+        atomic_write_text(str(output_file), "generated_template_content")
+
+        assert os.getxattr(output_file, xattr_name) == b"previous"
 
 
 class TestParamParsing:


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

`krkn_ai discover` was writing the generated `krkn-ai.yaml` directly with `open(output, "w")`. That means the destination file was truncated before the new template was fully written. If the process crashed, was interrupted, or hit an I/O error mid-write, users could be left with a partially-written YAML file. The next `krkn_ai run` would then fail later with a confusing parse/config error instead of preserving the last known-good config.

This PR makes the discover output write atomic.

It:

- Adds an `atomic_write_text()` helper that writes to a unique same-directory temporary file before replacing the destination with `os.replace()`
- Flushes and fsyncs the temporary file before replacement, then fsyncs the parent directory after replacement
- Preserves existing file permissions, best-effort ownership, and supported extended attributes when replacing an existing config file
- Updates `discover` to use the new helper instead of writing directly to the output path
- Adds regression coverage for partial-write failure behavior, metadata preservation, and the discover command path

# Documentation

- [ ] Is documentation needed for this update?

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Unit tests added with >80% coverage on changed code
- [x] Changes are consistent with the project's code style (PEP 8, ruff)
- [x] All existing tests pass

# Testing performed

```bash
uv run pytest -q
uv run ruff check .
uv run ruff format --check krkn_ai/cli/cmd.py krkn_ai/utils/fs.py tests/unit/cli/test_cmd.py tests/unit/utils/test_fs.py
uv run mypy --config-file mypy.ini krkn_ai
uv run pre-commit run --files krkn_ai/cli/cmd.py krkn_ai/utils/fs.py tests/unit/cli/test_cmd.py tests/unit/utils/test_fs.py
git diff --check
```
<img width="1469" height="675" alt="image" src="https://github.com/user-attachments/assets/627e95d1-758e-479e-9739-c3776fda23bb" />
