### PR TITLE
fix(config): make elastic config opt-in

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -308,9 +308,7 @@ class ConfigFile(BaseModel):
 
     output: OutputConfig = OutputConfig()
 
-    elastic: Optional[ElasticConfig] = Field(
-        default_factory=ElasticConfig
-    )  # Elasticsearch configuration
+    elastic: Optional[ElasticConfig] = None  # Elasticsearch configuration
 
     cluster_components: ClusterComponents
 

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -33,6 +33,28 @@ class TestGeneticAlgorithmInitialization:
                 assert ga.population == []
                 assert len(ga.best_of_generation) == 0
 
+    def test_init_skips_elasticsearch_without_config(
+        self, minimal_config, temp_output_dir
+    ):
+        """ElasticSearchClient is opt-in."""
+        assert minimal_config.elastic is None
+        with patch("krkn_ai.algorithm.genetic.KrknRunner"):
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                with patch(
+                    "krkn_ai.algorithm.genetic.ElasticSearchClient"
+                ) as mock_elastic:
+                    mock_gen.return_value = [("pod_scenarios", Mock)]
+                    ga = GeneticAlgorithm(
+                        config=minimal_config,
+                        output_dir=temp_output_dir,
+                        format="yaml",
+                    )
+
+                    assert ga.elastic_client is None
+                    mock_elastic.assert_not_called()
+
     def test_init_generates_unique_run_uuid(self, minimal_config, temp_output_dir):
         """Test initialization generates a unique run UUID per instance"""
         with patch("krkn_ai.algorithm.genetic.KrknRunner"):

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -16,6 +16,7 @@ from krkn_ai.models.config import (
     HealthCheckApplicationConfig,
     OutputConfig,
     ClusterComponents,
+    ElasticConfig,
     StoppingCriteria,
 )
 from krkn_ai.models.cluster_components import Namespace, Node
@@ -66,6 +67,7 @@ class TestConfigFile:
         assert isinstance(config_min.scenario, ScenarioConfig)
         assert isinstance(config_min.health_checks, HealthCheckConfig)
         assert isinstance(config_min.output, OutputConfig)
+        assert config_min.elastic is None
 
         # Test with all fields
         cluster_full = ClusterComponents(
@@ -93,6 +95,7 @@ class TestConfigFile:
                 ],
             ),
             output=OutputConfig(result_name_fmt="gen_%g_scenario_%s.yaml"),
+            elastic=ElasticConfig(enable=True, server="https://elastic.example.com"),
             cluster_components=cluster_full,
         )
         assert config.generations == 50
@@ -100,6 +103,9 @@ class TestConfigFile:
         assert config.parameters["key1"].value == "value1"
         assert config.scenario.pod_scenarios.enable is True
         assert len(config.health_checks.applications) == 1
+        assert config.elastic is not None
+        assert config.elastic.enable is True
+        assert config.elastic.server == "https://elastic.example.com"
 
     def test_config_missing_required_fields_raises_error(self):
         """Test that missing required fields raise ValidationError"""


### PR DESCRIPTION


## Summary

I made the Elasticsearch config truly optional.

Before this change, `ConfigFile.elastic` was marked as optional, but it still created a default `ElasticConfig()` object. Because of that, `self.config.elastic is not None` was always true in the genetic algorithm.

Now `elastic` defaults to `None`. An Elasticsearch client is only created when the user adds an `elastic:` config block.

## What I changed

- Changed the default value of `ConfigFile.elastic` to `None`.
- Added a config test to check that minimal configs do not include Elasticsearch by default.
- Added a test to check that `GeneticAlgorithm` does not create `ElasticSearchClient` when `elastic` is missing.
- Kept explicit Elasticsearch config working.

## Why this is correct

The type says `elastic` is optional, so the default should also behave that way.

This also matches the existing check in `GeneticAlgorithm`, which already expects `elastic` to be `None` when Elasticsearch is not configured.

## Tests

- `python -m pytest tests/unit/models/test_config.py tests/unit/algorithm/test_genetic_algorithm.py::TestGeneticAlgorithmInitialization` - Passed.
- `python -m pytest tests/unit/chaos_engines/test_krkn_runner_leak.py` - Passed.
- `python -m pytest -q` - Passed, 251 tests.
- `pre-commit run --files krkn_ai/models/config.py tests/unit/models/test_config.py tests/unit/algorithm/test_genetic_algorithm.py` - Passed.



