### PR TITLE
feat(scenario): add storage throttle scenario for I/O throttling testing

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -66,6 +66,10 @@ class KubevirtScenarioConfig(BaseModel):
     enable: bool = False
 
 
+class StorageThrottleScenarioConfig(BaseModel):
+    enable: bool = False
+
+
 class BaselineConfig(BaseModel):
     enable: bool = True
     duration: int = 60 * 2  # 2 minutes
@@ -105,6 +109,9 @@ class ScenarioConfig(BaseModel):
     )
     kubevirt_scenarios: Optional[KubevirtScenarioConfig] = Field(
         alias="kubevirt-scenarios", default=None
+    )
+    storage_throttle: Optional[StorageThrottleScenarioConfig] = Field(
+        alias="storage-throttle", default=None
     )
 
 

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -24,6 +24,7 @@ from krkn_ai.models.scenario.scenario_syn_flood import SynFloodScenario
 from krkn_ai.models.scenario.scenario_io_hog import NodeIOHogScenario
 from krkn_ai.models.scenario.scenario_pvc import PVCScenario
 from krkn_ai.models.scenario.scenario_kubevirt import KubevirtDisruptionScenario
+from krkn_ai.models.scenario.scenario_storage_throttle import StorageThrottleScenario
 
 logger = get_logger(__name__)
 
@@ -40,6 +41,7 @@ scenario_specs = [
     ("syn_flood", SynFloodScenario),
     ("pvc_scenarios", PVCScenario),
     ("kubevirt_scenarios", KubevirtDisruptionScenario),
+    ("storage_throttle", StorageThrottleScenario),
 ]
 
 

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -539,3 +539,77 @@ class KillCountParameter(BaseParameter):
     krknhub_name: str = "KILL_COUNT"
     krknctl_name: str = "kill-count"
     value: int = 1
+
+
+# Storage Throttle Scenario Parameters
+class StorageThrottleTypeParameter(BaseParameter):
+    krknhub_name: str = "THROTTLE_TYPE"
+    krknctl_name: str = "throttle-type"
+    value: str = "bandwidth"
+
+    def mutate(self):
+        self.value = rng.choice(["iops", "bandwidth", "both"])
+
+
+class ReadIOPSParameter(BaseParameter):
+    krknhub_name: str = "READ_IOPS"
+    krknctl_name: str = "read-iops"
+    value: int = 100
+
+    def mutate(self):
+        self.value = rng.randint(10, 500)
+
+
+class WriteIOPSParameter(BaseParameter):
+    krknhub_name: str = "WRITE_IOPS"
+    krknctl_name: str = "write-iops"
+    value: int = 50
+
+    def mutate(self):
+        self.value = rng.randint(10, 500)
+
+
+class ReadBPSParameter(BaseParameter):
+    krknhub_name: str = "READ_BPS"
+    krknctl_name: str = "read-bps"
+    value: int = 1048576  # 1Mi in bytes (1024 * 1024)
+
+    def get_value(self):
+        if self.value < 1024:
+            return f"{self.value}"
+        elif self.value < 1024 * 1024:
+            return f"{self.value // 1024}Ki"
+        else:
+            return f"{self.value // (1024 * 1024)}Mi"
+
+    def mutate(self):
+        self.value = rng.randint(256 * 1024, 10 * 1024 * 1024)
+
+
+class WriteBPSParameter(BaseParameter):
+    krknhub_name: str = "WRITE_BPS"
+    krknctl_name: str = "write-bps"
+    value: int = 524288  # 512Ki in bytes (512 * 1024)
+
+    def get_value(self):
+        if self.value < 1024:
+            return f"{self.value}"
+        elif self.value < 1024 * 1024:
+            return f"{self.value // 1024}Ki"
+        else:
+            return f"{self.value // (1024 * 1024)}Mi"
+
+    def mutate(self):
+        self.value = rng.randint(128 * 1024, 5 * 1024 * 1024)
+
+
+class MountPathParameter(BaseParameter):
+    krknhub_name: str = "MOUNT_PATH"
+    krknctl_name: str = "mount-path"
+    value: str = ""
+
+
+class StorageThrottleImageParameter(BaseParameter):
+    krknhub_name: str = "IMAGE"
+    krknctl_name: str = "image"
+    value: str = "quay.io/krkn-chaos/krkn:tools"

--- a/krkn_ai/models/scenario/scenario_storage_throttle.py
+++ b/krkn_ai/models/scenario/scenario_storage_throttle.py
@@ -1,0 +1,103 @@
+from typing import List, Tuple
+from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.rng import rng
+from krkn_ai.models.scenario.base import Scenario
+from krkn_ai.models.scenario.parameters import (
+    MountPathParameter,
+    NamespaceParameter,
+    PodNameParameter,
+    PVCNameParameter,
+    ReadBPSParameter,
+    ReadIOPSParameter,
+    StandardDurationParameter,
+    StorageThrottleImageParameter,
+    StorageThrottleTypeParameter,
+    WriteBPSParameter,
+    WriteIOPSParameter,
+)
+from krkn_ai.models.cluster_components import Namespace, Pod, PVC
+from krkn_ai.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class StorageThrottleScenario(Scenario):
+    name: str = "storage-throttle"
+    krknctl_name: str = "storage-throttle"
+    krknhub_image: str = (
+        "containers.krkn-chaos.dev/krkn-chaos/krkn-hub:storage-throttle"
+    )
+
+    namespace: NamespaceParameter = NamespaceParameter()
+    pvc_name: PVCNameParameter = PVCNameParameter()
+    pod_name: PodNameParameter = PodNameParameter()
+    mount_path: MountPathParameter = MountPathParameter()
+    throttle_type: StorageThrottleTypeParameter = StorageThrottleTypeParameter()
+    read_iops: ReadIOPSParameter = ReadIOPSParameter()
+    write_iops: WriteIOPSParameter = WriteIOPSParameter()
+    read_bps: ReadBPSParameter = ReadBPSParameter()
+    write_bps: WriteBPSParameter = WriteBPSParameter()
+    duration: StandardDurationParameter = StandardDurationParameter(value=60)
+    image: StorageThrottleImageParameter = StorageThrottleImageParameter()
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.mutate()
+
+    @property
+    def parameters(self):
+        params = [self.namespace]
+        if self.pvc_name.value:
+            params.append(self.pvc_name)
+        elif self.pod_name.value:
+            params.append(self.pod_name)
+        params.extend([self.mount_path, self.throttle_type])
+
+        if self.throttle_type.value == "iops":
+            params.extend([self.read_iops, self.write_iops])
+        elif self.throttle_type.value == "bandwidth":
+            params.extend([self.read_bps, self.write_bps])
+        else:  # "both"
+            params.extend(
+                [self.read_iops, self.write_iops, self.read_bps, self.write_bps]
+            )
+
+        params.extend([self.duration, self.image])
+        return params
+
+    def mutate(self):
+        if len(self._cluster_components.namespaces) == 0:
+            raise ScenarioParameterInitError(
+                "No namespaces found in cluster components"
+            )
+
+        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = []
+        namespace_pod_tuple: List[Tuple[Namespace, Pod]] = []
+
+        for namespace in self._cluster_components.namespaces:
+            if namespace.pvcs:
+                namespace_pvc_tuple.extend((namespace, pvc) for pvc in namespace.pvcs)
+            if namespace.pods:
+                namespace_pod_tuple.extend((namespace, pod) for pod in namespace.pods)
+
+        if not namespace_pvc_tuple and not namespace_pod_tuple:
+            raise ScenarioParameterInitError(
+                "No PVCs or pods found in cluster components for storage-throttle scenario"
+            )
+
+        if namespace_pvc_tuple:
+            namespace, pvc = rng.choice(namespace_pvc_tuple)
+            self.namespace.value = namespace.name
+            self.pvc_name.value = pvc.name
+            self.pod_name.value = ""
+        else:
+            namespace, pod = rng.choice(namespace_pod_tuple)
+            self.namespace.value = namespace.name
+            self.pod_name.set_pod(namespace.name, pod)
+            self.pvc_name.value = ""
+
+        self.throttle_type.mutate()
+        self.read_iops.mutate()
+        self.write_iops.mutate()
+        self.read_bps.mutate()
+        self.write_bps.mutate()

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -88,6 +88,8 @@ scenario:
     enable: false
   kubevirt-scenarios:
     enable: false
+  storage-throttle:
+    enable: false
 
 cluster_components:
 {{ cluster_components }}

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -16,6 +16,7 @@ from krkn_ai.models.scenario.scenario_network import NetworkScenario
 from krkn_ai.models.scenario.scenario_dns_outage import DnsOutageScenario
 from krkn_ai.models.scenario.scenario_syn_flood import SynFloodScenario
 from krkn_ai.models.scenario.scenario_pvc import PVCScenario
+from krkn_ai.models.scenario.scenario_storage_throttle import StorageThrottleScenario
 from krkn_ai.models.cluster_components import (
     ClusterComponents,
     Namespace,
@@ -324,3 +325,93 @@ class TestPVCScenario:
 
         with pytest.raises(ScenarioParameterInitError, match="No namespaces found"):
             PVCScenario(cluster_components=cluster)
+
+
+class TestStorageThrottleScenario:
+    """Test StorageThrottleScenario class"""
+
+    def test_storage_throttle_scenario_initialization_with_pvcs(self):
+        """Test that StorageThrottleScenario initializes when PVCs exist"""
+        pvc = PVC(name="test-pvc", labels={})
+        namespace = Namespace(name="test-ns", pvcs=[pvc])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = StorageThrottleScenario(cluster_components=cluster)
+        assert scenario.name == "storage-throttle"
+        assert scenario.namespace.value == "test-ns"
+        assert scenario.pvc_name.value == "test-pvc"
+        assert scenario.pod_name.value == ""
+        assert scenario.throttle_type.value in ["iops", "bandwidth", "both"]
+
+    def test_storage_throttle_scenario_initialization_with_pods_only(self):
+        """Test that StorageThrottleScenario falls back to pods when no PVCs exist"""
+        pod = Pod(
+            name="test-pod",
+            labels={"app": "web"},
+            containers=[Container(name="c1")],
+        )
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = StorageThrottleScenario(cluster_components=cluster)
+        assert scenario.name == "storage-throttle"
+        assert scenario.namespace.value == "test-ns"
+        assert scenario.pod_name.value == "test-pod"
+        assert scenario.pvc_name.value == ""
+
+    def test_storage_throttle_scenario_raises_error_when_no_pvcs_or_pods(self):
+        """Test that StorageThrottleScenario raises error when no PVCs or pods exist"""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+
+        with pytest.raises(ScenarioParameterInitError, match="No namespaces found"):
+            StorageThrottleScenario(cluster_components=cluster)
+
+    def test_storage_throttle_scenario_raises_error_empty_namespace(self):
+        """Test that StorageThrottleScenario raises error when namespace has no PVCs or pods"""
+        namespace = Namespace(name="test-ns")
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        with pytest.raises(ScenarioParameterInitError, match="No PVCs or pods found"):
+            StorageThrottleScenario(cluster_components=cluster)
+
+    def test_storage_throttle_scenario_conditional_parameters_iops(self):
+        """Test that parameters list includes IOPS params when throttle_type is iops"""
+        pvc = PVC(name="test-pvc", labels={})
+        namespace = Namespace(name="test-ns", pvcs=[pvc])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = StorageThrottleScenario(cluster_components=cluster)
+        scenario.throttle_type.value = "iops"
+        param_names = [p.krknctl_name for p in scenario.parameters]
+        assert "read-iops" in param_names
+        assert "write-iops" in param_names
+        assert "read-bps" not in param_names
+        assert "write-bps" not in param_names
+
+    def test_storage_throttle_scenario_conditional_parameters_bandwidth(self):
+        """Test that parameters list includes BPS params when throttle_type is bandwidth"""
+        pvc = PVC(name="test-pvc", labels={})
+        namespace = Namespace(name="test-ns", pvcs=[pvc])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = StorageThrottleScenario(cluster_components=cluster)
+        scenario.throttle_type.value = "bandwidth"
+        param_names = [p.krknctl_name for p in scenario.parameters]
+        assert "read-bps" in param_names
+        assert "write-bps" in param_names
+        assert "read-iops" not in param_names
+        assert "write-iops" not in param_names
+
+    def test_storage_throttle_scenario_conditional_parameters_both(self):
+        """Test that parameters list includes all throttle params when type is both"""
+        pvc = PVC(name="test-pvc", labels={})
+        namespace = Namespace(name="test-ns", pvcs=[pvc])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = StorageThrottleScenario(cluster_components=cluster)
+        scenario.throttle_type.value = "both"
+        param_names = [p.krknctl_name for p in scenario.parameters]
+        assert "read-iops" in param_names
+        assert "write-iops" in param_names
+        assert "read-bps" in param_names
+        assert "write-bps" in param_names


### PR DESCRIPTION
## Description
Adds a new [storage-throttle](https://krkn-chaos.dev/docs/scenarios/storage-throttle-scenario/) scenario that allows the genetic algorithm to generate and evolve chaos scenarios targeting storage I/O (IOPS and bandwidth) on PVC-backed volumes via Linux cgroup controllers.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
<!-- How have you tested these changes? -->

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
