### PR TITLE
fix(dashboard): resolve scenario output filenames from configured naming format

### DIFF
--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -7,6 +7,9 @@ import streamlit as st
 import re
 import json
 
+from krkn_ai.models.config import OutputConfig
+from krkn_ai.utils.output import fmt_to_glob, fmt_to_id_regex
+
 
 @st.cache_data(ttl=300)
 def load_results_csv(output_dir: str):
@@ -35,8 +38,23 @@ def load_config_yaml(output_dir: str):
 
 
 @st.cache_data(ttl=300)
+def _get_output_config(output_dir: str) -> OutputConfig:
+    """Load the output filename config for a run, falling back to defaults."""
+    raw = load_config_yaml(output_dir)
+    try:
+        return OutputConfig(**(raw or {}).get("output", {}))
+    except Exception as e:
+        logging.error(f"Failed to parse output config for {output_dir}: {e}")
+        return OutputConfig()
+
+
+@st.cache_data(ttl=300)
 def load_detailed_scenarios_data(output_dir: str):
-    yaml_pattern = os.path.join(output_dir, "yaml", "generation_*", "scenario_*.yaml")
+    output_config = _get_output_config(output_dir)
+    yaml_glob = fmt_to_glob(output_config.result_name_fmt)
+    base_name, _ext = os.path.splitext(yaml_glob)
+    yaml_glob = f"{base_name}.yaml"
+    yaml_pattern = os.path.join(output_dir, "yaml", "generation_*", yaml_glob)
     yaml_files = glob.glob(yaml_pattern)
 
     rows = []
@@ -101,13 +119,18 @@ def load_health_check_csv(output_dir: str):
 @st.cache_data(ttl=300)
 def load_logs(output_dir: str):
     """
-    Parse all scenario_N.log files and return a list of structured dicts,
-    one per scenario, containing everything needed for the report card.
+    Parse all scenario log files (matched using the run's configured
+    log_name_fmt) and return a list of structured dicts, one per scenario,
+    containing everything needed for the report card.
     """
 
     log_dir = os.path.join(output_dir, "logs")
     if not os.path.isdir(log_dir):
         return []
+
+    output_config = _get_output_config(output_dir)
+    log_glob = fmt_to_glob(output_config.log_name_fmt)
+    log_id_regex = fmt_to_id_regex(output_config.log_name_fmt)
 
     # Matches: "2026-03-17 11:58:12,164 [INFO] message..."
     log_re = re.compile(
@@ -119,9 +142,9 @@ def load_logs(output_dir: str):
     ansi_re = re.compile(r"\x1b\[[0-9;]*m")
 
     results = []
-    for log_file in sorted(glob.glob(os.path.join(log_dir, "scenario_*.log"))):
+    for log_file in sorted(glob.glob(os.path.join(log_dir, log_glob))):
         base = os.path.basename(log_file)
-        m = re.match(r"scenario_(\d+)\.log", base)
+        m = log_id_regex.match(base)
         scen_id = int(m.group(1)) if m else base
 
         try:

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -195,6 +195,19 @@ class OutputConfig(BaseModel):
     graph_name_fmt: str = "scenario_%s.png"
     log_name_fmt: str = "scenario_%s.log"
 
+    @field_validator("result_name_fmt", "graph_name_fmt", "log_name_fmt", mode="after")
+    @classmethod
+    def requires_scenario_id_placeholder(cls, value: str, info) -> str:
+        if "%s" not in value:
+            field_name = info.field_name
+            raise ValueError(
+                f"{field_name} must include the %s (scenario ID) placeholder "
+                f"so every scenario produces a uniquely named file. "
+                f"Got: '{value}'. Please check the '{field_name}' parameter "
+                f"in your krkn-ai config file."
+            )
+        return value
+
 
 class ElasticConfig(BaseModel):
     """

--- a/krkn_ai/utils/output.py
+++ b/krkn_ai/utils/output.py
@@ -1,8 +1,10 @@
+import glob
 import re
 
 from krkn_ai.models.app import CommandRunResult
 
 _INVALID_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+_PLACEHOLDERS = ("%g", "%s", "%c")
 
 
 def _sanitize_filename_component(value: str) -> str:
@@ -26,6 +28,29 @@ def format_result_filename(fmt: str, command_result: CommandRunResult) -> str:
         .replace("%s", str(command_result.scenario_id))
         .replace("%c", safe_name)
     )
+
+
+def fmt_to_glob(fmt: str) -> str:
+    """
+    Convert a name-format string (with %g/%s/%c placeholders) into a glob
+    pattern matching any filename the format string could produce.
+    """
+    pattern = glob.escape(fmt)
+    for placeholder in _PLACEHOLDERS:
+        pattern = pattern.replace(placeholder, "*")
+    return pattern
+
+
+def fmt_to_id_regex(fmt: str) -> re.Pattern:
+    """
+    Convert a name-format string into a compiled, anchored regex with one
+    capture group for the %s (scenario ID) placeholder. The capture group
+    matches digits only (\\d+). Assumes %s is present in fmt and occurs
+    exactly once.
+    """
+    pattern = re.escape(fmt)
+    pattern = pattern.replace("%g", ".*").replace("%s", r"(\d+)").replace("%c", ".*")
+    return re.compile(f"^{pattern}$")
 
 
 def format_duration(duration: float) -> str:

--- a/tests/unit/dashboard/test_data_loader.py
+++ b/tests/unit/dashboard/test_data_loader.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 import pytest
 import pandas as pd
@@ -199,3 +200,53 @@ def test_load_logs_exception():
     ):
         logs = load_logs("/tmp")
         assert logs == []
+
+
+def test_load_detailed_scenarios_data_uses_configured_result_fmt():
+    with (
+        patch(
+            "krkn_ai.dashboard.data_loader.load_config_yaml",
+            return_value={"output": {"result_name_fmt": "gen_%g_%c_%s.yaml"}},
+        ),
+        patch("glob.glob", return_value=[]) as mock_glob,
+    ):
+        load_detailed_scenarios_data("/tmp")
+        called_pattern = mock_glob.call_args[0][0]
+        assert called_pattern.endswith(os.path.join("generation_*", "gen_*_*_*.yaml"))
+
+
+def test_load_logs_uses_configured_log_fmt_for_scenario_id():
+    log_content = """
+2026-03-17 11:58:12,164 [INFO] some message
+
+container-scenarios ran for 3m12s
+"""
+    with (
+        patch("os.path.isdir", return_value=True),
+        patch(
+            "krkn_ai.dashboard.data_loader.load_config_yaml",
+            return_value={"output": {"log_name_fmt": "run_%g_%s.log"}},
+        ),
+        patch("glob.glob", return_value=["/tmp/logs/run_0_7.log"]),
+        patch("builtins.open", mock_open(read_data=log_content)),
+    ):
+        logs = load_logs("/tmp")
+        assert len(logs) == 1
+        assert logs[0]["scenario_id"] == 7
+
+
+def test_load_logs_falls_back_to_default_fmt_when_no_config():
+    log_content = """
+2026-03-17 11:58:12,164 [INFO] some message
+
+container-scenarios ran for 3m12s
+"""
+    with (
+        patch("os.path.isdir", return_value=True),
+        patch("krkn_ai.dashboard.data_loader.load_config_yaml", return_value=None),
+        patch("glob.glob", return_value=["/tmp/logs/scenario_9.log"]),
+        patch("builtins.open", mock_open(read_data=log_content)),
+    ):
+        logs = load_logs("/tmp")
+        assert len(logs) == 1
+        assert logs[0]["scenario_id"] == 9

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -239,6 +239,26 @@ class TestOutputConfig:
         assert "%g" in config.result_name_fmt
         assert "%s" in config.result_name_fmt
 
+    @pytest.mark.parametrize(
+        "field_name",
+        ["result_name_fmt", "graph_name_fmt", "log_name_fmt"],
+    )
+    def test_output_config_rejects_fmt_without_scenario_id(self, field_name):
+        """Format strings without %s must be rejected so scenarios don't collide on filenames"""
+        with pytest.raises(ValidationError, match="%s"):
+            OutputConfig(**{field_name: "gen_%g_scenario.yaml"})
+
+    def test_output_config_accepts_fmt_with_scenario_id(self):
+        """Format strings containing %s are accepted regardless of other placeholders"""
+        config = OutputConfig(
+            result_name_fmt="gen_%g_%s.yaml",
+            graph_name_fmt="%s.png",
+            log_name_fmt="%c_%s.log",
+        )
+        assert config.result_name_fmt == "gen_%g_%s.yaml"
+        assert config.graph_name_fmt == "%s.png"
+        assert config.log_name_fmt == "%c_%s.log"
+
 
 class TestStoppingCriteria:
     """Test StoppingCriteria model"""

--- a/tests/unit/utils/test_output.py
+++ b/tests/unit/utils/test_output.py
@@ -1,0 +1,39 @@
+from krkn_ai.utils.output import fmt_to_glob, fmt_to_id_regex
+
+
+class TestFmtToGlob:
+    def test_default_result_fmt(self):
+        assert fmt_to_glob("scenario_%s.yaml") == "scenario_*.yaml"
+
+    def test_default_log_fmt(self):
+        assert fmt_to_glob("scenario_%s.log") == "scenario_*.log"
+
+    def test_custom_fmt_with_all_placeholders(self):
+        assert fmt_to_glob("gen_%g_%c_%s.json") == "gen_*_*_*.json"
+
+    def test_fmt_with_glob_special_chars_is_escaped(self):
+        # literal "[v1]" in the filename must not be treated as a glob character class
+        assert fmt_to_glob("scenario_%s_[v1].log") == "scenario_*_[[]v1].log"
+
+
+class TestFmtToIdRegex:
+    def test_default_log_fmt_matches_and_captures_id(self):
+        regex = fmt_to_id_regex("scenario_%s.log")
+        match = regex.match("scenario_42.log")
+        assert match is not None
+        assert match.group(1) == "42"
+
+    def test_custom_fmt_with_generation_and_scenario_name(self):
+        regex = fmt_to_id_regex("gen_%g_%c_%s.log")
+        match = regex.match("gen_3_pod_scenarios_17.log")
+        assert match is not None
+        assert match.group(1) == "17"
+
+    def test_non_matching_filename_returns_none(self):
+        regex = fmt_to_id_regex("scenario_%s.log")
+        assert regex.match("other_file.log") is None
+
+    def test_literal_dot_is_not_a_wildcard(self):
+        regex = fmt_to_id_regex("scenario_%s.log")
+        # the "." before "log" is literal; it must not match an arbitrary character
+        assert regex.match("scenario_1Xlog") is None


### PR DESCRIPTION
## Description

`OutputConfig` already supports custom format strings for result/log filenames (`result_name_fmt`, `log_name_fmt`, `graph_name_fmt` with `%g`/`%s`/`%c`), and the genetic algorithm writer already uses them. The dashboard never did: `data_loader.py` hardcoded `scenario_*.yaml` / `scenario_*.log` when reading results and logs back, so a run with a customized format wouldn't show up in the dashboard at all.

This PR:
- Adds a validator on `OutputConfig` requiring `%s` in all three format fields, since scenario_id is the only placeholder that's actually guaranteed unique per scenario across a run.
- Adds `fmt_to_glob`/`fmt_to_id_regex` helpers in `utils/output.py` to turn a format string into a glob pattern plus an ID-capturing regex.
- Wires `load_detailed_scenarios_data` and `load_logs` in the dashboard to resolve filenames from the run's actual `krkn-ai.yaml` instead of the hardcoded defaults, falling back to defaults if the config is missing.

Fixes #335

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

Added tests for the new validator (`test_config.py`), the new glob/regex helpers (`test_output.py`), and the dashboard wiring including a case with a non-default `log_name_fmt` to prove scenario_id still resolves correctly. Ran the full unit suite locally, all passing except one pre-existing Windows-only teardown flake in `test_cmd.py` unrelated to this change (confirmed via `git stash`).

## Screenshots

**Tests passing:**
<img width="1437" height="274" alt="Screenshot 2026-06-22 141751" src="https://github.com/user-attachments/assets/abba7ecc-f7fd-4769-a92f-284fc18a89fe" />


**Dashboard resolving a custom `log_name_fmt`:**
Backing file is `logs/run_0_1.log` (not `scenario_1.log`), resolved via `log_name_fmt: "run_%g_%s.log"` in `krkn-ai.yaml`.
<img width="1529" height="1822" alt="screencapture-localhost-8501-2026-06-22-14_12_47" src="https://github.com/user-attachments/assets/6d710865-8dc7-4721-a89f-e479d5ad97ca" />


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
