### PR TITLE
Skip node interface discovery when debug image is unavailable

### DIFF
--- a/krkn_ai/utils/cluster_manager.py
+++ b/krkn_ai/utils/cluster_manager.py
@@ -1,5 +1,6 @@
 import re
 import concurrent.futures
+import threading
 from typing import Dict, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
@@ -31,6 +32,8 @@ class ClusterManager:
         self.api_client = self.krkn_k8s.api_client
         self.core_api = self.krkn_k8s.cli
         self.custom_obj_api = self.krkn_k8s.custom_object_client
+        self._can_pull_debug_image: Optional[bool] = None
+        self._can_pull_debug_image_lock = threading.Lock()
         logger.debug("ClusterManager initialized with kubeconfig: %s", kubeconfig)
 
     def discover_components(
@@ -415,7 +418,54 @@ class ClusterManager:
         logger.debug("Filtered %d nodes", len(node_list))
         return node_list
 
+    def can_pull_openshift_debug_image(self) -> bool:
+        """
+        Check whether the OpenShift debug image can be accessed.
+        This avoids waiting for long timeouts when `oc debug`
+        will eventually fail because the required image cannot
+        be pulled.
+        """
+        if self._can_pull_debug_image is not None:
+            return self._can_pull_debug_image
+
+        with self._can_pull_debug_image_lock:
+            if self._can_pull_debug_image is not None:
+                return self._can_pull_debug_image
+
+            try:
+                _, code = run_shell(
+                    "oc image info registry.redhat.io/rhel8/support-tools",
+                    do_not_log=True,
+                    timeout=5,
+                )
+                self._can_pull_debug_image = code == 0
+            except Exception:
+                self._can_pull_debug_image = False
+
+            if not self._can_pull_debug_image:
+                logger.warning(
+                    "Skipping node interface discovery. "
+                    "The OpenShift debug image "
+                    "'registry.redhat.io/rhel8/support-tools' "
+                    "is not accessible. "
+                    "This commonly indicates missing Red Hat registry "
+                    "credentials. Network chaos scenarios may not be available."
+                )
+
+            return self._can_pull_debug_image
+
     def list_node_interfaces(self, node: str) -> List[str]:
+        # TODO:
+        # Node interface discovery currently relies on OpenShift's
+        # `oc debug` workflow and the image
+        # `registry.redhat.io/rhel8/support-tools`.
+        # Investigate a Kubernetes-native mechanism for discovering
+        # node interfaces on Minikube, Kind and generic Kubernetes
+        # clusters without requiring Red Hat registry credentials.
+
+        if not self.can_pull_openshift_debug_image():
+            return []
+
         logger.debug("Listing node interfaces for node %s", node)
         try:
             log, code = run_shell(

--- a/tests/unit/utils/test_cluster_manager.py
+++ b/tests/unit/utils/test_cluster_manager.py
@@ -559,3 +559,12 @@ class TestClusterManager:
         by_name = {n.name: n for n in nodes}
         assert by_name["good-node"].interfaces == ["eth0"]
         assert by_name["bad-node"].interfaces == []
+
+    def test_can_pull_openshift_debug_image_caching(self, cluster_manager):
+        """Test that can_pull_openshift_debug_image caches the result and calls run_shell only once"""
+        with patch(
+            "krkn_ai.utils.cluster_manager.run_shell", return_value=("", 0)
+        ) as mock_run_shell:
+            assert cluster_manager.can_pull_openshift_debug_image() is True
+            assert cluster_manager.can_pull_openshift_debug_image() is True
+            mock_run_shell.assert_called_once()


### PR DESCRIPTION
## Description

This PR avoids long discovery delays when node interface discovery relies on OpenShift's `oc debug` workflow but the required debug image is not accessible.

Closes #358 

Currently, `list_node_interfaces()` invokes:

```
oc debug -q node/<node> -- chroot /host ls /sys/class/net
```

On environments where the image `registry.redhat.io/rhel8/support-tools` cannot be pulled (for example, when Red Hat registry credentials are not configured), discovery waits for the interface discovery timeout before continuing.

This change performs a lightweight image accessibility check before invoking `oc debug`. If the image is not accessible, node interface discovery is skipped and a warning is emitted explaining the likely cause and impact.

In my test environment, this reduced `discover` runtime from approximately **3 minutes** to **9 seconds** while still successfully generating the configuration file.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Other:

## Testing

Environment:

* Minikube
* Ubuntu (WSL2)
* Python 3.11

Validation performed:

1. Verified that:

```
oc image info registry.redhat.io/rhel8/support-tools
```

returns an authorization error immediately when Red Hat registry credentials are unavailable.

2. Ran:

```
krkn_ai discover \
  -k ./kubeconfig.yaml \
  -n robot-shop \
  -pl service \
  -nl kubernetes.io/hostname \
  -o ./krkn-ai.yaml \
  --skip-pod-name "nginx-proxy.*"
```

Before this change:

```
[WARNING] Timed out listing interfaces for node minikube, skipping

real    3m1.841s
```

After this change:

```
[WARNING] Skipping node interface discovery. The OpenShift debug image 'registry.redhat.io/rhel8/support-tools' is not accessible...

real    0m8.866s
```

3. Verified that the configuration file is still generated successfully.

## Checklist

* [x] I have read the CONTRIBUTING guidelines
* [x] My code follows the project's style guidelines
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] I have updated the documentation accordingly
* [x] My changes generate no new warnings or errors


<img width="1907" height="960" alt="image" src="https://github.com/user-attachments/assets/db59307f-c435-4e28-a690-11a12703a574" />
