### PR TITLE
dashboard: narrow bare except to specific exception types

### DIFF
--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import argparse
 import time
@@ -34,6 +35,8 @@ from krkn_ai.dashboard.tabs.config import render_config
 from krkn_ai.dashboard.tabs.anomalies import render_anomalies
 from krkn_ai.dashboard.report_generator import generate_html_report
 
+logger = logging.getLogger(__name__)
+
 
 def get_monitor_config():
     """Retrieve monitor config from command line arguments."""
@@ -57,8 +60,8 @@ def is_execution_running(output_dir: str) -> bool:
             status = data.get("status")
             if status in [STATUS_STARTED, STATUS_IN_PROGRESS]:
                 return True
-    except Exception:
-        pass
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not read results.json: %s", e)
     return False
 
 
@@ -71,7 +74,8 @@ def get_run_status(output_dir: str) -> Optional[str]:
         with open(results_file, "r") as f:
             data = json.load(f)
             return data.get("status")
-    except Exception:
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not read results.json: %s", e)
         return None
 
 

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -61,7 +61,7 @@ def is_execution_running(output_dir: str) -> bool:
             if status in [STATUS_STARTED, STATUS_IN_PROGRESS]:
                 return True
     except (json.JSONDecodeError, OSError) as e:
-        logger.warning("Could not read results.json: %s", e)
+        logger.warning("Could not read %s: %s", results_file, e)
     return False
 
 
@@ -75,7 +75,7 @@ def get_run_status(output_dir: str) -> Optional[str]:
             data = json.load(f)
             return data.get("status")
     except (json.JSONDecodeError, OSError) as e:
-        logger.warning("Could not read results.json: %s", e)
+        logger.warning("Could not read %s: %s", results_file, e)
         return None
 
 


### PR DESCRIPTION
﻿Addresses the bare exception handling in `krkn_ai/dashboard/app.py` (closes #267).

## What

`is_execution_running()` and `get_run_status()` both read `results.json` inside a
`try` block but caught `Exception` and swallowed the error silently. This makes it
very hard to diagnose problems in production — a permissions issue, a truncated file,
or any unexpected error would just return `False` / `None` with no indication of what
went wrong.

**Changes:**

- Narrow both `except` clauses to `(json.JSONDecodeError, OSError)` — the only
  realistic failure modes when reading a JSON file from disk.
- Add `logger.warning("Could not read results.json: %s", e)` in each handler so the
  error is visible in logs without crashing the dashboard.
- Add `import logging` and a module-level `logger = logging.getLogger(__name__)`.

## Testing

- Existing behaviour is preserved for the happy path.
- A malformed `results.json` now logs a warning instead of silently returning.
- Any other unexpected exception will still propagate and surface rather than be hidden.
