### PR TITLE
feat(elastic): index run summary to Elasticsearch after completed run

### DIFF
--- a/krkn_ai/algorithm/genetic.py
+++ b/krkn_ai/algorithm/genetic.py
@@ -785,7 +785,9 @@ class GeneticAlgorithm:
         )
         summary_reporter.save(self.output_dir)
 
-        # TODO: Send run summary to Elasticsearch
+        if self.elastic_client is not None:
+            summary = summary_reporter.generate_summary()
+            self.elastic_client.index_run_summary(summary, self.run_uuid)
 
     def save_config(self):
         logger.info("Saving config file to config.yaml")

--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -155,3 +155,42 @@ class ElasticSearchClient:
             item=result_data, index=INDEX_NAME
         )
         return self.__handle_index_status(status)
+
+    def index_run_summary(self, summary: dict, run_uuid: str) -> bool:
+        """
+        Index the run summary into krkn-ai "summary" index in Elasticsearch.
+
+        Args:
+            summary: Run summary dict from JSONSummaryReporter.generate_summary()
+            run_uuid: Unique identifier for the entire Krkn-AI run
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if not self.config.enable or self.client is None:
+            logger.debug(
+                "Elasticsearch indexing is disabled. Skipping indexing of run summary."
+            )
+            return False
+
+        INDEX_NAME = f"{self.config.index}-summary"
+
+        summary_data = {
+            "run_uuid": run_uuid,
+            "status": summary.get("status"),
+            "completed_generations": summary.get("completed_generations"),
+            "total_scenarios_evaluated": summary.get("total_scenarios_evaluated"),
+            "unique_scenarios": summary.get("unique_scenarios"),
+            "best_fitness_score": summary.get("best_fitness_score"),
+            "average_fitness_score": summary.get("average_fitness_score"),
+            "duration_seconds": summary.get("duration_seconds"),
+            "start_time": summary.get("start_time"),
+            "end_time": summary.get("end_time"),
+            "seed": summary.get("seed"),
+            "fitness_progression": summary.get("fitness_progression"),
+        }
+
+        status = self.client.upload_data_to_elasticsearch(
+            item=summary_data, index=INDEX_NAME
+        )
+        return self.__handle_index_status(status)

--- a/krkn_ai/utils/elastic_client.py
+++ b/krkn_ai/utils/elastic_client.py
@@ -175,18 +175,20 @@ class ElasticSearchClient:
 
         INDEX_NAME = f"{self.config.index}-summary"
 
+        nested = summary.get("summary", {})
         summary_data = {
             "run_uuid": run_uuid,
+            "run_id": summary.get("run_id"),
             "status": summary.get("status"),
-            "completed_generations": summary.get("completed_generations"),
-            "total_scenarios_evaluated": summary.get("total_scenarios_evaluated"),
-            "unique_scenarios": summary.get("unique_scenarios"),
-            "best_fitness_score": summary.get("best_fitness_score"),
-            "average_fitness_score": summary.get("average_fitness_score"),
-            "duration_seconds": summary.get("duration_seconds"),
+            "seed": summary.get("seed"),
             "start_time": summary.get("start_time"),
             "end_time": summary.get("end_time"),
-            "seed": summary.get("seed"),
+            "duration_seconds": summary.get("duration_seconds"),
+            "generations_completed": nested.get("generations_completed"),
+            "total_scenarios_executed": nested.get("total_scenarios_executed"),
+            "unique_scenarios": nested.get("unique_scenarios"),
+            "best_fitness_score": nested.get("best_fitness_score"),
+            "average_fitness_score": nested.get("average_fitness_score"),
             "fitness_progression": summary.get("fitness_progression"),
         }
 

--- a/tests/unit/utils/test_elastic_client.py
+++ b/tests/unit/utils/test_elastic_client.py
@@ -23,17 +23,20 @@ def make_client():
 def test_index_run_summary_returns_true_on_success():
     client = make_client()
     summary = {
+        "run_id": "test-uuid-123",
         "status": "completed",
-        "completed_generations": 3,
-        "best_fitness_score": 0.91,
-        "average_fitness_score": 0.75,
-        "duration_seconds": 120.0,
-        "total_scenarios_evaluated": 15,
-        "unique_scenarios": 12,
+        "seed": 42,
         "start_time": "2026-01-01T00:00:00",
         "end_time": "2026-01-01T00:02:00",
-        "seed": 42,
+        "duration_seconds": 120.0,
         "fitness_progression": [0.5, 0.7, 0.91],
+        "summary": {
+            "generations_completed": 3,
+            "total_scenarios_executed": 15,
+            "unique_scenarios": 12,
+            "best_fitness_score": 0.91,
+            "average_fitness_score": 0.75,
+        },
     }
     result = client.index_run_summary(summary, "test-uuid-123")
     assert result is True
@@ -42,7 +45,7 @@ def test_index_run_summary_returns_true_on_success():
 
 def test_index_run_summary_uses_correct_index():
     client = make_client()
-    summary = {"best_fitness_score": 0.9}
+    summary = {"summary": {"best_fitness_score": 0.9}}
     client.index_run_summary(summary, "test-uuid")
     call_kwargs = client.client.upload_data_to_elasticsearch.call_args
     assert call_kwargs.kwargs["index"] == "krkn-ai-summary"
@@ -62,3 +65,27 @@ def test_index_run_summary_skips_when_disabled():
         client = ElasticSearchClient(config)
         result = client.index_run_summary({}, "test-uuid")
         assert result is False
+
+
+def test_index_run_summary_fields_mapped_correctly():
+    """Verify nested summary fields are extracted and mapped correctly."""
+    client = make_client()
+    summary = {
+        "run_id": "abc",
+        "status": "completed",
+        "duration_seconds": 60.0,
+        "summary": {
+            "generations_completed": 5,
+            "best_fitness_score": 0.88,
+            "average_fitness_score": 0.65,
+            "total_scenarios_executed": 20,
+            "unique_scenarios": 18,
+        },
+        "fitness_progression": [],
+    }
+    client.index_run_summary(summary, "abc")
+    call_kwargs = client.client.upload_data_to_elasticsearch.call_args
+    indexed = call_kwargs.kwargs["item"]
+    assert indexed["generations_completed"] == 5
+    assert indexed["best_fitness_score"] == 0.88
+    assert indexed["total_scenarios_executed"] == 20

--- a/tests/unit/utils/test_elastic_client.py
+++ b/tests/unit/utils/test_elastic_client.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+from krkn_ai.utils.elastic_client import ElasticSearchClient
+from krkn_ai.models.config import ElasticConfig
+
+
+def make_client():
+    config = ElasticConfig(
+        enable=True,
+        server="http://localhost",
+        port=9200,
+        index="krkn-ai",
+        username="",
+        password="",
+        verify_certs=False,
+    )
+    with patch("krkn_ai.utils.elastic_client.KrknElastic"):
+        client = ElasticSearchClient(config)
+        client.client = MagicMock()
+        client.client.upload_data_to_elasticsearch.return_value = 1
+        return client
+
+
+def test_index_run_summary_returns_true_on_success():
+    client = make_client()
+    summary = {
+        "status": "completed",
+        "completed_generations": 3,
+        "best_fitness_score": 0.91,
+        "average_fitness_score": 0.75,
+        "duration_seconds": 120.0,
+        "total_scenarios_evaluated": 15,
+        "unique_scenarios": 12,
+        "start_time": "2026-01-01T00:00:00",
+        "end_time": "2026-01-01T00:02:00",
+        "seed": 42,
+        "fitness_progression": [0.5, 0.7, 0.91],
+    }
+    result = client.index_run_summary(summary, "test-uuid-123")
+    assert result is True
+    client.client.upload_data_to_elasticsearch.assert_called_once()
+
+
+def test_index_run_summary_uses_correct_index():
+    client = make_client()
+    summary = {"best_fitness_score": 0.9}
+    client.index_run_summary(summary, "test-uuid")
+    call_kwargs = client.client.upload_data_to_elasticsearch.call_args
+    assert call_kwargs.kwargs["index"] == "krkn-ai-summary"
+
+
+def test_index_run_summary_skips_when_disabled():
+    config = ElasticConfig(
+        enable=False,
+        server="http://localhost",
+        port=9200,
+        index="krkn-ai",
+        username="",
+        password="",
+        verify_certs=False,
+    )
+    with patch("krkn_ai.utils.elastic_client.KrknElastic"):
+        client = ElasticSearchClient(config)
+        result = client.index_run_summary({}, "test-uuid")
+        assert result is False


### PR DESCRIPTION
## Description
Noticed that while individual scenario results and configs are already sent to Elasticsearch during a run, the final summary never gets indexed — there was even a `# TODO: Send run summary to Elasticsearch` comment in `genetic.py` marking this as missing.

This PR wires that up. After a run completes, the overall summary (best fitness, average fitness, generations completed, duration, fitness progression etc.) now gets sent to a `<index>-summary` index in Elasticsearch, making it possible to compare runs against each other directly from Elasticsearch.

The implementation follows the exact same pattern as the existing `index_config()` and `index_run_result()` methods so nothing new is introduced structurally.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
pytest tests/unit/utils/test_elastic_client.py -v  # 3 passed
pytest tests/unit/ -v                               # all existing 257 tests pass

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
