### PR TITLE
docs: add macOS setup instructions to developer_guide

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -54,17 +54,12 @@ minikube start
 
 **macOS:**
 
-The recommended driver on macOS is [vfkit](https://github.com/crc-org/vfkit), a lightweight hypervisor that avoids Docker driver limitations (port forwarding, multi-node support).
+The recommended driver on macOS is [vfkit](https://github.com/crc-org/vfkit), a lightweight hypervisor that avoids Docker driver limitations (port forwarding, multi-node support). See the [minikube vfkit driver docs](https://minikube.sigs.k8s.io/docs/drivers/vfkit/) for more details.
 
 ```bash
 brew install vfkit
 minikube start --driver=vfkit
 ```
-
-> **Note (macOS + Docker driver):** If you prefer the Docker driver, `kicbase:v0.0.50` has a broken arm64 entrypoint. Use `--base-image=kicbase/stable:v0.0.49` as a workaround:
-> ```bash
-> minikube start --driver=docker --base-image=kicbase/stable:v0.0.49
-> ```
 
 # Switch to minikube cluster context
 kubectl config use-context minikube

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -32,13 +32,39 @@ uv run krkn_ai --help
 
 We use [Minikube](https://minikube.sigs.k8s.io/docs/start/) to create a local Kubernetes cluster.
 
+### Install Minikube
+
+**Linux:**
 ```bash
-# Install Minikube on Linux
 curl -LO https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
 sudo install minikube-linux-amd64 /usr/local/bin/minikube && rm minikube-linux-amd64
+```
 
-# Create the cluster
+**macOS (Apple Silicon / Intel):**
+```bash
+brew install minikube
+```
+
+### Create the Cluster
+
+**Linux:**
+```bash
 minikube start
+```
+
+**macOS:**
+
+The recommended driver on macOS is [vfkit](https://github.com/crc-org/vfkit), a lightweight hypervisor that avoids Docker driver limitations (port forwarding, multi-node support).
+
+```bash
+brew install vfkit
+minikube start --driver=vfkit
+```
+
+> **Note (macOS + Docker driver):** If you prefer the Docker driver, `kicbase:v0.0.50` has a broken arm64 entrypoint. Use `--base-image=kicbase/stable:v0.0.49` as a workaround:
+> ```bash
+> minikube start --driver=docker --base-image=kicbase/stable:v0.0.49
+> ```
 
 # Switch to minikube cluster context
 kubectl config use-context minikube


### PR DESCRIPTION
## Description
Add macOS-specific setup instructions to the developer guide. The existing guide only covered Linux. This adds platform-specific `minikube` install steps and recommends `vfkit` as the preferred driver on macOS 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other:

## Testing
Verified on Apple Silicon (M-series) macOS starts a fully healthy cluster with all control plane components running.
```
minikube start --driver=vfkit 
```


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
