### PR TITLE
fix(deps): pin krkn-lib dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "plotly>=6.6.0",
   "streamlit>=1.55.0",
   # VCS dependency
-  "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@v6.0.6",
+  "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@a89b299b1789eeb8f8ed07213eccd77414f03283",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "plotly>=6.6.0",
   "streamlit>=1.55.0",
   # VCS dependency
-  "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib",
+  "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@v6.0.6",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "seaborn",
   "plotly>=6.6.0",
   "streamlit>=1.55.0",
-  # VCS dependency
+  # Keep this pin in sync with requirements.txt.
   "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@a89b299b1789eeb8f8ed07213eccd77414f03283",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ notebook
 jupyterlab
 requests
 click
-krkn-lib@git+https://github.com/krkn-chaos/krkn-lib
+krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@v6.0.6
 pyyaml
 seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ notebook
 jupyterlab
 requests
 click
-krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@v6.0.6
+krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@a89b299b1789eeb8f8ed07213eccd77414f03283
 pyyaml
 seaborn


### PR DESCRIPTION


## Summary

I pinned `krkn-lib` to the commit behind the `v6.0.6` release tag.

Before this change, installs pulled `krkn-lib` from the default branch. That could change at any time.

Now normal installs and container builds use the same fixed commit.

## How I found it

I searched the repo for `krkn-lib` and its GitHub URL. The dependency was listed in `pyproject.toml` and `requirements.txt`.

The container also installs from `requirements.txt`, so that file needed the same pin.

I checked the local `conda-krkn` environment and saw `krkn-lib` version `6.0.6`. I also resolved the upstream `v6.0.6` tag to its commit SHA and used that SHA.

## What I changed

- Added the `v6.0.6` commit SHA to the `krkn-lib` URL in `pyproject.toml`.
- Added the same commit SHA in `requirements.txt`.
- Kept both install paths on the same commit.

## Why this is correct

The issue asks for a commit or tag pin. This uses the stricter option: a full commit SHA.

I did not touch the unrelated modified files that were already present in the working tree.


## Tests

- `python -c "... Requirement(...)"` - Passed. The dependency strings parse.
- `pre-commit run --files pyproject.toml requirements.txt` - Passed.
- `python -m pytest -q` - Passed, 254 tests.


