### PR TITLE
Improve demo setup script error handling, cleanup, and Helm documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An intelligent chaos engineering framework that uses genetic algorithms to evolv
 - Python 3.11+
 - `uv` package manager
 - [podman](https://podman.io/)
-- [helm 3.x](https://helm.sh/docs/intro/install/)
+- [helm 3.x](https://helm.sh/docs/v3/intro/install/)
 - Kubernetes/OpenShift cluster kubeconfig
 
 ## 🚀 Getting Started

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An intelligent chaos engineering framework that uses genetic algorithms to evolv
 - Python 3.11+
 - `uv` package manager
 - [podman](https://podman.io/)
-- [helm](https://helm.sh/docs/intro/install/)
+- [helm 3.x](https://helm.sh/docs/intro/install/)
 - Kubernetes/OpenShift cluster kubeconfig
 
 ## 🚀 Getting Started

--- a/scripts/setup-demo-microservice.sh
+++ b/scripts/setup-demo-microservice.sh
@@ -68,14 +68,15 @@ cd $repo_dir
 echo "Switched to cloned directory: $PWD"
 
 # Setup Namespace
-kubectl get ns $namespace || kubectl create ns $namespace
-
 if [ "$is_openshift" = "true" ]; then
     # Based on https://github.com/instana/robot-shop/tree/master/OpenShift
     echo "OpenShift cluster detected: $is_openshift"
-    oc adm new-project $namespace
+    oc get project "$namespace" >/dev/null 2>&1 || \oc adm new-project $namespace
     oc adm policy add-scc-to-user anyuid -z default -n $namespace
     oc adm policy add-scc-to-user privileged -z default -n $namespace
+
+else
+    kubectl get ns $namespace || kubectl create ns $namespace
 fi
 
 # Post-renderer to redirect hardcoded redis/rabbitmq images to the mirror registry

--- a/scripts/setup-demo-microservice.sh
+++ b/scripts/setup-demo-microservice.sh
@@ -17,6 +17,9 @@
 # - User should be already logged into cluster before running the script
 #
 #******************************************************************************
+
+set -e
+
 detect_openshift() {
     if kubectl get clusterversion &>/dev/null; then
         echo "true"
@@ -43,7 +46,9 @@ mkdir -p $temp_dir
 # Trap for exit signals and errors
 trap cleanup EXIT
 
+post_renderer=""
 cleanup() {
+  [ -n "$post_renderer" ] && rm -f "$post_renderer"
   echo "Script finished."
 }
 
@@ -90,5 +95,3 @@ helm upgrade -i $chart_name \
   --post-renderer "$post_renderer" \
   --namespace "$namespace" .
 echo "Installed helm chart '$chart_name' in namespace '$namespace'"
-
-rm -f "$post_renderer"

--- a/scripts/setup-demo-microservice.sh
+++ b/scripts/setup-demo-microservice.sh
@@ -43,14 +43,14 @@ infra_registry="mirror.gcr.io/library" # mirror for Docker Hub official images (
 temp_dir="./tmp"
 mkdir -p $temp_dir
 
-# Trap for exit signals and errors
-trap cleanup EXIT
-
 post_renderer=""
 cleanup() {
   [ -n "$post_renderer" ] && rm -f "$post_renderer"
   echo "Script finished."
 }
+
+# Trap for exit signals and errors
+trap cleanup EXIT
 
 # Switch to the temporary directory
 cd "$temp_dir"
@@ -71,9 +71,9 @@ echo "Switched to cloned directory: $PWD"
 if [ "$is_openshift" = "true" ]; then
     # Based on https://github.com/instana/robot-shop/tree/master/OpenShift
     echo "OpenShift cluster detected: $is_openshift"
-    oc get project "$namespace" >/dev/null 2>&1 || \oc adm new-project $namespace
-    oc adm policy add-scc-to-user anyuid -z default -n $namespace
-    oc adm policy add-scc-to-user privileged -z default -n $namespace
+    oc get project $namespace >/dev/null 2>&1 || oc adm new-project $namespace
+    oc adm policy add-scc-to-user anyuid -z default -n $namespace || true
+    oc adm policy add-scc-to-user privileged -z default -n $namespace || true
 
 else
     kubectl get ns $namespace || kubectl create ns $namespace


### PR DESCRIPTION
## Description

This PR improves the robustness of `setup-demo-microservice.sh` and clarifies Helm requirements for deploying the Robot Shop demo application.

### Changes

* Add `set -e` to terminate execution immediately when a command fails.
* Move temporary post-renderer cleanup into the existing `cleanup()` handler.
* Remove the standalone `rm -f "$post_renderer"` cleanup path.
* Document the Helm 3.x requirement in the README.

### Related Issue

Fixes #368 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

<img width="1089" height="701" alt="Screenshot 2026-06-17 at 11 47 14 AM" src="https://github.com/user-attachments/assets/44a3f984-f3bb-486c-ba0c-5f904c71f2c7" />


* Confirmed through the Helm v4 help output that `--post-renderer` expects the name of a post-renderer plugin rather than an executable path:

```bash
helm upgrade --help | grep post-renderer -A 5
```

* Switched to Helm v3.21.0 and reran the setup script.
* Verified successful deployment of the Robot Shop Helm chart.


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
