### PR TITLE
Add local nginx testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ kubectl config set-context --current --namespace=$DEMO_NAMESPACE
 ```
 
 ```bash
-# Setup NGINX reverse proxy and test endpoints
+# Setup NGINX reverse proxy
 ./scripts/setup-nginx.sh
+```
+
+```bash
+# Test Endpoints
+# For clusters that provide a LoadBalancer hostname
+export HOST="http://$(kubectl get service rs -o json | jq -r '.status.loadBalancer.ingress[0].hostname')"
 ./scripts/test-nginx-routes.sh
 
-export HOST="http://$(kubectl get service rs -o json | jq -r '.status.loadBalancer.ingress[0].hostname')"
+#For local environments, where a LoadBalancer hostname may not be available:
+kubectl port-forward svc/rs 8080:80 -n robot-shop
+export HOST=http://localhost:8080
+./scripts/test-nginx-routes.sh
 ```
 
 ### Generate Configuration

--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ kubectl config set-context --current --namespace=$DEMO_NAMESPACE
 
 ```bash
 # Test Endpoints
+
 # For clusters that provide a LoadBalancer hostname
 export HOST="http://$(kubectl get service rs -o json | jq -r '.status.loadBalancer.ingress[0].hostname')"
 ./scripts/test-nginx-routes.sh
 
-#For local environments, where a LoadBalancer hostname may not be available:
+#For local environments, where a LoadBalancer hostname may not be available
 kubectl port-forward svc/rs 8080:80 -n robot-shop
+# In a separate terminal
 export HOST=http://localhost:8080
 ./scripts/test-nginx-routes.sh
 ```


### PR DESCRIPTION
## Description

Added documentation for testing NGINX endpoints in local Kubernetes environments where a LoadBalancer hostname may not be available.
The README now includes alternative instructions using `kubectl port-forward` and a locally defined `HOST` value, allowing `test-nginx-routes.sh` to be executed successfully on local clusters.


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other:

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [ ] My changes generate no new warnings or errors
