### PR TITLE
fix(fitness): round range-query window up to cover full test duration

### DIFF
--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -1,5 +1,6 @@
 import os
 import json
+import math
 import datetime
 import tempfile
 import time
@@ -533,7 +534,7 @@ class KrknRunner:
 
         # Calculate number of minutes between test run
         if "$range$" in query:
-            time_dt_mins = int((end - start).total_seconds() / 60)
+            time_dt_mins = math.ceil((end - start).total_seconds() / 60)
             if time_dt_mins == 0:
                 time_dt_mins = 1
             query = query.replace("$range$", f"{time_dt_mins}m")

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -506,6 +506,50 @@ class TestCalculateRangeFitness:
             assert "10m" in call_str
             assert score == 15.5
 
+    def test_calculate_range_fitness_rounds_window_up_to_cover_full_run(
+        self, minimal_config, temp_output_dir
+    ):
+        """Range window must cover the whole test, not floor to whole minutes.
+
+        A 1m59s run must query a 2m window. Flooring to 1m would drop the
+        first ~59s of data and skew the fitness score.
+        """
+        minimal_config.fitness_function = FitnessFunction(
+            query="max_over_time(kube_pod_container_status_restarts_total{$range$})",
+            type=FitnessFunctionType.range,
+        )
+
+        mock_prom_client = Mock()
+        mock_prom_client.process_prom_query_in_range.return_value = [
+            {"values": [[1000, "15.5"]]}
+        ]
+
+        with patch(
+            "krkn_ai.chaos_engines.krkn_runner.create_prometheus_client",
+            return_value=mock_prom_client,
+        ):
+            runner = KrknRunner(
+                config=minimal_config,
+                output_dir=temp_output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+            runner.prom_client = mock_prom_client
+
+            start = datetime.datetime(2024, 1, 1, 12, 0, 0)
+            end = datetime.datetime(
+                2024, 1, 1, 12, 1, 59
+            )  # 1m59s -> must round up to 2m
+
+            runner.calculate_range_fitness(
+                start,
+                end,
+                "max_over_time(kube_pod_container_status_restarts_total{$range$})",
+            )
+
+            call_str = str(mock_prom_client.process_prom_query_in_range.call_args)
+            assert "2m" in call_str
+            assert "1m" not in call_str
+
     def test_calculate_range_fitness_multiple_series_raises_error(
         self, minimal_config, temp_output_dir
     ):


### PR DESCRIPTION
## Summary

`calculate_range_fitness` builds the `$range$` window for the Prometheus query from the test duration. It converted the duration to whole minutes with `int()`, which floors and throws away the leftover seconds.

A run that lasts 1m59s produced a "1m" window. Because the range query is anchored at the run's end time, a 1m lookback only covers the final minute and silently drops the first ~59 seconds of the run. Aggregates like `max_over_time` and `avg_over_time` then miss any spike from the start of the run, so the fitness score is computed from a partial window with no warning. Scenario execution is timed by wall clock (datetime.now() before and after the run), so durations are rarely exact multiples of 60 seconds.

## How I found it

I was reading `calculate_range_fitness` and saw the duration converted with `int((end - start).total_seconds() / 60)`. `int()` truncates toward zero, so any fractional minute is lost, and since the query is anchored at `end`, the shortened window starts after the real start time and misses early data.

## What I changed

- Replaced `int(...)` with `math.ceil(...)` so the window is never shorter than the actual test duration.
- Added a regression test: a 1m59s run must query a "2m" window (it produced "1m" before the fix).

## Why this is correct

The lookback window must cover the whole experiment so the aggregate sees all of it. Flooring can only undercount; rounding up guarantees full coverage. Exact-minute behavior is unchanged (a 10m run still queries "10m"), and the zero-duration guard
still applies.

## Tests

- New test `test_calculate_range_fitness_rounds_window_up_to_cover_full_run` fails on main ("1m") and passes after the fix ("2m").
- `uv run pytest` - 371 passed. (One pre-existing Windows-only temp-dir teardown error on `test_run_with_valid_config_succeeds`, unrelated to this change and not seen on the Linux CI.)
- `ruff check` clean.
