### PR TITLE
feat: add --save-strategy to discover command

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ krkn_ai discover \
   --skip-pod-name "nginx-proxy.*"
 ```
 
+By default `discover` won't overwrite an existing output file. Control this with `--save-strategy`:
+
+| Strategy         | Behavior                                              |
+|------------------|-------------------------------------------------------|
+| `skip` (default) | Keep the existing file, do nothing.                   |
+| `overwrite`      | Replace the file with a fresh config.                 |
+| `merge`          | Keep your edits, add newly discovered components.     |
+
+```bash
+krkn_ai discover -k ./tmp/kubeconfig.yaml -o ./tmp/krkn-ai.yaml --save-strategy merge
+```
+
+`merge` preserves manual edits (e.g. `disabled: true`) and adds newly discovered components.
+
 Key config options:
 
 ```yaml
@@ -121,7 +135,7 @@ krkn_ai run \
 
 | Command | Key Options |
 |---------|-------------|
-| `discover` | `-k` kubeconfig, `-n` namespace, `-pl` pod-label, `-nl` node-label, `-o` output, `--skip-pod-name` |
+| `discover` | `-k` kubeconfig, `-n` namespace, `-pl` pod-label, `-nl` node-label, `-o` output, `--skip-pod-name`, `--save-strategy` |
 | `run` | `-k` kubeconfig, `-c` config, `-o` output dir, `-f` format, `-r` runner type, `-p` params, `--monitoring`, `--port` |
 | `monitor` | `-o` results dir, `-p` port |
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ By default `discover` won't overwrite an existing output file. Control this with
 krkn_ai discover -k ./tmp/kubeconfig.yaml -o ./tmp/krkn-ai.yaml --save-strategy merge
 ```
 
-`merge` preserves manual edits (e.g. `disabled: true`) and adds newly discovered components.
+`merge` preserves manual edits (e.g. `disabled: true`) and adds newly discovered components. Note: comments inside `cluster_components` are not preserved after a merge.
 
 Key config options:
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -128,6 +128,8 @@ uv run krkn_ai discover -k ./kubeconfig.yaml \
 
 This generates `krkn-ai.yaml` containing cluster component details and boilerplate test configuration. Review and modify the file as needed—add health check endpoints, adjust the fitness function, and enable desired scenarios.
 
+> **Tip:** Re-running `discover` won't overwrite your file by default. Use `--save-strategy merge` to add new components while keeping edits, or `overwrite` to regenerate.
+
 > **Note:** Some scenarios may not work on Minikube due to limited node access or permissions.
 
 ### Start Krkn-AI Tests

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -128,7 +128,7 @@ uv run krkn_ai discover -k ./kubeconfig.yaml \
 
 This generates `krkn-ai.yaml` containing cluster component details and boilerplate test configuration. Review and modify the file as needed—add health check endpoints, adjust the fitness function, and enable desired scenarios.
 
-> **Tip:** Re-running `discover` won't overwrite your file by default. Use `--save-strategy merge` to add new components while keeping edits, or `overwrite` to regenerate.
+> **Tip:** Re-running `discover` won't overwrite your file by default. Use `--save-strategy merge` to add new components while keeping edits, or `overwrite` to regenerate. Note: `merge` does not preserve comments inside `cluster_components`.
 
 > **Note:** Some scenarios may not work on Minikube due to limited node access or permissions.
 

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -249,7 +249,7 @@ def monitor(ctx, output: str, port: int):
     "--save-strategy",
     type=click.Choice(["skip", "overwrite", "merge"], case_sensitive=False),
     default="skip",
-    help="How to save: skip, overwrite (replace), or merge (add new).",
+    help="How to save: skip, overwrite (replace), or merge (add new). Note: merge does not preserve comments inside cluster_components.",
 )
 @click.pass_context
 def discover(

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -20,8 +20,7 @@ from krkn_ai.models.custom_errors import (
     PrometheusConnectionError,
     UniqueScenariosError,
 )
-from krkn_ai.utils.fs import read_config_from_file
-from krkn_ai.templates.generator import create_krkn_ai_template
+from krkn_ai.utils.fs import read_config_from_file, save_discovery
 from krkn_ai.utils.cluster_manager import ClusterManager
 
 
@@ -246,6 +245,12 @@ def monitor(ctx, output: str, port: int):
     default=None,
     required=False,
 )
+@click.option(
+    "--save-strategy",
+    type=click.Choice(["skip", "overwrite", "merge"], case_sensitive=False),
+    default="skip",
+    help="How to save: skip, overwrite (replace), or merge (add new).",
+)
 @click.pass_context
 def discover(
     ctx,
@@ -256,6 +261,7 @@ def discover(
     node_label: str = ".*",
     verbose: int = 0,
     skip_pod_name: str = None,
+    save_strategy: str = "skip",
 ):
     init_logger(None, verbose >= 2)
     logger = get_logger(__name__)
@@ -283,13 +289,4 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
-    cluster_components_data = cluster_components.model_dump(
-        mode="json", warnings="none", exclude_defaults=True
-    )
-
-    template = create_krkn_ai_template(kubeconfig, cluster_components_data)
-
-    with open(output, "w") as f:
-        f.write(template)
-
-    logger.info("Saved component configuration to %s", output)
+    save_discovery(output, save_strategy, cluster_components, kubeconfig)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 from typing import Union, List, Dict
 
 from krkn_ai.models.config import ConfigFile, ParameterValue
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.templates.generator import create_krkn_ai_template
 from krkn_ai.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -118,3 +120,140 @@ def save_data_to_file(data: Union[Dict, List], file_path: str):
             json.dump(data, f, indent=4)
     else:
         raise ValueError(f"Unsupported format: {format}")
+
+
+def _indent_block(text: str) -> str:
+    """Indent text by 2 spaces for YAML nesting."""
+    lines = []
+    for line in text.split("\n"):
+        if line.strip():
+            lines.append("  " + line)
+        else:
+            lines.append("")
+    return "\n".join(lines)
+
+
+def _render_components_block(components: ClusterComponents) -> str:
+    """Convert components to YAML block."""
+    data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
+    body = yaml.dump(
+        data, default_flow_style=False, indent=2, allow_unicode=True, sort_keys=False
+    ).strip()
+    return "cluster_components:\n" + _indent_block(body)
+
+
+def _cluster_components_block(text: str) -> str:
+    """Extract cluster_components block from file."""
+    out, capturing = [], False
+    for line in text.splitlines():
+        if line.startswith("cluster_components:"):
+            capturing = True
+            out.append(line)
+            continue
+        if capturing:
+            if line and not line[0].isspace():
+                break
+            out.append(line)
+    return "\n".join(out).rstrip()
+
+
+def _union_by_name(existing: list, discovered: list) -> list:
+    """Union two lists by name, keep existing items."""
+    by_name = {item.name: item for item in existing}
+    for item in discovered:
+        if item.name not in by_name:
+            by_name[item.name] = item
+    return list(by_name.values())
+
+
+def merge_components(
+    existing: ClusterComponents, discovered: ClusterComponents
+) -> ClusterComponents:
+    """Merge existing and discovered components, preserving edits."""
+    namespaces = {ns.name: ns for ns in existing.namespaces}
+    for ns in discovered.namespaces:
+        current = namespaces.get(ns.name)
+        if current is None:
+            namespaces[ns.name] = ns
+            continue
+        current.pods = _union_by_name(current.pods, ns.pods)
+        current.services = _union_by_name(current.services, ns.services)
+        current.pvcs = _union_by_name(current.pvcs, ns.pvcs)
+        current.vmis = _union_by_name(current.vmis, ns.vmis)
+    nodes = _union_by_name(existing.nodes, discovered.nodes)
+    return ClusterComponents(namespaces=list(namespaces.values()), nodes=nodes)
+
+
+def _build_merged_config(output: str, discovered: ClusterComponents) -> str:
+    """Build file content with merged components block."""
+    with open(output, "r", encoding="utf-8") as f:
+        existing_text = f.read()
+
+    existing_block = _cluster_components_block(existing_text)
+    if not existing_block:
+        logger.warning(
+            "No cluster_components section found in %s; appending discovered components.",
+            output,
+        )
+        return (
+            existing_text.rstrip("\n")
+            + "\n\n"
+            + _render_components_block(discovered)
+            + "\n"
+        )
+
+    try:
+        block_data = yaml.safe_load(existing_block) or {}
+    except yaml.YAMLError as e:
+        logger.warning(
+            "Could not parse cluster_components in %s (%s); leaving file unchanged.",
+            output,
+            e,
+        )
+        return existing_text
+
+    existing = ClusterComponents.model_validate(
+        block_data.get("cluster_components", {}) or {}
+    )
+    merged = merge_components(existing, discovered)
+    return existing_text.replace(existing_block, _render_components_block(merged))
+
+
+def _write_fresh(output: str, components: ClusterComponents, kubeconfig: str):
+    """Write fresh config from discovered components."""
+    data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
+    template = create_krkn_ai_template(kubeconfig, data)
+    with open(output, "w", encoding="utf-8") as f:
+        f.write(template)
+    logger.info("Saved component configuration to %s", output)
+
+
+def save_discovery(
+    output: str,
+    strategy: str,
+    components: ClusterComponents,
+    kubeconfig: str,
+):
+    """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
+    strategy = strategy.lower()
+    exists = os.path.exists(output)
+
+    if exists and strategy == "skip":
+        logger.warning(
+            "%s already exists; skipping write "
+            "(use --save-strategy overwrite or merge to change this).",
+            output,
+        )
+        return
+
+    if exists and strategy == "merge":
+        text = _build_merged_config(output, components)
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(text)
+        logger.info("Merged discovered components into %s", output)
+        return
+
+    if exists and strategy == "overwrite":
+        logger.warning("Overwriting existing %s", output)
+
+    _write_fresh(output, components, kubeconfig)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -124,41 +124,6 @@ def save_data_to_file(data: Union[Dict, List], file_path: str):
         raise ValueError(f"Unsupported format: {format}")
 
 
-def _indent_block(text: str) -> str:
-    """Indent text by 2 spaces for YAML nesting."""
-    lines = []
-    for line in text.split("\n"):
-        if line.strip():
-            lines.append("  " + line)
-        else:
-            lines.append("")
-    return "\n".join(lines)
-
-
-def _render_components_block(components: ClusterComponents) -> str:
-    """Convert components to YAML block."""
-    data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    body = yaml.dump(
-        data, default_flow_style=False, indent=2, allow_unicode=True, sort_keys=False
-    ).strip()
-    return "cluster_components:\n" + _indent_block(body)
-
-
-def _cluster_components_block(text: str) -> str:
-    """Extract cluster_components block from file."""
-    out, capturing = [], False
-    for line in text.splitlines():
-        if line.startswith("cluster_components:"):
-            capturing = True
-            out.append(line)
-            continue
-        if capturing:
-            if line and not line[0].isspace():
-                break
-            out.append(line)
-    return "\n".join(out).rstrip()
-
-
 def _union_by_name(existing: list, discovered: list) -> list:
     """Union two lists by name, keep existing items."""
     by_name = {item.name: item for item in existing}
@@ -186,47 +151,22 @@ def merge_components(
     return ClusterComponents(namespaces=list(namespaces.values()), nodes=nodes)
 
 
-def _build_merged_config(output: str, discovered: ClusterComponents) -> str:
-    """Build file content with merged components block."""
-    with open(output, "r", encoding="utf-8") as f:
-        existing_text = f.read()
-
-    existing_block = _cluster_components_block(existing_text)
-    if not existing_block:
-        logger.warning(
-            "No cluster_components section found in %s; appending discovered components.",
-            output,
-        )
-        return (
-            existing_text.rstrip("\n")
-            + "\n\n"
-            + _render_components_block(discovered)
-            + "\n"
-        )
-
+def _build_merged_config(
+    output: str, discovered: ClusterComponents, kubeconfig: str
+) -> Union[str, None]:
+    """Merge discovered components into the existing file; returns None if unreadable."""
     try:
-        block_data = yaml.safe_load(existing_block) or {}
-    except yaml.YAMLError as e:
+        config = read_config_from_file(output)
+    except (yaml.YAMLError, ValueError, ValidationError) as e:
         logger.warning(
-            "Could not parse cluster_components in %s (%s); leaving file unchanged.",
+            "Could not read existing config %s (%s); leaving file unchanged.",
             output,
             e,
         )
-        return existing_text
-
-    try:
-        existing = ClusterComponents.model_validate(
-            block_data.get("cluster_components", {}) or {}
-        )
-    except ValidationError as e:
-        logger.warning(
-            "Invalid cluster_components in %s (%s); leaving file unchanged.",
-            output,
-            e,
-        )
-        return existing_text
-    merged = merge_components(existing, discovered)
-    return existing_text.replace(existing_block, _render_components_block(merged))
+        return None
+    merged = merge_components(config.cluster_components, discovered)
+    data = merged.model_dump(mode="json", warnings="none", exclude_defaults=True)
+    return create_krkn_ai_template(kubeconfig, data)
 
 
 def _write_fresh(output: str, components: ClusterComponents, kubeconfig: str):
@@ -257,7 +197,9 @@ def save_discovery(
         return
 
     if exists and strategy == "merge":
-        text = _build_merged_config(output, components)
+        text = _build_merged_config(output, components, kubeconfig)
+        if text is None:
+            return
         with open(output, "w", encoding="utf-8") as f:
             f.write(text)
         logger.info("Merged discovered components into %s", output)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -4,6 +4,8 @@ import yaml
 from collections.abc import Sequence
 from typing import Union, List, Dict
 
+from pydantic import ValidationError
+
 from krkn_ai.models.config import ConfigFile, ParameterValue
 from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.templates.generator import create_krkn_ai_template
@@ -212,9 +214,17 @@ def _build_merged_config(output: str, discovered: ClusterComponents) -> str:
         )
         return existing_text
 
-    existing = ClusterComponents.model_validate(
-        block_data.get("cluster_components", {}) or {}
-    )
+    try:
+        existing = ClusterComponents.model_validate(
+            block_data.get("cluster_components", {}) or {}
+        )
+    except ValidationError as e:
+        logger.warning(
+            "Invalid cluster_components in %s (%s); leaving file unchanged.",
+            output,
+            e,
+        )
+        return existing_text
     merged = merge_components(existing, discovered)
     return existing_text.replace(existing_block, _render_components_block(merged))
 

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -304,13 +304,12 @@ class TestDiscoverCommand:
 
         try:
             with patch("krkn_ai.cli.cmd.ClusterManager") as mock_cluster_manager_class:
-                with patch("krkn_ai.cli.cmd.create_krkn_ai_template") as mock_template:
+                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
                     mock_manager = Mock()
                     mock_manager.discover_components.return_value = (
                         mock_cluster_components
                     )
                     mock_cluster_manager_class.return_value = mock_manager
-                    mock_template.return_value = "generated_template_content"
 
                     output_file = os.path.join(temp_output_dir, "output.yaml")
                     result = runner.invoke(
@@ -327,10 +326,7 @@ class TestDiscoverCommand:
                     assert result.exit_code == 0
                     mock_cluster_manager_class.assert_called_once_with(kubeconfig_path)
                     mock_manager.discover_components.assert_called_once()
-                    mock_template.assert_called_once()
-                    assert os.path.exists(output_file)
-                    with open(output_file, "r") as f:
-                        assert f.read() == "generated_template_content"
+                    mock_save.assert_called_once()
         finally:
             os.unlink(kubeconfig_path)
 
@@ -357,3 +353,85 @@ class TestDiscoverCommand:
                 assert result.exit_code == 1
                 mock_logger.error.assert_called_once()
                 assert "Kubeconfig file not found" in str(mock_logger.error.call_args)
+
+    def test_discover_defaults_to_skip_strategy(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """Without the flag, discover passes the skip strategy through."""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
+                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
+                    mock_manager_class.return_value.discover_components.return_value = (
+                        mock_cluster_components
+                    )
+                    output_file = os.path.join(temp_output_dir, "output.yaml")
+                    result = runner.invoke(
+                        main,
+                        ["discover", "-k", kubeconfig_path, "-o", output_file],
+                    )
+
+                    assert result.exit_code == 0
+                    mock_save.assert_called_once()
+                    output_arg, strategy_arg = mock_save.call_args.args[:2]
+                    assert output_arg == output_file
+                    assert strategy_arg == "skip"
+        finally:
+            os.unlink(kubeconfig_path)
+
+    def test_discover_verify_chosen_strategy(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """Verify the chosen --save-strategy is used."""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
+                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
+                    mock_manager_class.return_value.discover_components.return_value = (
+                        mock_cluster_components
+                    )
+                    output_file = os.path.join(temp_output_dir, "output.yaml")
+                    result = runner.invoke(
+                        main,
+                        [
+                            "discover",
+                            "-k",
+                            kubeconfig_path,
+                            "-o",
+                            output_file,
+                            "--save-strategy",
+                            "merge",
+                        ],
+                    )
+
+                    assert result.exit_code == 0
+                    assert mock_save.call_args.args[1] == "merge"
+        finally:
+            os.unlink(kubeconfig_path)
+
+    def test_discover_rejects_invalid_strategy(self):
+        """An unknown --save-strategy value is rejected by click."""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            result = runner.invoke(
+                main,
+                ["discover", "-k", kubeconfig_path, "--save-strategy", "bogus"],
+            )
+            assert result.exit_code != 0
+        finally:
+            os.unlink(kubeconfig_path)

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,10 +1,23 @@
 """Tests for utils/fs.py"""
 
+from unittest.mock import patch
+
 import pytest
 import yaml
 from pydantic import ValidationError
 
-from krkn_ai.utils.fs import read_config_from_file
+from krkn_ai.utils.fs import (
+    read_config_from_file,
+    save_discovery,
+    merge_components,
+    _render_components_block,
+)
+from krkn_ai.models.cluster_components import (
+    ClusterComponents,
+    Namespace,
+    Pod,
+    Node,
+)
 
 
 class TestParamParsing:
@@ -136,3 +149,213 @@ class TestReadConfigValidation:
             f.write("just a string")
         with pytest.raises(ValueError, match="must be a mapping"):
             read_config_from_file(config_file)
+
+
+KUBECONFIG = "/tmp/kubeconfig"
+
+
+class TestMergeComponents:
+    def test_new_namespace_is_appended(self):
+        existing = ClusterComponents(namespaces=[Namespace(name="a")])
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="a"), Namespace(name="b")]
+        )
+        merged = merge_components(existing, discovered)
+        assert [n.name for n in merged.namespaces] == ["a", "b"]
+
+    def test_new_pod_added_to_existing_namespace(self):
+        existing = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1")])]
+        )
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1"), Pod(name="p2")])]
+        )
+        merged = merge_components(existing, discovered)
+        assert [p.name for p in merged.namespaces[0].pods] == ["p1", "p2"]
+
+    def test_duplicate_names_not_doubled(self):
+        existing = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1")])]
+        )
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1")])]
+        )
+        merged = merge_components(existing, discovered)
+        assert len(merged.namespaces) == 1
+        assert len(merged.namespaces[0].pods) == 1
+
+    def test_existing_disabled_flag_survives(self):
+        existing = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1", disabled=True)])]
+        )
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="a", pods=[Pod(name="p1")])]
+        )
+        merged = merge_components(existing, discovered)
+        assert merged.namespaces[0].pods[0].disabled is True
+
+    def test_nodes_union_by_name(self):
+        existing = ClusterComponents(nodes=[Node(name="n1")])
+        discovered = ClusterComponents(nodes=[Node(name="n1"), Node(name="n2")])
+        merged = merge_components(existing, discovered)
+        assert [n.name for n in merged.nodes] == ["n1", "n2"]
+
+
+def _write_existing(
+    path,
+    components,
+    prefix="baseline:\n  duration: 300\n\n",
+    suffix="\n\nadaptive_mutation: true\n",
+):
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(prefix + _render_components_block(components) + suffix)
+
+
+class TestSaveDiscovery:
+    def test_skip_writes_when_file_absent(self, tmp_path):
+        """Skip strategy creates file if it doesn't exist."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "skip", components, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "shop" in names
+
+    def test_skip_leaves_existing_file_unchanged(self, tmp_path):
+        """Skip strategy does nothing if file already exists."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("original: true\n")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "skip", components, KUBECONFIG)
+        assert open(path).read() == "original: true\n"
+
+    def test_overwrite_replaces_file(self, tmp_path):
+        """Overwrite strategy replaces entire file with fresh discovery."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("original: true\n")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "overwrite", components, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        assert "original" not in data
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "shop" in names
+
+    def test_merge_preserves_edits_and_adds_new(self, tmp_path):
+        """Merge preserves user edits and adds new discovered components."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        existing = ClusterComponents(
+            namespaces=[Namespace(name="shop", pods=[Pod(name="redis", disabled=True)])]
+        )
+        _write_existing(path, existing)
+        discovered = ClusterComponents(
+            namespaces=[
+                Namespace(name="shop", pods=[Pod(name="redis"), Pod(name="cart")]),
+                Namespace(name="pay", pods=[Pod(name="ledger")]),
+            ]
+        )
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        assert data["baseline"]["duration"] == 300
+        assert data["adaptive_mutation"] is True
+        shop = next(
+            n for n in data["cluster_components"]["namespaces"] if n["name"] == "shop"
+        )
+        redis = next(p for p in shop["pods"] if p["name"] == "redis")
+        assert redis["disabled"] is True
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "pay" in names
+
+    def test_merge_safe_to_repeat(self, tmp_path):
+        """Running merge twice produces the same result."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        existing = ClusterComponents(
+            namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])]
+        )
+        _write_existing(path, existing)
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])]
+        )
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        first = open(path).read()
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        assert open(path).read() == first
+
+    def test_merge_preserves_top_level_comment(self, tmp_path):
+        """Merge preserves comments in the rest of the file."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        existing = ClusterComponents(namespaces=[Namespace(name="shop")])
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                _render_components_block(existing)
+                + "\n# keep me\nadaptive_mutation: true\n"
+            )
+        discovered = ClusterComponents(
+            namespaces=[Namespace(name="shop"), Namespace(name="pay")]
+        )
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        text = open(path).read()
+        assert "# keep me" in text
+        names = [
+            n["name"] for n in yaml.safe_load(text)["cluster_components"]["namespaces"]
+        ]
+        assert "pay" in names
+
+    def test_merge_appends_when_no_components_block(self, tmp_path):
+        """Merge appends components block if file has no cluster_components section."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("baseline:\n  duration: 42\n")
+        discovered = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        assert data["baseline"]["duration"] == 42
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "shop" in names
+
+    def test_merge_leaves_file_unchanged_on_malformed_yaml(self, tmp_path):
+        """Merge leaves file unchanged if cluster_components block is malformed."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        broken = (
+            "cluster_components:\n  namespaces:\n  - name: shop\n"
+            "    labels: {app: cart\n"
+        )
+        with open(path, "w") as f:
+            f.write(broken)
+        discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+        assert open(path).read() == broken
+
+    def test_skip_and_overwrite_emit_warnings(self, tmp_path):
+        """Skip and overwrite both warn the user about the existing file."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("original: true\n")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+
+        with patch("krkn_ai.utils.fs.logger") as mock_logger:
+            save_discovery(path, "skip", components, KUBECONFIG)
+            assert mock_logger.warning.called
+
+        with patch("krkn_ai.utils.fs.logger") as mock_logger:
+            save_discovery(path, "overwrite", components, KUBECONFIG)
+            assert mock_logger.warning.called
+
+    def test_merge_writes_fresh_when_file_absent(self, tmp_path):
+        """Merge on a missing file falls back to a fresh write."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "merge", components, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "shop" in names
+
+    def test_strategy_is_case_insensitive(self, tmp_path):
+        """Strategy matching ignores case (e.g. SKIP behaves like skip)."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("original: true\n")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "SKIP", components, KUBECONFIG)
+        assert open(path).read() == "original: true\n"

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -282,51 +282,6 @@ class TestSaveDiscovery:
         save_discovery(path, "merge", discovered, KUBECONFIG)
         assert open(path).read() == first
 
-    def test_merge_preserves_top_level_comment(self, tmp_path):
-        """Merge preserves comments in the rest of the file."""
-        path = str(tmp_path / "krkn-ai.yaml")
-        existing = ClusterComponents(namespaces=[Namespace(name="shop")])
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(
-                _render_components_block(existing)
-                + "\n# keep me\nadaptive_mutation: true\n"
-            )
-        discovered = ClusterComponents(
-            namespaces=[Namespace(name="shop"), Namespace(name="pay")]
-        )
-        save_discovery(path, "merge", discovered, KUBECONFIG)
-        text = open(path).read()
-        assert "# keep me" in text
-        names = [
-            n["name"] for n in yaml.safe_load(text)["cluster_components"]["namespaces"]
-        ]
-        assert "pay" in names
-
-    def test_merge_appends_when_no_components_block(self, tmp_path):
-        """Merge appends components block if file has no cluster_components section."""
-        path = str(tmp_path / "krkn-ai.yaml")
-        with open(path, "w") as f:
-            f.write("baseline:\n  duration: 42\n")
-        discovered = ClusterComponents(namespaces=[Namespace(name="shop")])
-        save_discovery(path, "merge", discovered, KUBECONFIG)
-        data = yaml.safe_load(open(path))
-        assert data["baseline"]["duration"] == 42
-        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
-        assert "shop" in names
-
-    def test_merge_leaves_file_unchanged_on_malformed_yaml(self, tmp_path):
-        """Merge leaves file unchanged if cluster_components block is malformed."""
-        path = str(tmp_path / "krkn-ai.yaml")
-        broken = (
-            "cluster_components:\n  namespaces:\n  - name: shop\n"
-            "    labels: {app: cart\n"
-        )
-        with open(path, "w") as f:
-            f.write(broken)
-        discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
-        save_discovery(path, "merge", discovered, KUBECONFIG)
-        assert open(path).read() == broken
-
     def test_skip_and_overwrite_emit_warnings(self, tmp_path):
         """Skip and overwrite both warn the user about the existing file."""
         path = str(tmp_path / "krkn-ai.yaml")

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -10,8 +10,8 @@ from krkn_ai.utils.fs import (
     read_config_from_file,
     save_discovery,
     merge_components,
-    _render_components_block,
 )
+from krkn_ai.templates.generator import create_krkn_ai_template
 from krkn_ai.models.cluster_components import (
     ClusterComponents,
     Namespace,
@@ -201,14 +201,11 @@ class TestMergeComponents:
         assert [n.name for n in merged.nodes] == ["n1", "n2"]
 
 
-def _write_existing(
-    path,
-    components,
-    prefix="baseline:\n  duration: 300\n\n",
-    suffix="\n\nadaptive_mutation: true\n",
-):
+def _write_existing(path, components):
+    """Write a valid config file via the krkn-ai template."""
+    data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
     with open(path, "w", encoding="utf-8") as f:
-        f.write(prefix + _render_components_block(components) + suffix)
+        f.write(create_krkn_ai_template(KUBECONFIG, data))
 
 
 class TestSaveDiscovery:
@@ -242,8 +239,8 @@ class TestSaveDiscovery:
         names = [n["name"] for n in data["cluster_components"]["namespaces"]]
         assert "shop" in names
 
-    def test_merge_preserves_edits_and_adds_new(self, tmp_path):
-        """Merge preserves user edits and adds new discovered components."""
+    def test_merge_preserves_component_edits_and_adds_new(self, tmp_path):
+        """Preserves per-component edits and adds new components on merge."""
         path = str(tmp_path / "krkn-ai.yaml")
         existing = ClusterComponents(
             namespaces=[Namespace(name="shop", pods=[Pod(name="redis", disabled=True)])]
@@ -257,8 +254,6 @@ class TestSaveDiscovery:
         )
         save_discovery(path, "merge", discovered, KUBECONFIG)
         data = yaml.safe_load(open(path))
-        assert data["baseline"]["duration"] == 300
-        assert data["adaptive_mutation"] is True
         shop = next(
             n for n in data["cluster_components"]["namespaces"] if n["name"] == "shop"
         )
@@ -281,6 +276,19 @@ class TestSaveDiscovery:
         first = open(path).read()
         save_discovery(path, "merge", discovered, KUBECONFIG)
         assert open(path).read() == first
+
+    def test_merge_leaves_invalid_file_unchanged(self, tmp_path):
+        """Invalid existing file is left unchanged on merge."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("not: [a, valid, krkn-ai, config\n")  # malformed YAML
+        original = open(path).read()
+        discovered = ClusterComponents(namespaces=[Namespace(name="shop")])
+
+        with patch("krkn_ai.utils.fs.logger") as mock_logger:
+            save_discovery(path, "merge", discovered, KUBECONFIG)
+            assert mock_logger.warning.called
+        assert open(path).read() == original
 
     def test_skip_and_overwrite_emit_warnings(self, tmp_path):
         """Skip and overwrite both warn the user about the existing file."""
@@ -314,3 +322,25 @@ class TestSaveDiscovery:
         components = ClusterComponents(namespaces=[Namespace(name="shop")])
         save_discovery(path, "SKIP", components, KUBECONFIG)
         assert open(path).read() == "original: true\n"
+
+    def test_merge_leaves_invalid_config_unchanged(self, tmp_path):
+        """Valid YAML with wrong schema is left unchanged on merge."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write("some_field: value\n")  # valid YAML, not a valid krkn-ai config
+        original = open(path).read()
+        discovered = ClusterComponents(namespaces=[Namespace(name="shop")])
+
+        with patch("krkn_ai.utils.fs.logger") as mock_logger:
+            save_discovery(path, "merge", discovered, KUBECONFIG)
+            assert mock_logger.warning.called
+        assert open(path).read() == original
+
+    def test_overwrite_writes_when_file_absent(self, tmp_path):
+        """Overwrite strategy creates a fresh file when none exists."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "overwrite", components, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        names = [n["name"] for n in data["cluster_components"]["namespaces"]]
+        assert "shop" in names


### PR DESCRIPTION
## Description
  Adds `--save-strategy` to the `discover` command to control what happens when the output file already exists.

  - `skip` (default) : warn and do nothing
  - `overwrite` : replace the file with a fresh config
  - `merge` : keep existing edits, add newly discovered components by name

Week 2 #364 

  ## Type of Change
  - [x] New feature
  - [x] Documentation update

  ## Testing
  Tested all three strategies against a live minikube cluster. Verified:
  - `skip` warns and leaves the file unchanged
  - `overwrite` warns and replaces the file
  - `merge` preserves manual edits and adds new components

  Unit tests added for all strategies in `tests/unit/utils/test_fs.py` and `tests/unit/cli/test_cmd.py`.

<img width="1090" height="649" alt="Screenshot 2026-06-22 at 10 49 18 AM" src="https://github.com/user-attachments/assets/0acc1b50-c9ab-4473-bcc8-ff7697b3a5d3" />

  
## Checklist
  - [x] I have read the CONTRIBUTING guidelines
  - [x] My code follows the project's style guidelines
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have updated the documentation accordingly
  - [x] My changes generate no new warnings or errors


