### PR TITLE
fix(deps): sync uv.lock with pinned dev dependencies

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1460,17 +1460,17 @@ requires-dist = [
     { name = "jupyterlab", marker = "extra == 'dev'" },
     { name = "krkn-lib", git = "https://github.com/krkn-chaos/krkn-lib?rev=a89b299b1789eeb8f8ed07213eccd77414f03283" },
     { name = "kubernetes", specifier = ">=34.1.0,<36" },
-    { name = "mypy", marker = "extra == 'dev'" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "notebook", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "pandas", specifier = "==2.2.3" },
     { name = "plotly", specifier = ">=6.6.0" },
-    { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = "==4.3.0" },
     { name = "pydantic", specifier = "==2.11.4" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml" },
     { name = "requests" },
-    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.14.14" },
     { name = "seaborn" },
     { name = "setuptools" },
     { name = "streamlit", specifier = ">=1.55.0" },
@@ -2189,7 +2189,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.5.1"
+version = "4.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2198,9 +2198,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/29/7cf5bbc236333876e4b41f56e06857a87937ce4bf91e117a6991a2dbb02a/pre_commit-4.3.0.tar.gz", hash = "sha256:499fe450cc9d42e9d58e606262795ecb64dd05438943c62b66f6a8673da30b16", size = 193792, upload-time = "2025-08-09T18:56:14.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/a5/987a405322d78a73b66e39e4a90e4ef156fd7141bf71df987e50717c321b/pre_commit-4.3.0-py2.py3-none-any.whl", hash = "sha256:2b0747ad7e6e967169136edffee14c16e148a778a54e4f967921aa1ebf2308d8", size = 220965, upload-time = "2025-08-09T18:56:13.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The committed `uv.lock` does not match the dependency pins in `pyproject.toml`.
`pyproject.toml` pins `ruff==0.14.14`, `mypy==1.19.1` and `pre-commit==4.3.0`,
but the lock file still resolves `pre-commit` to `4.5.1` and does not record the
`==` specifiers. Regenerating with `uv lock` brings it back in sync.

## How I found it

I ran `uv lock --check` on `main` and it failed with "The lockfile at `uv.lock`
needs to be updated". Comparing the committed lock against `pyproject.toml`, the
dev tool pins from commit 74ea11a were never carried into the lock file, so the
lock no longer satisfies the project's own constraints.

## What I changed

- Regenerated `uv.lock` with `uv lock`.
- Only dev tool entries changed: `pre-commit` goes from 4.5.1 to 4.3.0, and the
  `==` specifiers for `ruff`, `mypy` and `pre-commit` are now recorded.
- No runtime dependencies change. The diff is 6 lines.

## Why this is correct

A lock file should satisfy the constraints declared in `pyproject.toml`. With the
current lock, `uv lock --check` fails and `uv sync` produces an environment that
does not match the pins. After regenerating, `uv lock --check` passes and `uv sync`
is reproducible. The README tells users to install with `uv`, so the lock file is
part of the supported install path.

CI installs with `pip` and does not check the lock today, which is why this was
not caught. I am happy to open a separate PR adding a `uv lock --check` step if
that would be useful.

## Tests

- `uv lock --check` fails on `main` and passes after this change.
- `uv lock` gives a 6 line diff with no runtime dependency changes.
- `python -m pytest -q` passed, 370 tests. One unrelated error shows up on Windows
  only (a temp directory cleanup holding `run.log` open during teardown); the test
  assertion itself passes and it does not occur on the Linux CI.
