### PR TITLE
feat(network-scenario): ingress/egress parameter split, per-scenario wait duration, loss workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,94 +2,63 @@
 
 [![Quay](https://img.shields.io/badge/quay.io-krkn--ai-blue?logo=quay)](https://quay.io/repository/krkn-chaos/krkn-ai)
 
+> [!CAUTION]
+> **The tool is currently under active development, use it at your own risk.**
 
-> [!CAUTION]  
-> __The tool is currently in under active development, use it at your own risk.__
+An intelligent chaos engineering framework that uses genetic algorithms to evolve and discover the most effective chaos experiments for testing your Kubernetes/OpenShift application's resilience.
 
-An intelligent chaos engineering framework that uses genetic algorithms to optimize chaos scenarios for Kubernetes/OpenShift applications. Krkn-AI automatically evolves and discovers the most effective chaos experiments to test your system's resilience.
+## ⚙️ How It Works
 
-## 🌟 Features
+1. **Initial Population** — Creates random chaos scenarios from your configuration
+2. **Fitness Evaluation** — Runs each scenario and measures system response via Prometheus metrics
+3. **Selection** — Identifies the most impactful scenarios based on fitness scores
+4. **Evolution** — Generates new scenarios through crossover and mutation
+5. **Iteration** — Repeats across multiple generations to converge on optimal scenarios
 
-- **Genetic Algorithm Optimization**: Automatically evolves chaos scenarios to find optimal testing strategies
-- **Multi-Scenario Support**: Pod failures, container scenarios, node resource exhaustion, and application outages
-- **Kubernetes/OpenShift Integration**: Native support for both platforms
-- **Health Monitoring**: Continuous monitoring of application health during chaos experiments
-- **Prometheus Integration**: Metrics-driven fitness evaluation
-- **Configurable Fitness Functions**: Point-based and range-based fitness evaluation
-- **Population Evolution**: Maintains and evolves populations of chaos scenarios across generations
+## 📋 Prerequisites
 
-
-## 🧬 How It Works
-
-The current version of Krkn-AI leverages an [evolutionary algorithm](https://en.wikipedia.org/wiki/Evolutionary_algorithm), an optimization technique that uses heuristics to identify chaos scenarios and components that impact the stability of your cluster and applications.
-
-1. **Initial Population**: Creates random chaos scenarios based on your configuration
-2. **Fitness Evaluation**: Runs each scenario and measures system response using Prometheus metrics
-3. **Selection**: Identifies the most effective scenarios based on fitness scores
-4. **Evolution**: Creates new scenarios through crossover and mutation
-5. **Health Monitoring**: Continuously monitors application health during experiments
-6. **Iteration**: Repeats the process across multiple generations to find optimal scenarios
+- [krknctl](https://github.com/krkn-chaos/krknctl)
+- [oc](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/) / kubectl
+- Python 3.11+
+- `uv` package manager
+- [podman](https://podman.io/)
+- [helm](https://helm.sh/docs/intro/install/)
+- Kubernetes/OpenShift cluster kubeconfig
 
 ## 🚀 Getting Started
 
-### Prerequisites
-
-- [krknctl](https://github.com/krkn-chaos/krknctl)
-- [oc](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)
-- Python 3.11+
-- `uv` package manager (recommended) or `pip`
-- [podman](https://podman.io/)
-- [helm](https://helm.sh/docs/intro/install/)
-- Kubernetes cluster access file (kubeconfig)
-
-### Setup Virtual Environment
+### Install
 
 ```bash
-# Install uv if you haven't already
 pip install uv
-
-# Create and activate virtual environment
-uv venv --python 3.11
-source .venv/bin/activate
-
-# Install Krkn-AI in development mode
+uv venv --python 3.11 && source .venv/bin/activate
 uv pip install -e .
-
-# Check Installation
 uv run krkn_ai --help
 ```
 
 ### Deploy Sample Microservice
 
-For demonstration purposes, deploy the robot-shop microservice:
-
 ```bash
-# Setup sample miroservice application example on cluster
 export DEMO_NAMESPACE=robot-shop
 ./scripts/setup-demo-microservice.sh
-
-# Switch context to the demo namespace
 kubectl config set-context --current --namespace=$DEMO_NAMESPACE
 ```
 
-#### Setup Monitoring and Testing
-
 ```bash
-# Setup NGINX reverse proxy for external access
+# Setup NGINX reverse proxy and test endpoints
 ./scripts/setup-nginx.sh
-
-# Test application endpoints once the services are available
 ./scripts/test-nginx-routes.sh
 
 export HOST="http://$(kubectl get service rs -o json | jq -r '.status.loadBalancer.ingress[0].hostname')"
 ```
 
-#### 📝 Generate Configuration
+### Generate Configuration
 
-Krkn-AI uses YAML configuration files to define experiments. You can generate a sample config file dynamically by running Krkn-AI discover command.
+Use the `discover` command to auto-generate a config from your running cluster:
 
 ```bash
-uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
+uv run krkn_ai discover \
+  -k ./tmp/kubeconfig.yaml \
   -n "robot-shop" \
   -pl "service" \
   -nl "kubernetes.io/hostname" \
@@ -97,324 +66,123 @@ uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
   --skip-pod-name "nginx-proxy.*"
 ```
 
+Key config options:
+
 ```yaml
-# Path to your kubeconfig file
 kubeconfig_file_path: "./tmp/kubeconfig.yaml"
 
-# Baseline evaluation configuration
-baseline:
-  enable: true
-  duration: 120
-
-# Optional: Random seed for reproducible runs
-# seed: 42
-
-# Genetic algorithm parameters
 generations: 5
 population_size: 10
 composition_rate: 0.3
 population_injection_rate: 0.1
+wait_duration: 30          # seconds between scenarios
 
-# Uncomment the line below to enable runs by duration instead of generation count
-# duration: 600
-
-# Duration to wait before running next scenario (seconds)
-wait_duration: 30
-
-# Elasticsearch configuration for storing run results (Optional)
-elastic:
-  enable: false  # Set to true to enable Elasticsearch integration
-  verify_certs: true  # Verify SSL certificates
-  server: "http://localhost"  # Elasticsearch URL
-  port: 9200  # Elasticsearch port
-  username: "$ES_USER"  # Elasticsearch username
-  password: "$__ES_PASSWORD"  # Elasticsearch password (start param with __ to treat as private)
-  index: "krkn-ai"  # Index prefix for storing Krkn-AI config and results
-
-# Specify how result filenames are formatted
-output:
-  result_name_fmt: "scenario_%s.yaml"
-  graph_name_fmt: "scenario_%s.png"
-  log_name_fmt: "scenario_%s.log"
-
-# Fitness function configuration
 fitness_function:
-  # Use an aggregate query that returns one Prometheus series.
   query: 'sum(kube_pod_container_status_restarts_total{namespace="robot-shop"})'
-  type: point  # or 'range'
+  type: point               # or 'range'
   include_krkn_failure: true
 
-# Health endpoints to monitor
 health_checks:
   stop_watcher_on_failure: false
   applications:
-  - name: cart
-    url: "$HOST/cart/add/1/Watson/1"
-  - name: catalogue
-    url: "$HOST/catalogue/categories"
+    - name: cart
+      url: "$HOST/cart/add/1/Watson/1"
 
-# Chaos scenarios to evolve
 scenario:
   pod-scenarios:
     enable: true
   application-outages:
     enable: true
-  container-scenarios:
-    enable: false
   node-cpu-hog:
     enable: true
-  node-memory-hog:
-    enable: false
-  kubevirt-outage:
-    enable: false
-
-# Cluster components to consider for Krkn-AI testing
-cluster_components:
-  namespaces:
-  - name: robot-shop
-    pods:
-    - containers:
-      - name: cart
-      labels:
-        service: cart
-      name: cart-7cd6c77dbf-j4gsv
-    - containers:
-      - name: catalogue
-      labels:
-        service: catalogue
-      name: catalogue-94df6b9b-pjgsr
-  nodes:
-  - labels:
-      kubernetes.io/hostname: node-1
-    name: node-1
-  - labels:
-      kubernetes.io/hostname: node-2
-    name: node-2
 ```
 
-You can modify `krkn-ai.yaml` as per your requirement to include/exclude any cluster components, scenarios, fitness function SLOs or health check endpoints for the Krkn-AI testing. For advanced customization, please refer to the krkn-ai docs.
+See the full config reference in the [docs](https://krkn-chaos.dev/docs/krkn_ai/config/).
 
-
-#### Running KrknAI Experiments
+### Run Experiments
 
 ```bash
-# Configure Prometheus endpoint and token
-# export PROMETHEUS_URL='https://your-prometheus-url'
-# export PROMETHEUS_TOKEN='your-prometheus-token'
-
-# Run Krkn-AI
 uv run krkn_ai run \
   -c ./tmp/krkn-ai.yaml \
   -o ./tmp/results/ \
   -p HOST=$HOST
 ```
 
-## CLI Options
+## 💻 CLI Reference
 
-```bash
-$ uv run krkn_ai discover --help
-Usage: krkn_ai discover [OPTIONS]
+| Command | Key Options |
+|---------|-------------|
+| `discover` | `-k` kubeconfig, `-n` namespace, `-pl` pod-label, `-nl` node-label, `-o` output, `--skip-pod-name` |
+| `run` | `-k` kubeconfig, `-c` config, `-o` output dir, `-f` format, `-r` runner type, `-p` params, `--monitoring`, `--port` |
+| `monitor` | `-o` results dir, `-p` port |
 
-  Discover components for Krkn-AI tests
+Run any command with `--help` for full details.
 
-Options:
-  -k, --kubeconfig TEXT   Path to cluster kubeconfig file.
-  -o, --output TEXT       Path to save config file.
-  -n, --namespace TEXT    Namespace(s) to discover components in. Supports
-                          Regex and comma separated values.
-  -pl, --pod-label TEXT   Pod Label Keys(s) to filter. Supports Regex and
-                          comma separated values.
-  -nl, --node-label TEXT  Node Label Keys(s) to filter. Supports Regex and
-                          comma separated values.
-  -v, --verbose           Increase verbosity of output.
-  --skip-pod-name TEXT    Pod name to skip. Supports comma separated values
-                          with regex.
-  --help                  Show this message and exit.
+## 🔍 Advanced Filtering
 
-
-
-$ uv run krkn_ai run --help
-Usage: krkn_ai run [OPTIONS]
-
-  Run Krkn-AI tests
-
-Options:
-  -k, --kubeconfig TEXT           Path to cluster kubeconfig file. Setting this
-                                  will override value in config file.
-  -c, --config TEXT               Path to Krkn-AI config file.
-  -o, --output TEXT               Directory to save results.
-  -f, --format [json|yaml]        Format of the output file.
-  -r, --runner-type [krknctl|krknhub]
-                                  Type of krkn engine to use.
-  -p, --param TEXT                Additional parameters for config file in
-                                  key=value format.
-  -s, --seed INTEGER              Random seed for reproducible runs. Overrides
-                                  seed in config file.
-  -v, --verbose                   Increase verbosity of output.
-  -m, --monitoring                Launch live monitoring dashboard in the
-                                  background.
-  --port INTEGER                  Port to run Streamlit server on when
-                                  monitoring is enabled.  [default: 8501]
-  --help                          Show this message and exit.
-
-
-$ uv run krkn_ai monitor --help
-Usage: krkn_ai monitor [OPTIONS]
-
-  Monitor results from previous completed runs
-
-Options:
-  -o, --output TEXT  Directory where results are saved.  [default: ./]
-  -p, --port TEXT    Port to run Streamlit server on.  [default: 8501]
-  --help             Show this message and exit.
-```
-
-> **Note:** You can also run Krkn-AI as a container with Podman or on Kubernetes. See [container instructions](./containers/README.md).
-
-
-## Advanced Filtering (discovery)
-
-The `-n` (namespace), `-pl` (pod-label), `-nl` (node-label), and `--skip-pod-name` options support flexible pattern matching:
+The `-n`, `-pl`, `-nl`, and `--skip-pod-name` options support flexible pattern matching:
 
 | Pattern | Description |
 |---------|-------------|
-| `robot-shop` | Match exactly "robot-shop" |
-| `robot-shop,default` | Match "robot-shop" OR "default" |
-| `openshift-.*` | Regex: match namespaces starting with "openshift-" |
+| `robot-shop` | Exact match |
+| `robot-shop,default` | Match either |
+| `openshift-.*` | Regex match |
 | `*` | Match all |
-| `!kube-system` | Match all EXCEPT "kube-system" |
-| `*,!kube-.*` | Match all except kube-* namespaces |
-| `openshift-.*,!openshift-operators` | Match openshift-* but exclude operators |
+| `!kube-system` | Exclude |
+| `*,!kube-.*` | All except kube-* |
+| `openshift-.*,!openshift-operators` | Regex with exclusion |
 
-**Examples:**
+## 📊 Monitoring Dashboard
 
-```bash
-# Discover in all namespaces except kube-system and openshift-*
-uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
-  -n "!kube-system,!openshift-.*" \
-  -o ./tmp/krkn-ai.yaml
-
-# Discover in openshift namespaces but exclude operators
-uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
-  -n "openshift-.*,!openshift-operators" \
-  -o ./tmp/krkn-ai.yaml
-```
-
-
-## Monitoring Dashboard
-
-Krkn-AI includes a Streamlit-based dashboard for visualizing experiment progress and results.
-
-#### Live monitoring
+Launch live monitoring alongside an experiment:
 
 ```bash
-uv run krkn_ai run \
-  -c ./tmp/krkn-ai.yaml \
-  -o ./tmp/results/ \
-  --monitoring
+uv run krkn_ai run -c ./tmp/krkn-ai.yaml -o ./tmp/results/ --monitoring
+# use --port 9000 to change from the default 8501
 ```
 
-This launches the dashboard in the background alongside the experiment. By default it runs on port `8501`. Use `--port` to change it:
-
-```bash
-uv run krkn_ai run \
-  -c ./tmp/krkn-ai.yaml \
-  -o ./tmp/results/ \
-  --monitoring --port 9000
-```
-
-#### View results
+View results from a completed run:
 
 ```bash
 uv run krkn_ai monitor -o ./tmp/results/
 ```
 
-The dashboard provides tabs for fitness evolution, health checks, detailed scenario telemetry, logs, and configuration review.
-
-## Understanding Results
-
-Each run of `krkn_ai run` creates a unique subdirectory (named by a generated UUID) inside the `--output` directory. All artifacts for that run are written there:
+## 📁 Output Structure
 
 ```
-.
-└── results/
-    └── <run_uuid>/
-        ├── run.log
-        ├── reports/
-        │   ├── health_check_report.csv
-        │   ├── all.csv
-        │   ├── best_scenarios.yaml
-        │   └── graphs/
-        │       ├── best_generation.png
-        │       ├── scenario_1.png
-        │       ├── scenario_2.png
-        │       └── ...
-        ├── yaml/
-        │   ├── generation_0/
-        │   │   ├── scenario_1.yaml
-        │   │   ├── scenario_2.yaml
-        │   │   └── ...
-        │   └── generation_1/
-        │       └── ...
-        ├── logs/
-        │   ├── scenario_1.log
-        │   ├── scenario_2.log
-        │   └── ...
-        ├── results.json
-        └── krkn-ai.yaml
+results/
+└── <run_uuid>/
+    ├── run.log
+    ├── krkn-ai.yaml
+    ├── results.json
+    ├── reports/
+    │   ├── health_check_report.csv
+    │   ├── all.csv
+    │   ├── best_scenarios.yaml
+    │   └── graphs/
+    ├── yaml/
+    │   ├── generation_0/
+    │   └── generation_1/
+    └── logs/
 ```
 
+> You can also run Krkn-AI as a container with Podman or on Kubernetes. See [container instructions](./containers/README.md).
 
 ## 🤝 Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes and run the [static checks](#static-checks) (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-### Static Checks
-
-Developers should run the project's static checks locally before committing. Below are recommended commands and notes for common environments (PowerShell / Bash).
-
-
-- Install tooling used for checks:
+1. Fork the repository and create a feature branch
+2. Install dev tooling and pre-commit hooks:
 
 ```bash
-# Activate Virtual Environment
 source .venv/bin/activate
-
-# Install dev requirement
 uv pip install -r requirements-dev.txt
-```
-
-- Install Git hooks (runs once per developer):
-
-```bash
 pre-commit install
-pre-commit autoupdate
 ```
-
-- Run all pre-commit hooks against the repository (fast, recommended):
+3. Run static checks before committing:
 
 ```bash
 pre-commit run --all-files
+# or individually: ruff check/format, mypy, hadolint
 ```
 
-- Run individual tools directly:
-
-```bash
-# Ruff (linter/formatter)
-ruff check .
-ruff format .
-
-# Mypy (type checking)
-mypy --config-file mypy.ini krkn_ai
-
-# Hadolint (Dockerfile/Containerfile linting) - Docker must be available
-hadolint containers/Containerfile
-```
-
-Notes:
-- The `pre-commit` configuration runs `ruff`, various file checks, and `hadolint` for container files. If `hadolint` fails with a Docker error, ensure Docker Desktop/daemon is running on your machine (the hook needs to query Docker to validate containerfile context).
-- Use `pre-commit run --all-files` to validate changes before pushing. CI will also run these checks.
+4. Open a pull request against `main`

--- a/README.md
+++ b/README.md
@@ -18,11 +18,24 @@ An intelligent chaos engineering framework that uses genetic algorithms to optim
 - **Configurable Fitness Functions**: Point-based and range-based fitness evaluation
 - **Population Evolution**: Maintains and evolves populations of chaos scenarios across generations
 
+
+## 🧬 How It Works
+
+The current version of Krkn-AI leverages an [evolutionary algorithm](https://en.wikipedia.org/wiki/Evolutionary_algorithm), an optimization technique that uses heuristics to identify chaos scenarios and components that impact the stability of your cluster and applications.
+
+1. **Initial Population**: Creates random chaos scenarios based on your configuration
+2. **Fitness Evaluation**: Runs each scenario and measures system response using Prometheus metrics
+3. **Selection**: Identifies the most effective scenarios based on fitness scores
+4. **Evolution**: Creates new scenarios through crossover and mutation
+5. **Health Monitoring**: Continuously monitors application health during experiments
+6. **Iteration**: Repeats the process across multiple generations to find optimal scenarios
+
 ## 🚀 Getting Started
 
 ### Prerequisites
 
 - [krknctl](https://github.com/krkn-chaos/krknctl)
+- [oc](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)
 - Python 3.11+
 - `uv` package manager (recommended) or `pip`
 - [podman](https://podman.io/)
@@ -51,30 +64,27 @@ uv run krkn_ai --help
 For demonstration purposes, deploy the robot-shop microservice:
 
 ```bash
+# Setup sample miroservice application example on cluster
 export DEMO_NAMESPACE=robot-shop
-export IS_OPENSHIFT=true
-#set IS_OPENSHIFT=false for kubernetes cluster
 ./scripts/setup-demo-microservice.sh
 
-# Set context to the demo namespace
-oc config set-context --current --namespace=$DEMO_NAMESPACE
-# or for kubectl:
-# kubectl config set-context --current --namespace=$DEMO_NAMESPACE
+# Switch context to the demo namespace
+kubectl config set-context --current --namespace=$DEMO_NAMESPACE
 ```
 
-### Setup Monitoring and Testing
+#### Setup Monitoring and Testing
 
 ```bash
 # Setup NGINX reverse proxy for external access
 ./scripts/setup-nginx.sh
 
-# Test application endpoints
+# Test application endpoints once the services are available
 ./scripts/test-nginx-routes.sh
 
 export HOST="http://$(kubectl get service rs -o json | jq -r '.status.loadBalancer.ingress[0].hostname')"
 ```
 
-## 📝 Generate Configuration
+#### 📝 Generate Configuration
 
 Krkn-AI uses YAML configuration files to define experiments. You can generate a sample config file dynamically by running Krkn-AI discover command.
 
@@ -85,34 +95,6 @@ uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
   -nl "kubernetes.io/hostname" \
   -o ./tmp/krkn-ai.yaml \
   --skip-pod-name "nginx-proxy.*"
-```
-
-### Pattern Syntax for Filtering
-
-The `-n` (namespace), `-pl` (pod-label), `-nl` (node-label), and `--skip-pod-name` options support flexible pattern matching:
-
-| Pattern | Description |
-|---------|-------------|
-| `robot-shop` | Match exactly "robot-shop" |
-| `robot-shop,default` | Match "robot-shop" OR "default" |
-| `openshift-.*` | Regex: match namespaces starting with "openshift-" |
-| `*` | Match all |
-| `!kube-system` | Match all EXCEPT "kube-system" |
-| `*,!kube-.*` | Match all except kube-* namespaces |
-| `openshift-.*,!openshift-operators` | Match openshift-* but exclude operators |
-
-**Examples:**
-
-```bash
-# Discover in all namespaces except kube-system and openshift-*
-uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
-  -n "!kube-system,!openshift-.*" \
-  -o ./tmp/krkn-ai.yaml
-
-# Discover in openshift namespaces but exclude operators
-uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
-  -n "openshift-.*,!openshift-operators" \
-  -o ./tmp/krkn-ai.yaml
 ```
 
 ```yaml
@@ -176,11 +158,11 @@ scenario:
   pod-scenarios:
     enable: true
   application-outages:
-    enable: false
+    enable: true
   container-scenarios:
     enable: false
   node-cpu-hog:
-    enable: false
+    enable: true
   node-memory-hog:
     enable: false
   kubevirt-outage:
@@ -213,28 +195,21 @@ cluster_components:
 You can modify `krkn-ai.yaml` as per your requirement to include/exclude any cluster components, scenarios, fitness function SLOs or health check endpoints for the Krkn-AI testing. For advanced customization, please refer to the krkn-ai docs.
 
 
-## 🎯 Usage
-
-### Basic Usage
+#### Running KrknAI Experiments
 
 ```bash
-# Configure custom Prometheus Querier endpoint and token
-export PROMETHEUS_URL='https://your-prometheus-url'
-export PROMETHEUS_TOKEN='your-prometheus-token'
-
-# Configure elastic search properties (optional)
-export ES_USER="elasticsearch-username"
-export __ES_PASSWORD="elasticsearch-password"
+# Configure Prometheus endpoint and token
+# export PROMETHEUS_URL='https://your-prometheus-url'
+# export PROMETHEUS_TOKEN='your-prometheus-token'
 
 # Run Krkn-AI
 uv run krkn_ai run \
   -c ./tmp/krkn-ai.yaml \
   -o ./tmp/results/ \
-  -p HOST=$HOST \
-  -p ES_USER=$ES_USER -p __ES_PASSWORD=$__ES_PASSWORD
+  -p HOST=$HOST
 ```
 
-### CLI Options
+## CLI Options
 
 ```bash
 $ uv run krkn_ai discover --help
@@ -296,11 +271,41 @@ Options:
 
 > **Note:** You can also run Krkn-AI as a container with Podman or on Kubernetes. See [container instructions](./containers/README.md).
 
-### Monitoring Dashboard
+
+## Advanced Filtering (discovery)
+
+The `-n` (namespace), `-pl` (pod-label), `-nl` (node-label), and `--skip-pod-name` options support flexible pattern matching:
+
+| Pattern | Description |
+|---------|-------------|
+| `robot-shop` | Match exactly "robot-shop" |
+| `robot-shop,default` | Match "robot-shop" OR "default" |
+| `openshift-.*` | Regex: match namespaces starting with "openshift-" |
+| `*` | Match all |
+| `!kube-system` | Match all EXCEPT "kube-system" |
+| `*,!kube-.*` | Match all except kube-* namespaces |
+| `openshift-.*,!openshift-operators` | Match openshift-* but exclude operators |
+
+**Examples:**
+
+```bash
+# Discover in all namespaces except kube-system and openshift-*
+uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
+  -n "!kube-system,!openshift-.*" \
+  -o ./tmp/krkn-ai.yaml
+
+# Discover in openshift namespaces but exclude operators
+uv run krkn_ai discover -k ./tmp/kubeconfig.yaml \
+  -n "openshift-.*,!openshift-operators" \
+  -o ./tmp/krkn-ai.yaml
+```
+
+
+## Monitoring Dashboard
 
 Krkn-AI includes a Streamlit-based dashboard for visualizing experiment progress and results.
 
-**Live monitoring during a run:**
+#### Live monitoring
 
 ```bash
 uv run krkn_ai run \
@@ -318,7 +323,7 @@ uv run krkn_ai run \
   --monitoring --port 9000
 ```
 
-**View results from a previous run:**
+#### View results
 
 ```bash
 uv run krkn_ai monitor -o ./tmp/results/
@@ -326,7 +331,7 @@ uv run krkn_ai monitor -o ./tmp/results/
 
 The dashboard provides tabs for fitness evolution, health checks, detailed scenario telemetry, logs, and configuration review.
 
-### Understanding Results
+## Understanding Results
 
 Each run of `krkn_ai run` creates a unique subdirectory (named by a generated UUID) inside the `--output` directory. All artifacts for that run are written there:
 
@@ -358,17 +363,6 @@ Each run of `krkn_ai run` creates a unique subdirectory (named by a generated UU
         ├── results.json
         └── krkn-ai.yaml
 ```
-
-## 🧬 How It Works
-
-The current version of Krkn-AI leverages an [evolutionary algorithm](https://en.wikipedia.org/wiki/Evolutionary_algorithm), an optimization technique that uses heuristics to identify chaos scenarios and components that impact the stability of your cluster and applications.
-
-1. **Initial Population**: Creates random chaos scenarios based on your configuration
-2. **Fitness Evaluation**: Runs each scenario and measures system response using Prometheus metrics
-3. **Selection**: Identifies the most effective scenarios based on fitness scores
-4. **Evolution**: Creates new scenarios through crossover and mutation
-5. **Health Monitoring**: Continuously monitors application health during experiments
-6. **Iteration**: Repeats the process across multiple generations to find optimal scenarios
 
 
 ## 🤝 Contributing

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -227,7 +227,9 @@ class KrknRunner:
                 env_list += f' -e {parameter.get_name(return_krknhub_name=True)}="{parameter.get_value()}" '
 
             command = PODMAN_TEMPLATE.format(
-                wait_duration=self.config.wait_duration,
+                wait_duration=scenario.scenario_wait_duration(
+                    self.config.wait_duration
+                ),
                 env_list=env_list,
                 kubeconfig=self.config.kubeconfig_file_path,
                 image=scenario.krknhub_image,
@@ -242,7 +244,9 @@ class KrknRunner:
                 env_list += f'--{param_name} "{parameter.get_value()}" '
 
             command = KRKNCTL_TEMPLATE.format(
-                wait_duration=self.config.wait_duration,
+                wait_duration=scenario.scenario_wait_duration(
+                    self.config.wait_duration
+                ),
                 env_list=env_list,
                 kubeconfig=self.config.kubeconfig_file_path,
                 name=scenario.krknctl_name,

--- a/krkn_ai/models/scenario/base.py
+++ b/krkn_ai/models/scenario/base.py
@@ -34,6 +34,9 @@ class Scenario(BaseScenario):
         super().__init__(**data)
         self._cluster_components = cluster_components
 
+    def scenario_wait_duration(self, config_wait_duration: int) -> int:
+        return config_wait_duration
+
     def __str__(self):
         param_value = ", ".join([str(x.value) for x in self.parameters])
         return f"{self.name}({param_value})"

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -270,13 +270,15 @@ class NetworkScenarioNetworkParamsParameter(BaseParameter):
 
     def mutate(self):
         self.value.latency = rng.randint(1, 1000)
-        self.value.loss = round(rng.uniform(0.01, 0.1), 2)
         self.value.bandwidth = rng.randint(100, 1000)
 
     def get_value(self):
+        # TODO: Add support for loss once https://github.com/krkn-chaos/krkn-hub/pull/349 is merged
+        # loss is excluded: krknctl regex requires unquoted numeric values which
+        # YAML parses as float, but krkn's arcaflow model requires Dict[str, str]
         return (
             "{"
-            + f"latency: {self.value.latency}ms,loss: {self.value.loss},bandwidth: {self.value.bandwidth}mbit"
+            + f"latency: {self.value.latency}ms,bandwidth: {self.value.bandwidth}mbit"
             + "}"
         )
 

--- a/krkn_ai/models/scenario/scenario_network.py
+++ b/krkn_ai/models/scenario/scenario_network.py
@@ -15,6 +15,11 @@ from krkn_ai.models.scenario.parameters import (
 )
 
 
+_INGRESS_WAIT_DURATION = (
+    30  # krkn requires >= 1 for ingress; 300s is krkn's own default
+)
+
+
 class NetworkScenario(Scenario):
     name: str = "network-chaos"
     krknctl_name: str = "network-chaos"
@@ -47,19 +52,28 @@ class NetworkScenario(Scenario):
 
     @property
     def parameters(self):
-        params = [
+        common = [
             self.traffic_type,
             self.image,
             self.duration,
             self.label_selector,
             self.execution,
-            self.node_name,
-            self.network_params,
-            self.egress_params,
         ]
         if self.traffic_type.value == "ingress":
-            params.append(self.target_node_interface)
-        return params
+            return common + [
+                self.network_params,
+                self.target_node_interface,
+            ]
+        # egress
+        return common + [
+            self.node_name,
+            self.egress_params,
+        ]
+
+    def scenario_wait_duration(self, config_wait_duration: int) -> int:
+        if self.traffic_type.value == "ingress":
+            return max(config_wait_duration, _INGRESS_WAIT_DURATION)
+        return config_wait_duration
 
     def mutate(self):
         # Get nodes with interfaces
@@ -72,8 +86,7 @@ class NetworkScenario(Scenario):
                 "No nodes found with interfaces in cluster components"
             )
 
-        # TODO: Add support for ingress traffic type
-        self.traffic_type.value = "egress"
+        self.traffic_type.mutate()
         self.execution.mutate()
 
         node = rng.choice(nodes)

--- a/krkn_ai/models/scenario/scenario_network.py
+++ b/krkn_ai/models/scenario/scenario_network.py
@@ -47,7 +47,7 @@ class NetworkScenario(Scenario):
 
     @property
     def parameters(self):
-        return [
+        params = [
             self.traffic_type,
             self.image,
             self.duration,
@@ -56,9 +56,10 @@ class NetworkScenario(Scenario):
             self.node_name,
             self.network_params,
             self.egress_params,
-            # self.interfaces,
-            self.target_node_interface,
         ]
+        if self.traffic_type.value == "ingress":
+            params.append(self.target_node_interface)
+        return params
 
     def mutate(self):
         # Get nodes with interfaces
@@ -75,14 +76,14 @@ class NetworkScenario(Scenario):
         self.traffic_type.value = "egress"
         self.execution.mutate()
 
-        if self.traffic_type.value == "ingress":
-            self.network_params.mutate()
-        elif self.traffic_type.value == "egress":
-            self.egress_params.mutate()
-
         node = rng.choice(nodes)
         self.node_name.value = node.name
         self.interfaces.value = f"[{rng.choice(node.interfaces)}]"
-        self.target_node_interface.value = (
-            "{" + f"{node.name}: [{rng.choice(node.interfaces)}]" + " }"
-        )
+
+        if self.traffic_type.value == "ingress":
+            self.network_params.mutate()
+            self.target_node_interface.value = (
+                "{" + f"{node.name}: [{rng.choice(node.interfaces)}]" + "}"
+            )
+        elif self.traffic_type.value == "egress":
+            self.egress_params.mutate()

--- a/krkn_ai/models/scenario/scenario_network.py
+++ b/krkn_ai/models/scenario/scenario_network.py
@@ -86,7 +86,10 @@ class NetworkScenario(Scenario):
                 "No nodes found with interfaces in cluster components"
             )
 
-        self.traffic_type.mutate()
+        # TODO: ingress verification broken on ROSA/OVNKubernetes — krkn's debug pod
+        # returns `ip` help text instead of interface list; re-enable once fixed upstream
+        # https://github.com/krkn-chaos/krkn/issues/1380
+        self.traffic_type.value = "egress"
         self.execution.mutate()
 
         node = rng.choice(nodes)

--- a/scripts/setup-demo-microservice.sh
+++ b/scripts/setup-demo-microservice.sh
@@ -17,6 +17,14 @@
 # - User should be already logged into cluster before running the script
 #
 #******************************************************************************
+detect_openshift() {
+    if kubectl get clusterversion &>/dev/null; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
 
 # Define variables
 chart_name="robot-shop"
@@ -24,7 +32,7 @@ repo_url="https://github.com/instana/robot-shop/" # Replace with the actual Helm
 namespace="${DEMO_NAMESPACE:-robot-shop}" # Replace with the desired namespace if not default
 repo_dir="temp-helm-repo"
 helm_chart="K8s/helm"
-is_openshift="${IS_OPENSHIFT:-true}" # TODO: Automatically detect if the cluster is openshift or not
+is_openshift="${IS_OPENSHIFT:-$(detect_openshift)}"
 image_repo="mirror.gcr.io/robotshop"
 infra_registry="mirror.gcr.io/library" # mirror for Docker Hub official images (redis, rabbitmq)
 
@@ -59,6 +67,7 @@ kubectl get ns $namespace || kubectl create ns $namespace
 
 if [ "$is_openshift" = "true" ]; then
     # Based on https://github.com/instana/robot-shop/tree/master/OpenShift
+    echo "OpenShift cluster detected: $is_openshift"
     oc adm new-project $namespace
     oc adm policy add-scc-to-user anyuid -z default -n $namespace
     oc adm policy add-scc-to-user privileged -z default -n $namespace


### PR DESCRIPTION
## Summary

- Correctly separates ingress vs egress parameter sets in `NetworkScenario` — previously all parameters were returned for both traffic types, and node selection happened after the type conditional (so ingress-only params were never properly set)
- Adds a `scenario_wait_duration()` hook on `Scenario` base class so individual scenarios can override the global `wait_duration` from config — network ingress uses this to enforce a minimum of 30s as required by krkn
- Removes `loss` from ingress network params (temporarily) due to a type-system mismatch between krknctl and krkn's arcaflow model; tracked in krkn-hub [PR #349](https://github.com/krkn-chaos/krkn-hub/pull/349)
- Disables ingress traffic type pending a fix in krkn upstream for interface verification failing on ROSA/OVNKubernetes; tracked in krkn [issue #1380](https://github.com/krkn-chaos/krkn/issues/1380)
- Auto-detects OpenShift in `setup-demo-microservice.sh` via `kubectl get clusterversion` instead of requiring `IS_OPENSHIFT` env var
- Cleans up README

## Changes

| File | What changed |
|---|---|
| `krkn_ai/models/scenario/scenario_network.py` | Split ingress/egress params; fix node selection order; add `scenario_wait_duration`; disable ingress (krkn #1380) |
| `krkn_ai/models/scenario/base.py` | Add default `scenario_wait_duration()` pass-through on `Scenario` |
| `krkn_ai/chaos_engines/krkn_runner.py` | Use `scenario.scenario_wait_duration()` instead of raw `config.wait_duration` |
| `krkn_ai/models/scenario/parameters.py` | Remove `loss` from ingress network params; add TODO linking krkn-hub PR #349 |
| `scripts/setup-demo-microservice.sh` | Auto-detect OpenShift; remove `IS_OPENSHIFT` manual override requirement |
| `README.md` | Simplify and clean up docs |

## Test plan

- [x] Run `krkn_ai run` with `network-scenarios: enable: true` and confirm egress scenarios execute without error
- [x] Confirm ingress scenarios are skipped (traffic type locked to egress) with no crash
- [x] Run `setup-demo-microservice.sh` on both a vanilla k8s cluster and an OpenShift cluster to verify auto-detection works

## Related issues

- krkn [#1380](https://github.com/krkn-chaos/krkn/issues/1380) — ingress interface verification broken on ROSA/OVNKubernetes (`ip -br addr show` returns help text in debug pod)
- krkn-hub [#349](https://github.com/krkn-chaos/krkn-hub/pull/349) — `loss` parameter type mismatch in network chaos arcaflow model

---

Signed-off-by: Rahul Shetty <rashetty@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)