### PR TITLE
fix(rng): avoid NumPy array conversion of Pydantic objects in choice/choices

### DIFF
--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -24,10 +24,14 @@ class RNG:
 
     def choice(self, items: Sequence[T]) -> T:
         """Return a random element from the given non-empty sequence. The return type is inferred from the list type."""
-        return self.rng.choice(items)
+        if not items:
+            raise ValueError("Cannot select from an empty sequence")
+        idx = self.rng.integers(0, len(items))
+        return items[idx]
 
     def choices(self, items: List[Any], weights: List[float], k: int = 1):
-        return list(self.rng.choice(items, p=weights, size=k))
+        indices = list(self.rng.choice(len(items), p=weights, size=k))
+        return [items[i] for i in indices]
 
     def randint(self, low: int, high: int) -> int:
         """Return a random integer N such that low <= N <= high (both inclusive).

--- a/krkn_ai/utils/rng.py
+++ b/krkn_ai/utils/rng.py
@@ -1,5 +1,5 @@
 import numpy as np
-from typing import List, Any, Optional
+from typing import List, Optional
 from typing import TypeVar, Sequence
 
 T = TypeVar("T")
@@ -24,12 +24,14 @@ class RNG:
 
     def choice(self, items: Sequence[T]) -> T:
         """Return a random element from the given non-empty sequence. The return type is inferred from the list type."""
-        if not items:
+        if len(items) == 0:
             raise ValueError("Cannot select from an empty sequence")
         idx = self.rng.integers(0, len(items))
         return items[idx]
 
-    def choices(self, items: List[Any], weights: List[float], k: int = 1):
+    def choices(self, items: Sequence[T], weights: List[float], k: int = 1) -> List[T]:
+        if len(items) == 0:
+            raise ValueError("Cannot select from an empty sequence")
         indices = list(self.rng.choice(len(items), p=weights, size=k))
         return [items[i] for i in indices]
 

--- a/tests/unit/utils/test_rng.py
+++ b/tests/unit/utils/test_rng.py
@@ -1,4 +1,10 @@
+from pydantic import BaseModel
 from krkn_ai.utils.rng import RNG
+
+
+class DummyPydanticModel(BaseModel):
+    value: int
+    nested: list[int] = [1, 2, 3]
 
 
 class TestRNG:
@@ -55,6 +61,17 @@ class TestRNG:
         choice2 = rng.choice(items)
         assert choice == choice2
 
+    def test_choice_pydantic_compatibility(self):
+        """Test choice() works with Pydantic models (prevents NumPy array conversion failure)."""
+        rng = RNG(42)
+        models = [
+            DummyPydanticModel(value=1),
+            DummyPydanticModel(value=2),
+            DummyPydanticModel(value=3),
+        ]
+        choice = rng.choice(models)
+        assert choice in models
+
     def test_choices(self):
         """Test choices() picks multiple elements with weights."""
         rng = RNG(42)
@@ -71,6 +88,19 @@ class TestRNG:
         rng.set_seed(42)
         choices2 = rng.choices(items, weights, k=5)
         assert choices == choices2
+
+    def test_choices_pydantic_compatibility(self):
+        """Test choices() works with Pydantic models (prevents NumPy array conversion failure)."""
+        rng = RNG(42)
+        models = [
+            DummyPydanticModel(value=1),
+            DummyPydanticModel(value=2),
+            DummyPydanticModel(value=3),
+        ]
+        weights = [0.1, 0.8, 0.1]
+        choices = rng.choices(models, weights, k=5)
+        assert len(choices) == 5
+        assert all(c in models for c in choices)
 
     def test_randint_returns_int_in_inclusive_range(self):
         """Test randint() returns an integer within [low, high] inclusive."""

--- a/tests/unit/utils/test_rng.py
+++ b/tests/unit/utils/test_rng.py
@@ -72,6 +72,27 @@ class TestRNG:
         choice = rng.choice(models)
         assert choice in models
 
+    def test_choice_numpy_array_compatibility(self):
+        """Test choice() works with numpy arrays (both 1D and object arrays)."""
+        import numpy as np
+
+        rng = RNG(42)
+        arr = np.array([10, 20, 30])
+        choice = rng.choice(arr)
+        assert choice in [10, 20, 30]
+
+    def test_choice_empty_sequence_raises_value_error(self):
+        """Test choice() raises ValueError when passed an empty sequence or empty numpy array."""
+        import numpy as np
+
+        rng = RNG(42)
+        import pytest
+
+        with pytest.raises(ValueError, match="Cannot select from an empty sequence"):
+            rng.choice([])
+        with pytest.raises(ValueError, match="Cannot select from an empty sequence"):
+            rng.choice(np.array([]))
+
     def test_choices(self):
         """Test choices() picks multiple elements with weights."""
         rng = RNG(42)
@@ -101,6 +122,29 @@ class TestRNG:
         choices = rng.choices(models, weights, k=5)
         assert len(choices) == 5
         assert all(c in models for c in choices)
+
+    def test_choices_numpy_array_compatibility(self):
+        """Test choices() works with numpy arrays."""
+        import numpy as np
+
+        rng = RNG(42)
+        arr = np.array([10, 20, 30])
+        weights = [0.2, 0.6, 0.2]
+        choices = rng.choices(arr, weights, k=5)
+        assert len(choices) == 5
+        assert all(c in [10, 20, 30] for c in choices)
+
+    def test_choices_empty_sequence_raises_value_error(self):
+        """Test choices() raises ValueError when passed an empty sequence or empty numpy array."""
+        import numpy as np
+
+        rng = RNG(42)
+        import pytest
+
+        with pytest.raises(ValueError, match="Cannot select from an empty sequence"):
+            rng.choices([], [1.0], k=2)
+        with pytest.raises(ValueError, match="Cannot select from an empty sequence"):
+            rng.choices(np.array([]), [], k=2)
 
     def test_randint_returns_int_in_inclusive_range(self):
         """Test randint() returns an integer within [low, high] inclusive."""


### PR DESCRIPTION
Using `self.rng.choice(items)` directly converts sequence elements to a NumPy array. When `items` is a list of complex objects (such as Pydantic `BaseModel` instances like `BaseScenario`), NumPy fails to construct the multi-dimensional array layout, throwing a `ValueError: object too deep for desired array` runtime crash during GA execution.

## Changes
- Refactored `choice(self, items)` to pick a random index using `self.rng.integers(0, len(items))` and return the item at that index.
- Refactored `choices(self, items, weights, k)` to select indices using `self.rng.choice(len(items), p=weights, size=k)` and retrieve the corresponding items.
- Added unit tests verifying compatibility of both methods with lists of Pydantic models.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Ran the entire test suite locally (359 unit tests passed successfully, including new compatibility tests).

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] My code was formatted using the project's formatter
- [x] I have performed a self-review of my own code
