### PR TITLE
fix: stop dashboard server when parent process exits

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -2,6 +2,7 @@ import os
 import sys
 import uuid
 import json
+from contextlib import nullcontext
 from kubernetes.client.rest import ApiException
 from urllib3.exceptions import MaxRetryError
 from krkn_ai.constants import STATUS_STARTED, STATUS_FAILED
@@ -128,52 +129,54 @@ def run(
         elif runner_type.lower() == "krknhub":
             enum_runner_type = KrknRunnerType.HUB_RUNNER
 
-    streamlit_process = None
-    if monitoring:
-        logger.info("Starting live monitoring dashboard...")
-        streamlit_process = DashboardManager.start(
-            new_output_path, port, background=True
-        )
+    dashboard = DashboardManager(new_output_path, port) if monitoring else nullcontext()
 
-    run_success = False
-    try:
-        os.makedirs(new_output_path, exist_ok=True)
-        with open(os.path.join(new_output_path, "results.json"), "w") as f:
-            json.dump({"status": STATUS_STARTED}, f)
-
-        genetic = GeneticAlgorithm(
-            run_uuid=run_uuid,
-            config=parsed_config,
-            output_dir=new_output_path,
-            format=format,
-            runner_type=enum_runner_type,
-        )
-        genetic.simulate()
-
-        genetic.save()
-        run_success = True
-    except (MissingScenarioError, PrometheusConnectionError, UniqueScenariosError) as e:
-        logger.error("%s", e)
-        exit(1)
-    except FitnessFunctionCalculationError as e:
-        logger.error("Unable to calculate fitness function score: %s", e)
-        exit(1)
-    except Exception as e:
-        logger.exception("Something went wrong: %s", e)
-        exit(1)
-    finally:
-        if not run_success:
-            try:
-                with open(os.path.join(new_output_path, "results.json"), "w") as f:
-                    json.dump({"status": STATUS_FAILED}, f)
-            except Exception:
-                pass
-
-        if streamlit_process:
-            logger.info(
-                "Run finished. Monitoring dashboard will remain running. Terminate manually when done."
+    with dashboard:
+        if monitoring and not dashboard.is_running:
+            logger.warning(
+                "Dashboard did not start. Continuing run without monitoring."
             )
-        logger.info("Check run.log file in '%s' for more details.", new_output_path)
+
+        run_success = False
+        try:
+            os.makedirs(new_output_path, exist_ok=True)
+            with open(os.path.join(new_output_path, "results.json"), "w") as f:
+                json.dump({"status": STATUS_STARTED}, f)
+
+            genetic = GeneticAlgorithm(
+                run_uuid=run_uuid,
+                config=parsed_config,
+                output_dir=new_output_path,
+                format=format,
+                runner_type=enum_runner_type,
+            )
+            genetic.simulate()
+
+            genetic.save()
+            run_success = True
+        except (
+            MissingScenarioError,
+            PrometheusConnectionError,
+            UniqueScenariosError,
+        ) as e:
+            logger.error("%s", e)
+            exit(1)
+        except FitnessFunctionCalculationError as e:
+            logger.error("Unable to calculate fitness function score: %s", e)
+            exit(1)
+        except Exception as e:
+            logger.exception("Something went wrong: %s", e)
+            exit(1)
+        finally:
+            if not run_success:
+                try:
+                    with open(os.path.join(new_output_path, "results.json"), "w") as f:
+                        json.dump({"status": STATUS_FAILED}, f)
+                except Exception:
+                    pass
+            logger.info(
+                "Check run.log file in '%s' for more details.", new_output_path
+            )
 
 
 @main.command(help="Monitor results from previous completed runs")
@@ -189,7 +192,14 @@ def monitor(ctx, output: str, port: int):
         output,
     )
 
-    DashboardManager.start(output, port, background=False)
+    with DashboardManager(output, port) as dashboard:
+        if not dashboard.is_running:
+            logger.error("Unable to start dashboard monitor.")
+            sys.exit(1)
+        try:
+            dashboard.wait()
+        except KeyboardInterrupt:
+            logger.info("Monitoring dashboard stopped.")
 
 
 @main.command(help="Discover components for Krkn-AI tests")

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -179,6 +179,11 @@ def run(
                 except Exception:
                     pass
             logger.info("Check run.log file in '%s' for more details.", new_output_path)
+            if monitoring:
+                logger.info(
+                    "To inspect results interactively, run: krkn-ai monitor -o %s",
+                    output,
+                )
 
 
 @main.command(help="Monitor results from previous completed runs")

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -132,7 +132,11 @@ def run(
     dashboard = DashboardManager(new_output_path, port) if monitoring else nullcontext()
 
     with dashboard:
-        if monitoring and not dashboard.is_running:
+        if (
+            monitoring
+            and isinstance(dashboard, DashboardManager)
+            and not dashboard.is_running
+        ):
             logger.warning(
                 "Dashboard did not start. Continuing run without monitoring."
             )
@@ -174,9 +178,7 @@ def run(
                         json.dump({"status": STATUS_FAILED}, f)
                 except Exception:
                     pass
-            logger.info(
-                "Check run.log file in '%s' for more details.", new_output_path
-            )
+            logger.info("Check run.log file in '%s' for more details.", new_output_path)
 
 
 @main.command(help="Monitor results from previous completed runs")

--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -2,6 +2,7 @@ import os
 import sys
 import atexit
 import subprocess
+from typing import Optional
 from krkn_ai.utils.logger import get_logger
 
 
@@ -9,7 +10,7 @@ class DashboardManager:
     def __init__(self, output_dir: str, port: int):
         self._output_dir = os.path.abspath(output_dir if output_dir else "./")
         self._port = port
-        self._process: subprocess.Popen = None
+        self._process: Optional[subprocess.Popen] = None
         self._logger = get_logger(__name__)
 
     @property

--- a/krkn_ai/dashboard/manager.py
+++ b/krkn_ai/dashboard/manager.py
@@ -1,15 +1,24 @@
 import os
 import sys
+import atexit
 import subprocess
 from krkn_ai.utils.logger import get_logger
 
 
 class DashboardManager:
-    @staticmethod
-    def start(output_dir: str, port: int, background: bool = True):
-        logger = get_logger(__name__)
+    def __init__(self, output_dir: str, port: int):
+        self._output_dir = os.path.abspath(output_dir if output_dir else "./")
+        self._port = port
+        self._process: subprocess.Popen = None
+        self._logger = get_logger(__name__)
+
+    @property
+    def is_running(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def start(self) -> bool:
+        """Launch Streamlit in background. Returns True if server started."""
         dashboard_dir = os.path.dirname(__file__)
-        actual_output = os.path.abspath(output_dir if output_dir else "./")
 
         cmd = [
             sys.executable,
@@ -18,49 +27,74 @@ class DashboardManager:
             "run",
             os.path.join(dashboard_dir, "app.py"),
             "--server.port",
-            str(port),
+            str(self._port),
             "--server.headless",
             "true",
             "--",
             "--output-dir",
-            actual_output,
+            self._output_dir,
         ]
 
+        log_file_path = os.path.join(self._output_dir, "dashboard.log")
+
         try:
-            if background:
-                log_file_path = os.path.join(actual_output, "dashboard.log")
-                log_file = open(log_file_path, "a")
+            log_file = open(log_file_path, "a")
+            try:
+                self._process = subprocess.Popen(
+                    cmd,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                )
+            finally:
+                log_file.close()
 
-                try:
-                    process = subprocess.Popen(
-                        cmd,
-                        stdout=log_file,
-                        stderr=subprocess.STDOUT,
-                    )
-                finally:
-                    # Parent can safely close its file descriptor
-                    log_file.close()
+            # Check quickly if the process failed to start
+            try:
+                retcode = self._process.wait(timeout=2)
+                with open(log_file_path, "r", errors="replace") as f:
+                    output = f.read().strip()
+                self._logger.warning(
+                    "Dashboard process exited immediately (code %d): %s",
+                    retcode,
+                    output,
+                )
+                self._process = None
+                return False
+            except subprocess.TimeoutExpired:
+                self._logger.info(
+                    "Dashboard running at http://localhost:%s", self._port
+                )
+                atexit.register(self.stop)
+                return True
 
-                # Check quickly if the process failed to start
-                try:
-                    retcode = process.wait(timeout=2)
-                    # Process exited immediately — something went wrong
-                    with open(log_file_path, "r", errors="replace") as f:
-                        output = f.read().strip()
-                    logger.warning(
-                        "Dashboard process exited immediately (code %d): %s",
-                        retcode,
-                        output,
-                    )
-                    return None
-                except subprocess.TimeoutExpired:
-                    # Still running after 2s
-                    logger.info(f"Dashboard running at http://localhost:{port}")
-                    return process
-            else:
-                subprocess.run(cmd, check=True)
-        except KeyboardInterrupt:
-            logger.info("Monitoring dashboard stopped.")
         except Exception as e:
-            logger.error(f"Failed to start monitoring dashboard: {e}")
-            return None
+            self._logger.error("Failed to start monitoring dashboard: %s", e)
+            self._process = None
+            return False
+
+    def stop(self):
+        """Terminate the server if running. Idempotent."""
+        if self._process is None or self._process.poll() is not None:
+            return
+
+        self._logger.info("Stopping dashboard server on port %s...", self._port)
+        self._process.terminate()
+        try:
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=5)
+        self._logger.info("Dashboard server stopped.")
+
+    def wait(self):
+        """Block until the server process exits."""
+        if self._process is not None:
+            self._process.wait()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.stop()
+        return False

--- a/tests/unit/dashboard/test_manager.py
+++ b/tests/unit/dashboard/test_manager.py
@@ -6,9 +6,11 @@ MODULE = "krkn_ai.dashboard.manager"
 
 
 def test_start_success():
-    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
-        "builtins.open", mock_open()
-    ), patch(f"{MODULE}.atexit.register") as mock_atexit:
+    with (
+        patch(f"{MODULE}.subprocess.Popen") as mock_popen,
+        patch("builtins.open", mock_open()),
+        patch(f"{MODULE}.atexit.register") as mock_atexit,
+    ):
         mock_process = Mock()
         mock_process.wait.side_effect = subprocess.TimeoutExpired(cmd="cmd", timeout=2)
         mock_process.poll.return_value = None
@@ -98,9 +100,11 @@ def test_stop_kills_on_timeout():
 
 
 def test_context_manager_starts_and_stops():
-    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
-        "builtins.open", mock_open()
-    ), patch(f"{MODULE}.atexit.register"):
+    with (
+        patch(f"{MODULE}.subprocess.Popen") as mock_popen,
+        patch("builtins.open", mock_open()),
+        patch(f"{MODULE}.atexit.register"),
+    ):
         mock_process = Mock()
         mock_process.wait.side_effect = [
             subprocess.TimeoutExpired(cmd="cmd", timeout=2),
@@ -116,9 +120,11 @@ def test_context_manager_starts_and_stops():
 
 
 def test_context_manager_stops_on_exception():
-    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
-        "builtins.open", mock_open()
-    ), patch(f"{MODULE}.atexit.register"):
+    with (
+        patch(f"{MODULE}.subprocess.Popen") as mock_popen,
+        patch("builtins.open", mock_open()),
+        patch(f"{MODULE}.atexit.register"),
+    ):
         mock_process = Mock()
         mock_process.wait.side_effect = [
             subprocess.TimeoutExpired(cmd="cmd", timeout=2),

--- a/tests/unit/dashboard/test_manager.py
+++ b/tests/unit/dashboard/test_manager.py
@@ -2,46 +2,135 @@ import subprocess
 from unittest.mock import patch, Mock, mock_open
 from krkn_ai.dashboard.manager import DashboardManager
 
+MODULE = "krkn_ai.dashboard.manager"
 
-def test_start_background_success():
-    with patch("subprocess.Popen") as mock_popen, patch("builtins.open", mock_open()):
+
+def test_start_success():
+    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
+        "builtins.open", mock_open()
+    ), patch(f"{MODULE}.atexit.register") as mock_atexit:
         mock_process = Mock()
         mock_process.wait.side_effect = subprocess.TimeoutExpired(cmd="cmd", timeout=2)
+        mock_process.poll.return_value = None
         mock_popen.return_value = mock_process
 
-        result = DashboardManager.start("/tmp", 8080, background=True)
-        assert result is mock_process
+        dm = DashboardManager("/tmp", 8080)
+        result = dm.start()
+
+        assert result is True
+        assert dm.is_running
         mock_popen.assert_called_once()
+        mock_atexit.assert_called_once_with(dm.stop)
 
 
-def test_start_background_immediate_exit():
+def test_start_immediate_exit():
     with (
-        patch("subprocess.Popen") as mock_popen,
+        patch(f"{MODULE}.subprocess.Popen") as mock_popen,
         patch("builtins.open", mock_open(read_data="error msg")),
     ):
         mock_process = Mock()
         mock_process.wait.return_value = 1
+        mock_process.poll.return_value = 1
         mock_popen.return_value = mock_process
 
-        result = DashboardManager.start("/tmp", 8080, background=True)
-        assert result is None
+        dm = DashboardManager("/tmp", 8080)
+        result = dm.start()
+
+        assert result is False
+        assert not dm.is_running
         mock_popen.assert_called_once()
 
 
-def test_start_foreground_success():
-    with patch("subprocess.run") as mock_run:
-        result = DashboardManager.start("/tmp", 8080, background=False)
-        assert result is None
-        mock_run.assert_called_once()
-
-
-def test_start_foreground_keyboard_interrupt():
-    with patch("subprocess.run", side_effect=KeyboardInterrupt):
-        result = DashboardManager.start("/tmp", 8080, background=False)
-        assert result is None
-
-
 def test_start_exception():
-    with patch("subprocess.run", side_effect=Exception("Failed")):
-        result = DashboardManager.start("/tmp", 8080, background=False)
-        assert result is None
+    with patch("builtins.open", side_effect=Exception("disk full")):
+        dm = DashboardManager("/tmp", 8080)
+        result = dm.start()
+
+        assert result is False
+        assert not dm.is_running
+
+
+def test_stop_terminates_running_process():
+    mock_process = Mock()
+    mock_process.poll.return_value = None
+    mock_process.wait.return_value = None
+
+    dm = DashboardManager("/tmp", 8080)
+    dm._process = mock_process
+
+    dm.stop()
+
+    mock_process.terminate.assert_called_once()
+
+
+def test_stop_noop_when_already_exited():
+    mock_process = Mock()
+    mock_process.poll.return_value = 0
+
+    dm = DashboardManager("/tmp", 8080)
+    dm._process = mock_process
+
+    dm.stop()
+
+    mock_process.terminate.assert_not_called()
+
+
+def test_stop_noop_when_no_process():
+    dm = DashboardManager("/tmp", 8080)
+    dm.stop()
+
+
+def test_stop_kills_on_timeout():
+    mock_process = Mock()
+    mock_process.poll.return_value = None
+    mock_process.wait.side_effect = [
+        subprocess.TimeoutExpired(cmd="cmd", timeout=5),
+        None,
+    ]
+
+    dm = DashboardManager("/tmp", 8080)
+    dm._process = mock_process
+
+    dm.stop()
+
+    mock_process.terminate.assert_called_once()
+    mock_process.kill.assert_called_once()
+
+
+def test_context_manager_starts_and_stops():
+    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
+        "builtins.open", mock_open()
+    ), patch(f"{MODULE}.atexit.register"):
+        mock_process = Mock()
+        mock_process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="cmd", timeout=2),
+            None,
+        ]
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        with DashboardManager("/tmp", 8080) as dm:
+            assert dm.is_running
+
+        mock_process.terminate.assert_called_once()
+
+
+def test_context_manager_stops_on_exception():
+    with patch(f"{MODULE}.subprocess.Popen") as mock_popen, patch(
+        "builtins.open", mock_open()
+    ), patch(f"{MODULE}.atexit.register"):
+        mock_process = Mock()
+        mock_process.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="cmd", timeout=2),
+            None,
+        ]
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        try:
+            with DashboardManager("/tmp", 8080):
+                raise RuntimeError("simulated crash")
+        except RuntimeError:
+            pass
+
+        mock_process.terminate.assert_called_once()

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -38,10 +38,10 @@ class TestJSONSummaryReporter:
         now = datetime.datetime(2023, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
         cc = minimal_config.cluster_components
         scenario = DummyScenario(cluster_components=cc)
-        
+
         gen0 = self._create_results(0, 0, 3, scenario, now)
         gen1 = self._create_results(1, 40, 3, scenario, now)
-        
+
         pop = {**gen0, **gen1}
         best = [gen0[2], gen1[102]]
 
@@ -53,24 +53,24 @@ class TestJSONSummaryReporter:
             start_time=now,
             end_time=now + datetime.timedelta(seconds=100),
             completed_generations=2,
-            seed=123
+            seed=123,
         )
-        
+
         summary = reporter.generate_summary()
 
         assert summary["run_id"] == "test-run"
         assert summary["seed"] == 123
         assert summary["start_time"] == now.isoformat()
         assert summary["duration_seconds"] == 100.0
-        
+
         assert summary["config"]["generations"] == minimal_config.generations
         assert summary["config"]["population_size"] == minimal_config.population_size
-        
+
         assert summary["summary"]["total_scenarios_executed"] == 6
         assert summary["summary"]["best_fitness_score"] == 60.0
         assert summary["summary"]["average_fitness_score"] == 30.0
         assert summary["summary"]["generations_completed"] == 2
-        
+
         assert len(summary["fitness_progression"]) == 2
         assert summary["fitness_progression"][0]["average"] == 10.0
         assert summary["fitness_progression"][0]["best"] == 20.0
@@ -82,19 +82,19 @@ class TestJSONSummaryReporter:
         now = datetime.datetime.now(datetime.timezone.utc)
         cc = minimal_config.cluster_components
         scenario = DummyScenario(cluster_components=cc)
-        
+
         pop = self._create_results(0, 0, 15, scenario, now)
-        
+
         reporter = JSONSummaryReporter(
             run_uuid="test",
             config=minimal_config,
             seen_population=pop,
             best_of_generation=[],
         )
-        
+
         best = reporter.generate_summary()["best_scenarios"]
         assert len(best) == 10
-        
+
         for i in range(10):
             item = best[i]
             assert item["rank"] == i + 1
@@ -117,7 +117,7 @@ class TestJSONSummaryReporter:
             config=minimal_config,
             seen_population=gen0,
             best_of_generation=[gen0[1]],
-            completed_generations=1
+            completed_generations=1,
         )
         summary = reporter.generate_summary()
         assert len(summary["fitness_progression"]) == 1
@@ -171,10 +171,10 @@ class TestJSONSummaryReporter:
             seen_population=pop,
             best_of_generation=[],
         )
-        
+
         expected_summary = reporter.generate_summary()
         reporter.save(temp_output_dir)
-        
+
         path = os.path.join(temp_output_dir, "results.json")
         assert os.path.exists(path)
         with open(path, "r") as f:


### PR DESCRIPTION
**Summary:**

The Streamlit dashboard process kept running after the parent command finished or crashed. This reworks `DashboardManager` into a context manager that automatically stops the server on exit.

**Changes:**

- `krkn_ai/dashboard/manager.py` — Instance-based class with `start()`, `stop()`, `wait()`, context manager support, and an `atexit` hook as a safety net.
- `krkn_ai/cli/cmd.py` — Both `run` and `monitor` commands use `with DashboardManager(...)` for automatic cleanup.
- `tests/unit/dashboard/test_manager.py` — Updated for new API.


Assisted-with: Cursor IDE (Claude)