### PR TITLE
fix(prometheus): raise error when token discovery fails

### DIFF
--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -86,6 +86,13 @@ def create_prometheus_client(kubeconfig: str) -> KrknPrometheus:
             "  export PROMETHEUS_TOKEN=$(oc whoami -t)"
         )
 
+    if not token:
+        raise PrometheusConnectionError(
+            "Automatic Prometheus token discovery failed on OpenShift.\n"
+            "Please set the token explicitly:\n"
+            "  export PROMETHEUS_TOKEN=$(oc whoami -t)"
+        )
+
     return _validate_and_create_client(url, token)
 
 


### PR DESCRIPTION
## Summary
- `get_prometheus_client()` validated `url` after auto-discovery but never checked `token`
- A failed token discovery silently passed an empty token to `_validate_and_create_client()`
- Added a matching check that raises `PrometheusConnectionError` with clear instructions if token is empty

Fixes #372