### PR TITLE
chore(config): align mypy python_version with project baseline and remove unused sections

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,18 +1,8 @@
 [mypy]
-python_version = 3.9
+python_version = 3.11
 ignore_missing_imports = True
 follow_imports = skip
 no_implicit_optional = False
 show_error_codes = True
 warn_return_any = False
 warn_unused_configs = True
-
-# Ignore missing stubs for third-party libraries
-[mypy-krkn_lib.*]
-ignore_missing_imports = True
-
-[mypy-kubernetes.*]
-ignore_missing_imports = True
-
-[mypy-setuptools.*]
-ignore_missing_imports = True


### PR DESCRIPTION
**Problem**
The `mypy.ini` configuration is currently pinned to Python 3.9 (`python_version = 3.9`) and contains dead configuration blocks, which generates unused-section warnings during local CI runs. The project baseline currently requires Python 3.11+.

**Solution**
Aligned the `python_version` in `mypy.ini` with the project's baseline and removed the unused configuration sections to ensure clean static type checking.

**Testing**
✅ `ruff check .`
✅ `mypy --config-file mypy.ini krkn_ai`
✅ `pytest -q` (253 passed)