### PR TITLE
fix(fitness): advance end and forward-look post-test scrape in point queries

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -401,14 +401,22 @@ class KrknRunner:
         if env_is_truthy("MOCK_FITNESS"):
             return rng.random()
 
-        # Retry to calculate fitness function if it fails
-        # Case when data isn't available in prometheus for latest time range
+        # Retry to calculate fitness function if it fails.
+        # Case when data isn't available in prometheus for latest time range.
+        # For point fitness, each retry advances `current_end` by `retry_delay`
+        # so the next attempt's query lands at a later timestamp, picking up
+        # scrapes that arrived during the wall-clock sleep. Prometheus does
+        # not backfill, so re-querying the same instant would hit the same gap.
+        # For range fitness the window stays pinned to the original
+        # [start, end] because advancing `end` would stretch the user's
+        # `$range$` substitution and bias the measurement.
         retries = 3  # Number of retries to calculate fitness function
         retry_delay = 10  # in seconds
+        current_end = end
         for retry in range(retries):
             try:
                 if fitness_type == FitnessFunctionType.point:
-                    return self.calculate_point_fitness(start, end, query)
+                    return self.calculate_point_fitness(start, current_end, query)
                 elif fitness_type == FitnessFunctionType.range:
                     return self.calculate_range_fitness(start, end, query)
             except Exception as error:
@@ -417,6 +425,8 @@ class KrknRunner:
                     f"Retrying fitness function calculation... (retry {retry + 1} of {retries})"
                 )
                 time.sleep(retry_delay)
+                if fitness_type == FitnessFunctionType.point:
+                    current_end = current_end + datetime.timedelta(seconds=retry_delay)
         raise FitnessFunctionCalculationError(
             f"Fitness function calculation failed after {retries} retries"
         )


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

# Description

The retry loop in `calculate_fitness_value` sleeps `retry_delay` between attempts but passes the same `start` and `end` to every attempt. Prometheus doesn't backfill, so re-querying the same window after waiting hits the same gap. The sleep was wasted, and runs that would have succeeded with one more scrape interval were aborting after three retries.

There's a related issue at `_query_prometheus_single_point`, which queried `[t, t]` with no slack for scrape jitter. For point fitness on monotonic counters (restart counts and similar), the end-side query returned the most recent during-test scrape, missing increments that landed in the final seconds of the test and were only captured by the first post-test scrape. The GA cached those under-counted deltas and used them for selection, so evolution was running on biased fitness with nothing in the logs to flag it.

The fix is asymmetric, because "before the test" and "after the test" want opposite query directions:

- `_query_prometheus_single_point` gets a `look_forward: bool = False` keyword argument. Default queries `[t - PROM_POINT_WINDOW_SECONDS, t]` and returns the last sample. `look_forward=True` queries `[t, t + PROM_POINT_WINDOW_SECONDS]` and returns the first.
- `calculate_point_fitness` passes `look_forward=True` on the end side, unchanged on start.
- `calculate_fitness_value` tracks `current_end` and advances it by `retry_delay` after each failed attempt, so the forward-look window in subsequent retries actually covers the wall-clock territory the sleep made available.
- `calculate_range_fitness` is untouched. Range queries already span a real window via `$range$`.

The new parameter is keyword-only with a backward-compatible default, so every existing call site keeps working. Existing test mocks return single-element `values` lists where `[0]` and `[-1]` are identical, so the asymmetric directions produce the same results against current fixtures.

# Documentation

- [ ] Is documentation needed for this update?

# Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] Unit test added for the changed behavior
- [x] Changes are consistent with the project's code style
- [x] Existing tests pass

# Testing performed

```bash
./.venv/bin/pytest tests/unit/chaos_engines/test_krkn_runner.py -v
./.venv/bin/pytest tests/ -q
./.venv/bin/ruff check krkn_ai/chaos_engines/krkn_runner.py
./.venv/bin/ruff format --check krkn_ai/chaos_engines/krkn_runner.py
./.venv/bin/mypy --config-file mypy.ini krkn_ai/chaos_engines/krkn_runner.py
./.venv/bin/pre-commit run --files krkn_ai/chaos_engines/krkn_runner.py
```
<img width="1130" height="803" alt="image" src="https://github.com/user-attachments/assets/376a5c6d-426b-40da-b777-e48d8deb47a5" />
