### PR TITLE
fix: correct per-generation average fitness when scenarios repeat across generations

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -83,6 +83,9 @@ class GeneticAlgorithm:
         self.seen_population: Dict[
             BaseScenario, CommandRunResult
         ] = {}  # Map between scenario and its result
+        self.all_evaluated_results: List[
+            CommandRunResult
+        ] = []  # All results incl. cache hits, for per-gen stats
         self.best_of_generation: List[BaseScenario] = []
 
         self.health_check_reporter = HealthCheckReporter(
@@ -544,6 +547,8 @@ class GeneticAlgorithm:
             result = self.seen_population[scenario]
             result = copy.deepcopy(result)
             result.generation_id = generation_id
+            # Track cache-hit result so per-generation average stats are correct
+            self.all_evaluated_results.append(result)
             return result
 
         # This is a new scenario - track it for exploration limit
@@ -553,6 +558,8 @@ class GeneticAlgorithm:
 
         # Add scenario to seen population
         self.seen_population[scenario] = scenario_result
+        # Track every evaluated result (fresh run) for per-generation stats
+        self.all_evaluated_results.append(scenario_result)
 
         # Save scenario result
         self.save_scenario_result(scenario_result)
@@ -782,6 +789,7 @@ class GeneticAlgorithm:
             completed_generations=self.completed_generations,
             seed=self.seed,
             scenario_mutation_rate=self.current_scenario_mutation_rate,
+            all_evaluated_results=self.all_evaluated_results,
         )
         summary_reporter.save(self.output_dir)
 

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -35,6 +35,7 @@ class JSONSummaryReporter:
         completed_generations: int = 0,
         seed: Optional[int] = None,
         scenario_mutation_rate: Optional[float] = None,
+        all_evaluated_results: Optional[List[CommandRunResult]] = None,
     ):
         """
         Initialize the JSON summary reporter.
@@ -44,12 +45,19 @@ class JSONSummaryReporter:
             config: Configuration used for this run.
             seen_population: Map of scenarios to their execution results.
             best_of_generation: List of best results per generation.
+            baseline_result: Result from the baseline run (optional).
             start_time: When the run started.
             end_time: When the run ended.
             completed_generations: Number of generations completed.
             seed: Random seed used for the run (if any).
             scenario_mutation_rate: Scenario mutation rate to write in the
                 summary.
+            all_evaluated_results: Every ``CommandRunResult`` returned by
+                ``calculate_fitness()``, including cache-hit copies with their
+                corrected ``generation_id``.  When provided, this list is used
+                to compute per-generation average fitness scores accurately.
+                Falls back to ``list(seen_population.values())`` when omitted
+                for backward compatibility.
         """
         self.run_uuid = run_uuid
         self.config = config
@@ -64,6 +72,13 @@ class JSONSummaryReporter:
             config.scenario_mutation_rate
             if scenario_mutation_rate is None
             else scenario_mutation_rate
+        )
+        # Fall back to seen_population values for backward compatibility when
+        # all_evaluated_results is not provided (e.g., in older tests/callers).
+        self.all_evaluated_results: List[CommandRunResult] = (
+            all_evaluated_results
+            if all_evaluated_results is not None
+            else list(seen_population.values())
         )
         self.status = STATUS_COMPLETED
 
@@ -143,13 +158,20 @@ class JSONSummaryReporter:
         return results_summary
 
     def _build_fitness_progression(self) -> List[Dict[str, Any]]:
-        """Build fitness progression data from best_of_generation."""
+        """Build fitness progression data from best_of_generation.
+
+        Uses ``all_evaluated_results`` (which includes cache-hit results with
+        their corrected ``generation_id``) rather than ``seen_population`` so
+        that scenarios repeated across generations are attributed to the right
+        generation when computing per-generation averages.
+        """
         fitness_progression = []
         for i, result in enumerate(self.best_of_generation):
-            # Calculate average fitness for this generation from seen_population
+            # Calculate average fitness for this generation from all evaluated results,
+            # including cache-hit scenarios that carry the correct generation_id.
             gen_fitness_scores = [
                 r.fitness_result.fitness_score
-                for r in self.seen_population.values()
+                for r in self.all_evaluated_results
                 if r.generation_id == i
             ]
             gen_average = 0.0

--- a/tests/unit/algorithm/test_fitness_calculation.py
+++ b/tests/unit/algorithm/test_fitness_calculation.py
@@ -91,3 +91,84 @@ class TestFitnessCalculation:
         assert result.generation_id == new_generation_id
         # Should not call krkn_client.run (using cache)
         genetic_algorithm_with_mock_runner.krkn_client.run.assert_not_called()
+
+    def test_all_evaluated_results_populated_for_fresh_scenario(
+        self, genetic_algorithm_with_mock_runner
+    ):
+        """Fresh scenario run must be appended to all_evaluated_results."""
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        generation_id = 0
+        mock_result = CommandRunResult(
+            generation_id=generation_id,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="test-command",
+            log="test-log",
+            returncode=0,
+            start_time=datetime.datetime.now(),
+            end_time=datetime.datetime.now(),
+            fitness_result=FitnessResult(fitness_score=42.0),
+            health_check_results={},
+        )
+        genetic_algorithm_with_mock_runner.krkn_client.run = Mock(
+            return_value=mock_result
+        )
+
+        with patch.object(genetic_algorithm_with_mock_runner, "save_scenario_result"):
+            with patch.object(
+                genetic_algorithm_with_mock_runner.health_check_reporter, "plot_report"
+            ):
+                with patch.object(
+                    genetic_algorithm_with_mock_runner.health_check_reporter,
+                    "write_fitness_result",
+                ):
+                    assert (
+                        len(genetic_algorithm_with_mock_runner.all_evaluated_results)
+                        == 0
+                    )
+                    genetic_algorithm_with_mock_runner.calculate_fitness(
+                        scenario, generation_id
+                    )
+                    assert (
+                        len(genetic_algorithm_with_mock_runner.all_evaluated_results)
+                        == 1
+                    )
+                    assert (
+                        genetic_algorithm_with_mock_runner.all_evaluated_results[
+                            0
+                        ].fitness_result.fitness_score
+                        == 42.0
+                    )
+
+    def test_all_evaluated_results_populated_for_cache_hit(
+        self, genetic_algorithm_with_mock_runner
+    ):
+        """Cache-hit result (with corrected generation_id) must be appended to all_evaluated_results."""
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        existing_result = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="test-command",
+            log="test-log",
+            returncode=0,
+            start_time=datetime.datetime.now(),
+            end_time=datetime.datetime.now(),
+            fitness_result=FitnessResult(fitness_score=99.0),
+            health_check_results={},
+        )
+        genetic_algorithm_with_mock_runner.seen_population[scenario] = existing_result
+
+        assert len(genetic_algorithm_with_mock_runner.all_evaluated_results) == 0
+        genetic_algorithm_with_mock_runner.calculate_fitness(scenario, 2)
+
+        # Cache-hit copy must be tracked with the new generation_id
+        assert len(genetic_algorithm_with_mock_runner.all_evaluated_results) == 1
+        tracked = genetic_algorithm_with_mock_runner.all_evaluated_results[0]
+        assert tracked.generation_id == 2
+        assert tracked.fitness_result.fitness_score == 99.0
+        # Original in seen_population must remain untouched (generation_id=0)
+        assert (
+            genetic_algorithm_with_mock_runner.seen_population[scenario].generation_id
+            == 0
+        )

--- a/tests/unit/reporter/test_fitness_progression_cache.py
+++ b/tests/unit/reporter/test_fitness_progression_cache.py
@@ -1,0 +1,156 @@
+"""
+Tests that per-generation average fitness in fitness_progression is computed
+correctly when scenarios repeat across generations (cache hits).
+
+Regression test for:
+  Bug: _build_fitness_progression() used seen_population.values() filtered by
+  generation_id, but seen_population only stores results with the generation_id
+  from the *first* run.  Cache-hit copies returned by calculate_fitness() carry
+  the corrected generation_id but were never reflected in seen_population, so
+  later generations showed artificially low (or zero) averages.
+
+Fix: GeneticAlgorithm now accumulates every result (fresh + cache) in
+  all_evaluated_results and passes that list to JSONSummaryReporter, which uses
+  it instead of seen_population.values() for per-generation average calculation.
+"""
+
+import datetime
+
+
+from krkn_ai.models.app import CommandRunResult, FitnessResult
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
+from krkn_ai.reporter.json_summary_reporter import JSONSummaryReporter
+
+
+def _make_result(generation_id: int, fitness_score: float, scenario_id: int, scenario):
+    now = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    return CommandRunResult(
+        generation_id=generation_id,
+        scenario_id=scenario_id,
+        scenario=scenario,
+        cmd="test",
+        log="",
+        returncode=0,
+        start_time=now,
+        end_time=now,
+        fitness_result=FitnessResult(fitness_score=fitness_score),
+    )
+
+
+class TestFitnessProgressionCacheCorrectness:
+    """
+    Verify that per-generation average fitness accounts for cache-hit
+    (repeated) scenarios, not just first-time scenario evaluations.
+    """
+
+    def test_per_generation_average_includes_cache_hits(self, minimal_config):
+        """
+        Scenario repeated in generation 1 must be counted in generation 1's
+        average, even though seen_population stores it with generation_id=0.
+        """
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+
+        # Generation 0: scenario evaluated fresh, fitness=10.0
+        gen0_result = _make_result(
+            generation_id=0, fitness_score=10.0, scenario_id=1, scenario=scenario
+        )
+
+        # seen_population stores only the first-run result (generation_id=0)
+        seen_population = {scenario: gen0_result}
+
+        # Generation 1: same scenario reappears as a cache hit.
+        # calculate_fitness() deep-copies and sets generation_id=1.
+        gen1_cache_hit = _make_result(
+            generation_id=1, fitness_score=10.0, scenario_id=1, scenario=scenario
+        )
+        # Generation 1 also has a fresh scenario with fitness=30.0
+        scenario2 = DummyScenario(cluster_components=ClusterComponents())
+        gen1_fresh = _make_result(
+            generation_id=1, fitness_score=30.0, scenario_id=2, scenario=scenario2
+        )
+        seen_population[scenario2] = gen1_fresh
+
+        # all_evaluated_results mirrors what GeneticAlgorithm.calculate_fitness()
+        # produces: gen0 fresh + gen1 cache-hit copy + gen1 fresh.
+        all_evaluated_results = [gen0_result, gen1_cache_hit, gen1_fresh]
+
+        # best_of_generation = one entry per generation (gen0 best, gen1 best)
+        best_of_generation = [gen0_result, gen1_fresh]
+
+        reporter = JSONSummaryReporter(
+            run_uuid="test-cache",
+            config=minimal_config,
+            seen_population=seen_population,
+            best_of_generation=best_of_generation,
+            all_evaluated_results=all_evaluated_results,
+        )
+
+        summary = reporter.generate_summary()
+        progression = summary["fitness_progression"]
+
+        assert len(progression) == 2
+
+        # Generation 0: only gen0_result → average = 10.0
+        assert progression[0]["generation"] == 0
+        assert progression[0]["average"] == 10.0
+
+        # Generation 1: gen1_cache_hit (10.0) + gen1_fresh (30.0) → average = 20.0
+        # Without the fix this would be 30.0 (only gen1_fresh counted) because
+        # gen1_cache_hit's generation_id=1 is invisible to seen_population filter.
+        assert progression[1]["generation"] == 1
+        assert progression[1]["average"] == 20.0
+
+    def test_backward_compat_without_all_evaluated_results(self, minimal_config):
+        """
+        When all_evaluated_results is not provided (old callers), the reporter
+        falls back to seen_population.values() and still works correctly.
+        """
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        gen0_result = _make_result(
+            generation_id=0, fitness_score=50.0, scenario_id=1, scenario=scenario
+        )
+        seen_population = {scenario: gen0_result}
+        best_of_generation = [gen0_result]
+
+        reporter = JSONSummaryReporter(
+            run_uuid="compat",
+            config=minimal_config,
+            seen_population=seen_population,
+            best_of_generation=best_of_generation,
+            # all_evaluated_results intentionally omitted
+        )
+        summary = reporter.generate_summary()
+        assert summary["fitness_progression"][0]["average"] == 50.0
+
+    def test_no_cache_hits_results_unchanged(self, minimal_config):
+        """
+        When every scenario is unique (no cache hits), all_evaluated_results
+        equals seen_population.values() and averages must be identical.
+        """
+        cc = minimal_config.cluster_components
+
+        s1 = DummyScenario(cluster_components=cc)
+        s2 = DummyScenario(cluster_components=cc)
+
+        r1 = _make_result(
+            generation_id=0, fitness_score=20.0, scenario_id=1, scenario=s1
+        )
+        r2 = _make_result(
+            generation_id=1, fitness_score=40.0, scenario_id=2, scenario=s2
+        )
+
+        seen_population = {s1: r1, s2: r2}
+        all_evaluated_results = [r1, r2]
+        best_of_generation = [r1, r2]
+
+        reporter = JSONSummaryReporter(
+            run_uuid="no-cache",
+            config=minimal_config,
+            seen_population=seen_population,
+            best_of_generation=best_of_generation,
+            all_evaluated_results=all_evaluated_results,
+        )
+        summary = reporter.generate_summary()
+        assert summary["fitness_progression"][0]["average"] == 20.0
+        assert summary["fitness_progression"][1]["average"] == 40.0


### PR DESCRIPTION
### Description
This PR fixes a bug in the reporting of per-generation average fitness scores. The cache seen_population stores each unique scenario result indexed under the generation_id of its first evaluation. When a scenario is re-evaluated in a later generation, the algorithm correctly retrieves the cached result, deep-copies it, and updates its generation_id to the current generation. However, since the dictionary key remains mapped to the original result, the copy is not captured by the JSONSummaryReporter which filters on seen_population.values().

To resolve this: 

- Added all_evaluated_results list to GeneticAlgorithm to track all results returned by calculate_fitness() (both fresh evaluations and cache hits).
- Passed all_evaluated_results to JSONSummaryReporter to use it for computing progression statistics.
- Maintained backward compatibility by falling back to seen_population.values() if all_evaluated_results is omitted.

### Type of Change
 - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Other
 
Fixes:#348

**Testing**
Added unit tests to tests/unit/algorithm/test_fitness_calculation.py and a new test module tests/unit/reporter/test_fitness_progression_cache.py covering:

1. Retrieval and tracking of cache hits with updated generation IDs.
2. Non-mutation of the original seen_population cache entries.
3. Verification of correctness in the JSON reporter progression statistics with and without cache hits.
4. Backward compatibility fallback behavior.

Ran the test suite locally:
```bash
pytest tests/
```
Output: 258 passed in 20.46s

Checklist
  - [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
  - [x] My code follows the project's style guidelines
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have updated the documentation accordingly (where needed)
  - [x] My changes generate no new warnings or errors