### PR TITLE
fix(fitness): reject multi-series PromQL queries with preflight validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ output:
 
 # Fitness function configuration
 fitness_function:
+  # Use an aggregate query that returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
   type: point  # or 'range'
   include_krkn_failure: true

--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -120,6 +120,10 @@ class GeneticAlgorithm:
         # logger.debug("--------------------------------------------------------")
         # logger.debug("%s", json.dumps(self.config.model_dump(), indent=2))
 
+    def validate_fitness_queries(self) -> None:
+        """Delegate to KrknRunner; opt-in preflight from the CLI."""
+        self.krkn_client.validate_fitness_queries()
+
     def simulate(self):
         try:
             results_path = os.path.join(self.output_dir, "results.json")

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -3,7 +3,7 @@ import json
 import datetime
 import tempfile
 import time
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from krkn_ai.chaos_engines.health_check_watcher import HealthCheckWatcher
 from krkn_ai.models.app import (
@@ -13,7 +13,10 @@ from krkn_ai.models.app import (
     KrknRunnerType,
 )
 from krkn_ai.models.config import ConfigFile, FitnessFunctionType
-from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
+from krkn_ai.models.custom_errors import (
+    FitnessFunctionCalculationError,
+    FitnessFunctionValidationError,
+)
 from krkn_ai.models.scenario.base import (
     Scenario,
     BaseScenario,
@@ -59,6 +62,65 @@ class KrknRunner:
         else:
             logger.debug("Using user provided runner type: %s", runner_type)
             self.runner_type = runner_type
+
+    def validate_fitness_queries(self) -> None:
+        """Validate configured fitness queries before running any chaos scenario."""
+        if env_is_truthy("MOCK_FITNESS"):
+            logger.info("Skipping fitness query validation in mock mode")
+            return
+
+        fitness_function = self.config.fitness_function
+        if fitness_function.query is not None:
+            queries_to_validate = [
+                (
+                    fitness_function.query,
+                    "fitness_function.query",
+                    fitness_function.type,
+                )
+            ]
+        else:
+            queries_to_validate = [
+                (item.query, f"fitness_function.items (ID: {item.id})", item.type)
+                for item in fitness_function.items
+            ]
+
+        for query, context, fitness_type in queries_to_validate:
+            if fitness_type == FitnessFunctionType.range:
+                probe_query = query.replace("$range$", "5m")
+            elif fitness_type == FitnessFunctionType.point:
+                if "$range$" in query:
+                    raise FitnessFunctionValidationError(
+                        f"Prometheus query '{query}' in {context} contains $range$, "
+                        "but $range$ is only supported for range fitness queries."
+                    )
+                probe_query = query
+            else:
+                raise FitnessFunctionValidationError(
+                    f"Unsupported fitness_type: {fitness_type!r}. "
+                    "Expected 'point' or 'range'."
+                )
+
+            try:
+                result = self.prom_client.process_query(probe_query)
+            except Exception as error:
+                logger.debug(
+                    "Prometheus probe failed for query '%s'", query, exc_info=True
+                )
+                raise FitnessFunctionValidationError(
+                    f"Prometheus query validation failed for '{query}' in {context}. "
+                    "The query may be syntactically invalid or Prometheus may be "
+                    f"unreachable. Cause: {type(error).__name__}. "
+                    "Run with -v for the full traceback."
+                ) from error
+
+            if isinstance(result, list) and len(result) > 1:
+                raise FitnessFunctionValidationError(
+                    f"Prometheus query '{query}' in {context} returned {len(result)} "
+                    "time series during validation. Fitness queries must return "
+                    "exactly one time series. Use PromQL aggregation such as "
+                    "sum(...), avg(...), max(...), or otherwise constrain labels "
+                    "to produce a single series."
+                )
 
     def __check_runner_availability(self):
         # Check if krknctl is available
@@ -401,24 +463,34 @@ class KrknRunner:
         if env_is_truthy("MOCK_FITNESS"):
             return rng.random()
 
+        if fitness_type not in (FitnessFunctionType.point, FitnessFunctionType.range):
+            raise FitnessFunctionCalculationError(
+                f"Unsupported fitness_type: {fitness_type!r}. "
+                "Expected 'point' or 'range'."
+            )
+
         # Retry to calculate fitness function if it fails
         # Case when data isn't available in prometheus for latest time range
         retries = 3  # Number of retries to calculate fitness function
         retry_delay = 10  # in seconds
+        last_error = None
         for retry in range(retries):
             try:
                 if fitness_type == FitnessFunctionType.point:
                     return self.calculate_point_fitness(start, end, query)
                 elif fitness_type == FitnessFunctionType.range:
                     return self.calculate_range_fitness(start, end, query)
+            except FitnessFunctionValidationError:
+                raise
             except Exception as error:
+                last_error = error
                 logger.error(f"Fitness function calculation failed: {error}")
                 logger.info(
                     f"Retrying fitness function calculation... (retry {retry + 1} of {retries})"
                 )
                 time.sleep(retry_delay)
         raise FitnessFunctionCalculationError(
-            f"Fitness function calculation failed after {retries} retries"
+            f"Fitness function calculation failed after {retries} retries: {last_error}"
         )
 
     def calculate_fitness_score_for_items(self, start, end):
@@ -477,7 +549,9 @@ class KrknRunner:
             The metric value as a string
 
         Raises:
-            FitnessFunctionCalculationError: If Prometheus returns no data
+            FitnessFunctionCalculationError: If Prometheus returns no data.
+            FitnessFunctionValidationError: If Prometheus returns more than
+                one time series for the query.
         """
         result = self.prom_client.process_prom_query_in_range(
             query,
@@ -485,20 +559,41 @@ class KrknRunner:
             end_time=timestamp,
             granularity=100,
         )
-        if not result:
-            raise FitnessFunctionCalculationError(
-                f"Prometheus returned no data for query '{query}' at {timestamp} "
-                f"during {context}. This may indicate the metric does not exist "
-                f"in the requested time range or Prometheus has not yet scraped data."
-            )
-        for series in result:
-            if series.get("values"):
-                return series["values"][-1][1]
-        raise FitnessFunctionCalculationError(
+        no_data_error = (
             f"Prometheus returned no data for query '{query}' at {timestamp} "
             f"during {context}. This may indicate the metric does not exist "
             f"in the requested time range or Prometheus has not yet scraped data."
         )
+        return self._extract_single_prometheus_value(
+            result=result,
+            query=query,
+            context=f"{context} at {timestamp}",
+            no_data_error=no_data_error,
+        )
+
+    def _extract_single_prometheus_value(
+        self,
+        result: Optional[list[dict[str, Any]]],
+        query: str,
+        context: str,
+        no_data_error: str,
+    ) -> str:
+        if not result:
+            raise FitnessFunctionCalculationError(no_data_error)
+
+        if len(result) > 1:
+            raise FitnessFunctionValidationError(
+                f"Prometheus query '{query}' returned {len(result)} time series during "
+                f"{context}. Fitness queries must return exactly one time series. "
+                "Use PromQL aggregation such as sum(...), avg(...), max(...), or "
+                "otherwise constrain labels to produce a single series."
+            )
+
+        values = result[0].get("values")
+        if values:
+            return values[-1][1]
+
+        raise FitnessFunctionCalculationError(no_data_error)
 
     def calculate_range_fitness(self, start, end, query):
         """
@@ -527,19 +622,18 @@ class KrknRunner:
             end_time=end,
             granularity=100,
         )
-        if not result:
-            raise FitnessFunctionCalculationError(
-                f"Prometheus returned no data for query '{query}' in range "
-                f"[{start}, {end}]. This may indicate the metric does not exist "
-                f"in the requested time range or Prometheus has not yet scraped data."
-            )
-        for series in result:
-            if series.get("values"):
-                return float(series["values"][-1][1])
-        raise FitnessFunctionCalculationError(
+        no_data_error = (
             f"Prometheus returned no data for query '{query}' in range "
             f"[{start}, {end}]. This may indicate the metric does not exist "
             f"in the requested time range or Prometheus has not yet scraped data."
+        )
+        return float(
+            self._extract_single_prometheus_value(
+                result=result,
+                query=query,
+                context=f"range [{start}, {end}]",
+                no_data_error=no_data_error,
+            )
         )
 
     def __extract_returncode_from_run(

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -79,6 +79,16 @@ def main():
     help="Port to run Streamlit server on when monitoring is enabled.",
     default=8501,
 )
+@click.option(
+    "--validate-queries",
+    is_flag=True,
+    default=False,
+    help=(
+        "Pre-validate PromQL fitness queries against a live Prometheus "
+        "connection before running. Requires PROMETHEUS_URL/PROMETHEUS_TOKEN "
+        "or OpenShift auto-discovery."
+    ),
+)
 @click.pass_context
 def run(
     ctx,
@@ -92,6 +102,7 @@ def run(
     verbose: int = 0,  # Default to INFO level
     monitoring: bool = False,
     port: int = 8501,
+    validate_queries: bool = False,
 ):
     run_uuid = str(uuid.uuid4())
     new_output_path = os.path.join(output, run_uuid)
@@ -149,6 +160,8 @@ def run(
             format=format,
             runner_type=enum_runner_type,
         )
+        if validate_queries:
+            genetic.validate_fitness_queries()
         genetic.simulate()
 
         genetic.save()

--- a/krkn_ai/models/custom_errors.py
+++ b/krkn_ai/models/custom_errors.py
@@ -30,6 +30,14 @@ class FitnessFunctionCalculationError(Exception):
     pass
 
 
+class FitnessFunctionValidationError(FitnessFunctionCalculationError):
+    """
+    Exception raised when a fitness function query result is invalid.
+    """
+
+    pass
+
+
 class ScenarioParameterInitError(Exception):
     """
     Exception raised when there is an error initializing a scenario parameter.

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -38,6 +38,7 @@ elastic:
 
 
 fitness_function:
+  # Use an aggregate query that returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total)'
   type: point
   include_krkn_failure: true

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -11,13 +11,40 @@ from krkn_ai.chaos_engines.krkn_runner import KrknRunner
 from krkn_ai.models.app import KrknRunnerType
 from krkn_ai.models.config import (
     FitnessFunction,
+    FitnessFunctionItem,
     FitnessFunctionType,
     HealthCheckConfig,
 )
-from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
+from krkn_ai.models.custom_errors import (
+    FitnessFunctionCalculationError,
+    FitnessFunctionValidationError,
+)
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
 from krkn_ai.models.cluster_components import ClusterComponents
+
+
+def make_runner(minimal_config, temp_output_dir, mock_prom_client):
+    with patch(
+        "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+        return_value=mock_prom_client,
+    ):
+        return KrknRunner(
+            config=minimal_config,
+            output_dir=temp_output_dir,
+            runner_type=KrknRunnerType.CLI_RUNNER,
+        )
+
+
+MULTI_SERIES_RANGE_RESULT = [
+    {"metric": {"pod": "cart"}, "values": [[1000, "5"]]},
+    {"metric": {"pod": "catalogue"}, "values": [[1000, "8"]]},
+]
+
+MULTI_SERIES_INSTANT_RESULT = [
+    {"metric": {"pod": "cart"}, "value": [1000, "5"]},
+    {"metric": {"pod": "catalogue"}, "value": [1000, "8"]},
+]
 
 
 class TestKrknRunnerInitialization:
@@ -60,6 +87,151 @@ class TestKrknRunnerInitialization:
         with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client"):
             with pytest.raises(Exception, match="krknctl and podman are not available"):
                 KrknRunner(config=minimal_config, output_dir=temp_output_dir)
+
+
+class TestKrknRunnerQueryValidation:
+    """Test opt-in preflight fitness query validation (validate_fitness_queries)"""
+
+    def test_validation_fails_with_multi_series(self, minimal_config, temp_output_dir):
+        """Preflight rejects queries that return multiple time series"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.return_value = MULTI_SERIES_INSTANT_RESULT
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        error = str(exc_info.value)
+        assert "returned 2 time series during validation" in error
+        assert "exactly one time series" in error
+
+    def test_validation_fails_with_invalid_query_syntax(
+        self, minimal_config, temp_output_dir
+    ):
+        """Preflight rejects invalid PromQL queries"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="invalid_query(",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.side_effect = RuntimeError(
+            "bad query syntax with secret-token"
+        )
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        error = str(exc_info.value)
+        assert "may be syntactically invalid" in error
+        assert "Cause: RuntimeError" in error
+        assert "secret-token" not in error
+
+    def test_validation_rejects_range_parameter_in_point_query(
+        self, minimal_config, temp_output_dir
+    ):
+        """Preflight rejects $range$ in point queries because runtime will not replace it"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="rate(container_cpu_usage_seconds_total[$range$])",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError) as exc_info:
+            runner.validate_fitness_queries()
+
+        error = str(exc_info.value)
+        assert "$range$ is only supported for range fitness queries" in error
+        mock_prom_client.process_query.assert_not_called()
+
+    def test_validation_substitutes_range_parameter(
+        self, minimal_config, temp_output_dir
+    ):
+        """Preflight substitutes $range$ with a sample range"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="rate(container_cpu_usage_seconds_total[$range$])",
+            type=FitnessFunctionType.range,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.return_value = [{"value": [1000, "0.5"]}]
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        mock_prom_client.process_query.assert_called_once_with(
+            "rate(container_cpu_usage_seconds_total[5m])"
+        )
+
+    def test_validation_skips_empty_result(self, minimal_config, temp_output_dir):
+        """Preflight allows queries with no data before chaos runs (metric may appear later)"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(metric_that_has_no_samples_yet)",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.return_value = []
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        mock_prom_client.process_query.assert_called_once()
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=True)
+    def test_validation_skips_in_mock_fitness_mode(
+        self, mock_env, minimal_config, temp_output_dir
+    ):
+        """Preflight is a no-op when MOCK_FITNESS is enabled"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        mock_prom_client.process_query.assert_not_called()
+
+    def test_validation_checks_fitness_items(self, minimal_config, temp_output_dir):
+        """Preflight validates each weighted fitness item when query is unset"""
+        minimal_config.fitness_function = FitnessFunction(
+            items=[
+                FitnessFunctionItem(
+                    query="sum(kube_pod_container_status_restarts_total)",
+                    type=FitnessFunctionType.point,
+                )
+            ]
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.return_value = [{"value": [1000, "1"]}]
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        runner.validate_fitness_queries()
+
+        mock_prom_client.process_query.assert_called_once_with(
+            "sum(kube_pod_container_status_restarts_total)"
+        )
+
+    def test_init_does_not_auto_validate(self, minimal_config, temp_output_dir):
+        """KrknRunner.__init__ must not call Prometheus; validation is opt-in via --validate-queries"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+        mock_prom_client = Mock()
+        mock_prom_client.process_query.return_value = [
+            {"value": [1000, "5"]},
+            {"value": [1000, "8"]},
+        ]
+
+        make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        mock_prom_client.process_query.assert_not_called()
 
 
 class TestKrknRunnerRun:
@@ -387,6 +559,68 @@ class TestCalculatePointFitness:
             assert "up" in str(exc_info.value)
             assert "2024-01-01 12:00:00" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        "result",
+        [
+            MULTI_SERIES_RANGE_RESULT,
+            [
+                {"metric": {"pod": "cart"}, "values": [[1000, "5"]]},
+                {"metric": {"pod": "catalogue"}, "values": []},
+            ],
+        ],
+    )
+    def test_query_prometheus_single_point_multi_series_raises_error(
+        self, result, minimal_config, temp_output_dir
+    ):
+        """Test point fitness rejects PromQL queries that return multiple time series"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = result
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError) as exc_info:
+            runner._query_prometheus_single_point(
+                "kube_pod_container_status_restarts_total",
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                "point fitness (start)",
+            )
+
+        error = str(exc_info.value)
+        assert "returned 2 time series" in error
+        assert "exactly one time series" in error
+        assert "sum(...)" in error
+
+    def test_calculate_range_fitness_multi_series_raises_error(
+        self, minimal_config, temp_output_dir
+    ):
+        """Test range fitness rejects PromQL queries that return multiple time series"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="rate(container_cpu_usage_seconds_total[$range$])",
+            type=FitnessFunctionType.range,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = (
+            MULTI_SERIES_RANGE_RESULT
+        )
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError) as exc_info:
+            runner.calculate_range_fitness(
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                datetime.datetime(2024, 1, 1, 12, 10, 0),
+                "rate(container_cpu_usage_seconds_total[$range$])",
+            )
+
+        error = str(exc_info.value)
+        assert "returned 2 time series" in error
+        assert "rate(container_cpu_usage_seconds_total[10m])" in error
+        assert "exactly one time series" in error
+
 
 class TestCalculateRangeFitness:
     """Test calculate_range_fitness"""
@@ -501,6 +735,32 @@ class TestCalculateFitnessValueRetries:
 
     @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
     @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    def test_calculate_fitness_value_rejects_unsupported_type(
+        self, mock_env, mock_sleep, minimal_config, temp_output_dir
+    ):
+        """Test unsupported fitness types fail before entering the retry loop"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionCalculationError) as exc_info:
+            runner.calculate_fitness_value(
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                datetime.datetime(2024, 1, 1, 12, 5, 0),
+                "sum(kube_pod_container_status_restarts_total)",
+                "histogram",
+            )
+
+        assert "Unsupported fitness_type" in str(exc_info.value)
+        mock_sleep.assert_not_called()
+        mock_prom_client.process_prom_query_in_range.assert_not_called()
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
     def test_calculate_fitness_value_retries_on_empty_data(
         self, mock_env, mock_sleep, minimal_config, temp_output_dir
     ):
@@ -585,3 +845,31 @@ class TestCalculateFitnessValueRetries:
             # Each retry calls calculate_point_fitness which calls _query_prometheus_single_point
             # for the start point. The guard fails immediately, so 1 Prometheus call per retry = 3 total.
             assert mock_prom_client.process_prom_query_in_range.call_count == 3
+
+    @patch("krkn_ai.chaos_engines.krkn_runner.time.sleep")
+    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    def test_calculate_fitness_value_does_not_retry_validation_error(
+        self, mock_env, mock_sleep, minimal_config, temp_output_dir
+    ):
+        """Test that query validation errors are not retried as transient failures"""
+        minimal_config.fitness_function = FitnessFunction(
+            query="kube_pod_container_status_restarts_total",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = (
+            MULTI_SERIES_RANGE_RESULT
+        )
+        runner = make_runner(minimal_config, temp_output_dir, mock_prom_client)
+
+        with pytest.raises(FitnessFunctionValidationError):
+            runner.calculate_fitness_value(
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                datetime.datetime(2024, 1, 1, 12, 5, 0),
+                "kube_pod_container_status_restarts_total",
+                FitnessFunctionType.point,
+            )
+
+        mock_sleep.assert_not_called()
+        assert mock_prom_client.process_prom_query_in_range.call_count == 1

--- a/tests/unit/chaos_engines/test_krkn_runner_leak.py
+++ b/tests/unit/chaos_engines/test_krkn_runner_leak.py
@@ -28,7 +28,7 @@ class TestKrknRunnerThreadLeak(unittest.TestCase):
         config.health_checks = MagicMock(spec=HealthCheckConfig)
         config.elastic = None
         config.wait_duration = 10
-        config.parameters = {}  # Pydantic v2 fields aren't in MagicMock spec; set explicitly
+        config.parameters = {}
 
         from krkn_ai.models.scenario.base import Scenario
 


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

When a fitness query returned more than one Prometheus series, krkn-ai silently picked one of them and dropped the rest. Prometheus orders results by an internal label hash, so the "picked" series was effectively random and could change from one call to the next. Two things this broke in practice:

- In `point` mode, `_query_prometheus_single_point` is called twice: once at the start of the scenario, once at the end. Those two calls could land on different containers, so the diff would sometimes come out negative even when the system was clearly degrading.
- In `range` mode, the helper just returned the value from one arbitrary series and ignored everything else.

The genetic algorithm then cached these scores in `seen_population` and used them for selection and best-of-generation tracking. So evolution was running on noise instead of signal, and nothing in the logs gave any hint that something was off.

This PR makes the behavior safer by:

- Adding a runtime guard in `_extract_single_prometheus_value` that raises `FitnessFunctionValidationError` (a subclass of the existing `FitnessFunctionCalculationError`) when a query returns more than one series. The error message tells the user exactly what to do, wrap the query in `sum(...)`, `avg(...)`, `max(...)`, or constrain its labels.
- Adding an **opt-in** startup preflight behind a new `--validate-queries` CLI flag. When the flag is passed, krkn-ai probes each active fitness query against Prometheus before the GA starts, so a typo, missing aggregation, or unreachable Prometheus fails immediately instead of after the first scenario completes ten minutes later. Default behavior is unchanged without the flag, preflight does nothing and no extra Prometheus call is made at startup.
- Skipping the retry loop on `FitnessFunctionValidationError`, since multi-series is a permanent config error and not worth burning 3 × 10s on. The underlying error is also now surfaced in the "retries exhausted" message instead of being swallowed.
- Failing fast when `fitness_type` is neither `point` nor `range`, so a misconfigured value doesn't iterate the retry loop silently and surface a useless "retries exhausted: None" message. The check runs in both the runtime path and the opt-in preflight.
- Logging the full underlying error at debug level when preflight fails, and surfacing only the exception *type* (e.g. `ConnectionError`) in the user-facing message. This avoids accidentally leaking auth headers or token-bearing URLs that some HTTP-client exceptions include in their string form.
- Rejecting `$range$` in `point`-mode queries at preflight, since the runtime doesn't substitute `$range$` in that path and would otherwise send the literal `$range$` token to Prometheus.
- Honoring `MOCK_FITNESS` so unit tests and offline dry-runs don't need a live Prometheus even when `--validate-queries` is passed.
- Adding a one-line reminder in the README and the generated config template that fitness queries should aggregate to a single series.

The preflight follows the same precedence the runner uses at runtime: when `fitness_function.query` is set, only that query is validated; otherwise each entry in `fitness_function.items` is. This avoids confusing failures on unused `items` blocks that the runner would never actually execute.

And because the new exception subclasses the existing one, the CLI's `except FitnessFunctionCalculationError` handler in `cli/cmd.py` still catches it cleanly, no extra wiring needed.

#313 fixes the same root-cause bug with the runtime guard. I landed there independently while building the preflight side. This PR adds the opt-in `--validate-queries` preflight, surfaces `last_error` after retries, documents `granularity=100`, broadens the error message, and adds extra regression tests on top of the same guard.

# Documentation

- [x] Is documentation needed for this update?

The README and the generated config template get a one-line reminder that fitness queries should return a single Prometheus series. The new `--validate-queries` flag is documented in its Click `--help` text.

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] Unit test added for the changed behavior
- [x] Changes are consistent with the project's code style
- [x] Existing tests pass

# Testing performed

```bash
./.venv/bin/pytest tests/unit/chaos_engines/test_krkn_runner.py -q
./.venv/bin/pytest -q
./.venv/bin/ruff check krkn_ai/ tests/
./.venv/bin/pre-commit run --files \
  README.md \
  krkn_ai/algorithm/genetic.py \
  krkn_ai/chaos_engines/krkn_runner.py \
  krkn_ai/cli/cmd.py \
  krkn_ai/models/custom_errors.py \
  krkn_ai/templates/krkn-ai.yaml.j2 \
  tests/unit/chaos_engines/test_krkn_runner.py \
  tests/unit/chaos_engines/test_krkn_runner_leak.py
```
