### PR TITLE
fix(deps): add setuptools dependency for Python 3.12 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "streamlit>=1.55.0",
   "kubernetes>=34.1.0,<36",
   "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@a89b299b1789eeb8f8ed07213eccd77414f03283",
+  "setuptools"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description
This PR addresses a runtime `ModuleNotFoundError: No module named 'distutils'` encountered when running `krkn_ai` commands on modern systems using Python 3.12+.

Per PEP 632, the `distutils` package has been completely removed from the Python standard library starting in version 3.12. The upstream dependency `kubeconfig` used by this repository still attempts to execute `import distutils.spawn` to track down the system's `kubectl` binary path. This patch explicitly adds `setuptools` to the core project dependency mapping within `pyproject.toml` to provide the legacy standard library fallback wrappers out-of-the-box for all contributors using `uv sync` or standard `pip` environments.

Fixes #354 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other:

## Testing
I reproduced and validated this environment blocker natively on an Arch Linux system running Python 3.12.4:
1. Provisioned a fresh virtual environment using `uv venv && uv sync` without this patch and confirmed the `ModuleNotFoundError` crash when running `uv run krkn_ai discover --help`.
2. Applied `setuptools` to the dependency tree, re-ran `uv sync`, and verified that the CLI successfully compiles and prints out the core discovery help manuals without warnings.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors