### PR TITLE
fix(fitness): handle NaN/Inf fitness values so they don't crash or skew the GA

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -10,6 +10,7 @@ from krkn_ai.models.app import (
     FitnessResult,
     FitnessScoreResult,
     KrknRunnerType,
+    coerce_finite_fitness,
 )
 from krkn_ai.models.config import ConfigFile, FitnessFunctionType
 from krkn_ai.models.custom_errors import (
@@ -467,7 +468,7 @@ class KrknRunner:
             query, end, "point fitness (end)"
         )
 
-        return float(result_at_end) - float(result_at_beginning)
+        return coerce_finite_fitness(float(result_at_end) - float(result_at_beginning))
 
     def _query_prometheus_single_point(
         self, query: str, timestamp: datetime.datetime, context: str
@@ -554,11 +555,13 @@ class KrknRunner:
             f"in the requested time range or Prometheus has not yet scraped data."
         )
 
-        return float(
-            self._extract_single_prometheus_value(
-                result,
-                query,
-                f"range fitness [{start}, {end}]",
-                no_data_error,
+        return coerce_finite_fitness(
+            float(
+                self._extract_single_prometheus_value(
+                    result,
+                    query,
+                    f"range fitness [{start}, {end}]",
+                    no_data_error,
+                )
             )
         )

--- a/krkn_ai/models/app.py
+++ b/krkn_ai/models/app.py
@@ -1,16 +1,34 @@
 import logging
+import math
 import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 from dataclasses import dataclass
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from krkn_ai.models.scenario.base import BaseScenario
 from krkn_ai.models.config import HealthCheckResult
 from krkn_ai.utils import id_generator
+from krkn_ai.utils.logger import get_logger
 
 
+logger = get_logger(__name__)
 auto_id = id_generator()
+
+# Floor applied to any non-finite (NaN/±Inf) fitness value. PromQL can legitimately
+# return NaN/Inf (counter resets, zero denominators, scrape gaps during chaos); left
+# unguarded these crash roulette selection and corrupt sorted() ranking.
+NONFINITE_FITNESS_FLOOR = 0.0
+
+
+def coerce_finite_fitness(value: float) -> float:
+    """Coerce a non-finite fitness value to NONFINITE_FITNESS_FLOOR with a warning."""
+    if math.isfinite(value):
+        return value
+    logger.warning(
+        "Non-finite fitness value %r coerced to %s", value, NONFINITE_FITNESS_FLOOR
+    )
+    return NONFINITE_FITNESS_FLOOR
 
 
 @dataclass
@@ -23,13 +41,29 @@ class FitnessScoreResult(BaseModel):
     fitness_score: float
     weighted_score: float
 
+    _finite = field_validator("fitness_score", "weighted_score", mode="after")(
+        staticmethod(coerce_finite_fitness)
+    )
+
 
 class FitnessResult(BaseModel):
-    scores: List[FitnessScoreResult] = []
+    # validate_assignment ensures the invariant also holds when fitness_score is
+    # reassigned after construction (e.g. the aggregate sum in KrknRunner.run).
+    model_config = ConfigDict(validate_assignment=True)
+
+    scores: List[FitnessScoreResult] = Field(default_factory=list)
     health_check_failure_score: float = 0.0  # Health check failure score
     health_check_response_time_score: float = 0.0  # Health check response time score
     krkn_failure_score: float = 0.0  # Krkn failure score
     fitness_score: float = 0.0  # Overall fitness score
+
+    _finite = field_validator(
+        "fitness_score",
+        "health_check_failure_score",
+        "health_check_response_time_score",
+        "krkn_failure_score",
+        mode="after",
+    )(staticmethod(coerce_finite_fitness))
 
 
 class CommandRunResult(BaseModel):

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -256,6 +256,76 @@ class TestCalculatePointFitness:
             assert score == 5.0  # 10 - 5
             assert mock_prom_client.process_prom_query_in_range.call_count == 2
 
+    @pytest.mark.parametrize("bad_value", ["NaN", "+Inf", "-Inf"])
+    def test_calculate_point_fitness_coerces_non_finite(
+        self, bad_value, minimal_config, temp_output_dir
+    ):
+        """Non-finite PromQL values must be coerced to a finite floor (0.0)
+        so they cannot crash roulette selection or corrupt ranking."""
+        minimal_config.fitness_function = FitnessFunction(
+            query="sum(kube_pod_container_status_restarts_total)",
+            type=FitnessFunctionType.point,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.side_effect = [
+            [{"values": [[1000, "5"]]}],  # start
+            [{"values": [[2000, bad_value]]}],  # end -> 5 - non-finite
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            score = runner.calculate_point_fitness(
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                datetime.datetime(2024, 1, 1, 12, 5, 0),
+                "sum(kube_pod_container_status_restarts_total)",
+            )
+
+            assert score == 0.0
+
+    @pytest.mark.parametrize("bad_value", ["NaN", "+Inf", "-Inf"])
+    def test_calculate_range_fitness_coerces_non_finite(
+        self, bad_value, minimal_config, temp_output_dir
+    ):
+        """Non-finite PromQL values in range mode are coerced to 0.0."""
+        minimal_config.fitness_function = FitnessFunction(
+            query="max_over_time(foo[$range$])",
+            type=FitnessFunctionType.range,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[2000, bad_value]]}
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            score = runner.calculate_range_fitness(
+                datetime.datetime(2024, 1, 1, 12, 0, 0),
+                datetime.datetime(2024, 1, 1, 12, 5, 0),
+                "max_over_time(foo[$range$])",
+            )
+
+            assert score == 0.0
+
     def test_calculate_point_fitness_empty_values_raises_error(
         self, minimal_config, temp_output_dir
     ):

--- a/tests/unit/models/test_app.py
+++ b/tests/unit/models/test_app.py
@@ -4,6 +4,8 @@ AppContext and CommandRunResult model tests
 
 import datetime
 
+import pytest
+
 from krkn_ai.models.app import (
     CommandRunResult,
     FitnessResult,
@@ -157,3 +159,45 @@ class TestFitnessResult:
         assert fitness.health_check_response_time_score == 2.0
         assert fitness.krkn_failure_score == 0.5
         assert fitness.fitness_score == 15.0
+
+
+class TestFitnessResultNonFiniteInvariant:
+    """A fitness score must always be finite. PromQL can emit NaN/±Inf, which
+    otherwise crashes roulette selection and corrupts sorted() ranking."""
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_coerced_on_construction(self, bad):
+        assert FitnessResult(fitness_score=bad).fitness_score == 0.0
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_coerced_on_assignment(self, bad):
+        # validate_assignment must catch the post-construction aggregate reassignment
+        result = FitnessResult()
+        result.fitness_score = bad
+        assert result.fitness_score == 0.0
+
+    def test_all_score_fields_coerced(self):
+        result = FitnessResult(
+            health_check_failure_score=float("nan"),
+            health_check_response_time_score=float("inf"),
+            krkn_failure_score=float("-inf"),
+            fitness_score=float("nan"),
+        )
+        assert result.health_check_failure_score == 0.0
+        assert result.health_check_response_time_score == 0.0
+        assert result.krkn_failure_score == 0.0
+        assert result.fitness_score == 0.0
+
+    def test_per_item_scores_coerced(self):
+        item = FitnessScoreResult(
+            id=1, fitness_score=float("nan"), weighted_score=float("inf")
+        )
+        assert item.fitness_score == 0.0
+        assert item.weighted_score == 0.0
+
+    def test_finite_values_preserved(self):
+        # Includes the -1.0 misconfiguration sentinel, which must pass through.
+        result = FitnessResult(fitness_score=-1.0)
+        assert result.fitness_score == -1.0
+        result.fitness_score = 7.5
+        assert result.fitness_score == 7.5


### PR DESCRIPTION
# Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Description

Right now a fitness query can return a non-finite value (NaN, +Inf or -Inf) and nothing guards against it. This happens more often than you'd expect during chaos, for example when a pod gets killed its counters reset, so a `rate()` or a division query can come back as NaN for that window.

When that value reaches the genetic algorithm two bad things happen:

1. Roulette selection crashes. The NaN turns the selection probabilities into NaN and `np.random.choice` raises a ValueError, which kills the whole run partway through.
2. Even when it doesn't crash, `sorted()` orders NaN in an undefined way, so the "best" scenario it picks is basically wrong and the search quietly optimizes on garbage.

This is also related to the older negative-fitness fix (#50 / #51), which hardened roulette against negative scores but didn't cover the NaN/Inf case.

The fix coerces any non-finite fitness value to a finite floor (0.0) and logs a warning so it's visible, not silent. It's done in two small places:

- At the Prometheus boundary in `calculate_point_fitness` / `calculate_range_fitness`, where the raw value first becomes a score.
- As an invariant on the `FitnessResult` / `FitnessScoreResult` models, so the guarantee also holds for the aggregate score that gets reassigned later in `run()`, and for any future code that produces a fitness result.

Both layers share a single `coerce_finite_fitness` helper and one `NONFINITE_FITNESS_FLOOR` constant, so the policy lives in one spot. Finite values, including the existing `-1.0` misconfiguration marker, pass through untouched. No config, CLI or output format changes.

I went with 0.0 because fitness is summed with the other signals (krkn failure, health checks), so 0.0 means "this metric gave no usable signal" while the rest still count. Happy to switch it to -1.0 if you'd rather penalize those cases, it's a one line change.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

## Testing

```text
.venv/bin/python -m pytest -q

.............................................................................................. [ 25%]
.............................................................................................. [ 50%]
.............................................................................................. [ 75%]
..........................................................................................     [100%]
372 passed in 10.57s
```