### PR TITLE
fix: duration-mode runs overshoot configured budget due to missing pre-generation and pre-sleep time checks

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -134,6 +134,7 @@ class GeneticAlgorithm:
         # Variables to track the progress of the algorithm
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
         start_time = time.time()
+        mono_start = time.monotonic()
         cur_generation = 0
 
         # Establish baseline by running dummy scenario to evaluate cluster health, fitness score before chaos testing
@@ -145,6 +146,13 @@ class GeneticAlgorithm:
         while True:
             # Calculate elapsed time since the start of the algorithm
             elapsed_time = time.time() - start_time
+
+            if self.config.duration is not None:
+                if time.monotonic() - mono_start >= self.config.duration:
+                    logger.info(
+                        "Duration budget exhausted before generation start, stopping."
+                    )
+                    break
 
             # Check all stopping criteria before processing generation
             if self._check_and_stop(cur_generation, elapsed_time):
@@ -198,6 +206,16 @@ class GeneticAlgorithm:
             elapsed_after_eval = time.time() - start_time
             if self._check_and_stop(cur_generation, elapsed_after_eval):
                 break
+
+            if self.config.duration is not None:
+                elapsed = time.monotonic() - mono_start
+                remaining = self.config.duration - elapsed
+                if remaining <= 0:
+                    logger.info("Duration budget exhausted, skipping wait.")
+                    break
+                time.sleep(min(self.config.wait_duration, remaining))
+            else:
+                time.sleep(self.config.wait_duration)
 
             # Repopulate off-springs
             self.population = []

--- a/tests/test_duration_mode.py
+++ b/tests/test_duration_mode.py
@@ -1,0 +1,168 @@
+#
+# Copyright 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import Mock, patch
+
+from krkn_ai.algorithm.genetic import GeneticAlgorithm
+
+
+class TestDurationModeOvershoot:
+    """Test duration mode overshoot fixes in simulate loop"""
+
+    def test_loop_exits_before_generation_when_budget_exhausted(
+        self, minimal_config, temp_output_dir
+    ):
+        """Loop exits when elapsed >= duration before starting a new generation"""
+        minimal_config.duration = 60
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner_class.return_value = mock_runner
+
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+
+                # Mock time.monotonic to simulate elapsed > duration
+                with patch("time.monotonic") as mock_monotonic:
+                    # start_time, then the check inside loop
+                    mock_monotonic.side_effect = [0.0, 65.0]
+
+                    with patch("time.time", return_value=0.0):
+                        with patch("time.sleep") as mock_sleep:
+                            ga.simulate()
+
+                            # Should have broken out of loop before calculating fitness (generation 1)
+                            # And sleep shouldn't be called because the loop exited
+                            mock_sleep.assert_not_called()
+                            assert ga.completed_generations == 0
+
+    def test_wait_sleep_skipped_when_no_budget_remains(
+        self, minimal_config, temp_output_dir
+    ):
+        """wait_duration sleep is skipped when no time remains"""
+        minimal_config.duration = 60
+        minimal_config.wait_duration = 30
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner.run = Mock()
+            mock_runner.run.return_value.fitness_result.fitness_score = 10.0
+            mock_runner.run.return_value.scenario = Mock()
+            mock_runner_class.return_value = mock_runner
+
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                ga.krkn_client = mock_runner
+                ga.run_baseline = Mock()
+
+                with patch("time.monotonic") as mock_monotonic:
+                    # 1: start_time
+                    # 2: before gen check (0 -> 10s elapsed)
+                    # 3: before sleep check (10 -> 65s elapsed)
+                    mock_monotonic.side_effect = [0.0, 10.0, 65.0]
+
+                    with patch("time.time", return_value=0.0):
+                        with patch("time.sleep") as mock_sleep:
+                            ga.simulate()
+
+                            # Should have completed 1 generation and exited before sleep
+                            assert ga.completed_generations == 1
+                            mock_sleep.assert_not_called()
+
+    def test_wait_sleeps_only_remaining_time(self, minimal_config, temp_output_dir):
+        """A generation that starts with time remaining runs to completion and sleeps remaining time"""
+        minimal_config.duration = 60
+        minimal_config.wait_duration = 30
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner.run = Mock()
+            mock_runner.run.return_value.fitness_result.fitness_score = 10.0
+            mock_runner.run.return_value.scenario = Mock()
+            mock_runner_class.return_value = mock_runner
+
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                ga.krkn_client = mock_runner
+                ga.run_baseline = Mock()
+
+                with patch("time.monotonic") as mock_monotonic:
+                    # 1: start_time (0s)
+                    # 2: before gen 1 check (10s elapsed)
+                    # 3: before sleep gen 1 check (45s elapsed, remaining = 15s) -> sleep(15)
+                    # 4: before gen 2 check (65s elapsed, after sleep) -> exits loop
+                    mock_monotonic.side_effect = [0.0, 10.0, 45.0, 65.0]
+
+                    with patch("time.time", return_value=0.0):
+                        with patch("time.sleep") as mock_sleep:
+                            ga.simulate()
+
+                            assert ga.completed_generations == 1
+                            mock_sleep.assert_called_once_with(15.0)
+
+    def test_generation_mode_unaffected(self, minimal_config, temp_output_dir):
+        """Existing generations-based loop is unaffected by this change"""
+        minimal_config.duration = None
+        minimal_config.generations = 2
+        minimal_config.wait_duration = 5
+
+        with patch("krkn_ai.algorithm.genetic.KrknRunner") as mock_runner_class:
+            mock_runner = Mock()
+            mock_runner.run = Mock()
+            mock_runner.run.return_value.fitness_result.fitness_score = 10.0
+            mock_runner.run.return_value.scenario = Mock()
+            mock_runner_class.return_value = mock_runner
+
+            with patch(
+                "krkn_ai.algorithm.genetic.ScenarioFactory.generate_valid_scenarios"
+            ) as mock_gen:
+                mock_gen.return_value = [("pod_scenarios", Mock)]
+
+                ga = GeneticAlgorithm(
+                    config=minimal_config, output_dir=temp_output_dir, format="yaml"
+                )
+                ga.krkn_client = mock_runner
+                ga.run_baseline = Mock()
+
+                with patch("time.monotonic") as mock_monotonic:
+                    # start_time, then unused monotonic calls since duration is None
+                    mock_monotonic.side_effect = [0.0, 10.0, 20.0, 30.0, 40.0, 50.0]
+                    with patch("time.time", return_value=0.0):
+                        with patch("time.sleep") as mock_sleep:
+                            ga.simulate()
+
+                            assert ga.completed_generations == 2
+                            # Sleep called twice with wait_duration=5
+                            assert mock_sleep.call_count == 2
+                            mock_sleep.assert_called_with(5)


### PR DESCRIPTION
## Problem

In duration mode, the genetic algorithm simulation loop overshoots the configured `duration` budget. A run configured for 120s can take 150s or more before stopping.

## Root Cause

In `krkn_ai/algorithm/genetic.py` → `simulate()`, elapsed time is only checked as a stopping criterion **after** a generation fully completes. Two paths cause overshoot:

1. **Missing pre-generation check** — a generation that starts with 5s remaining still runs to full completion (e.g. 90s), blowing the budget entirely.
2. **Unconditional wait sleep** — `wait_duration` is slept in full even when zero budget remains, adding unnecessary time after the last generation.

Concrete example: `duration=120s`, generation takes 90s, `wait_duration=30s` → actual runtime ~150s.

## Solution

Introduced `time.monotonic()` checks at two surgical locations in `simulate()`:

- **Before each generation**: exit immediately if elapsed ≥ duration
- **Before sleeping**: sleep only `min(wait_duration, remaining)`, skip entirely if no budget remains

Generation-mode (`duration=None`) is completely unaffected.

## Files Changed

- `krkn_ai/algorithm/genetic.py`
- `tests/test_duration_mode.py` (new)

## How to Test

```bash
pytest tests/test_duration_mode.py -v
```

## Checklist

- [ ] Existing tests pass: `pytest tests/`
- [ ] New tests added and passing
- [ ] No cluster required to run new tests
- [ ] Apache 2.0 header on new test file
- [ ] Squashed to single commit
- [ ] `pre-commit run --all-files` passes