### PR TITLE
feat(discover): dynamic scenario enablement

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -290,8 +290,7 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
-    # recommend calls only for overwrite and if no file exists for other strategies
-    recommended = (
+    scenario_enables = (
         ScenarioFactory.recommend_enabled_scenarios(cluster_components, kubeconfig)
         if not os.path.exists(output) or save_strategy.lower() == "overwrite"
         else None
@@ -301,5 +300,5 @@ def discover(
         save_strategy,
         cluster_components,
         kubeconfig,
-        dynamic={"scenarios": recommended},
+        scenario_enables=scenario_enables,
     )

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -249,7 +249,7 @@ def monitor(ctx, output: str, port: int):
     "--save-strategy",
     type=click.Choice(["skip", "overwrite", "merge"], case_sensitive=False),
     default="skip",
-    help="How to save: skip, overwrite (replace), or merge (add new). Note: merge does not preserve comments inside cluster_components.",
+    help="How to save: skip, overwrite (replace), or merge (add new components, keep your edits). Note: merge does not preserve comments.",
 )
 @click.pass_context
 def discover(

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -22,6 +22,7 @@ from krkn_ai.models.custom_errors import (
 )
 from krkn_ai.utils.fs import read_config_from_file, save_discovery
 from krkn_ai.utils.cluster_manager import ClusterManager
+from krkn_ai.models.scenario.factory import ScenarioFactory
 
 
 @click.group(context_settings={"show_default": True})
@@ -289,4 +290,21 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
-    save_discovery(output, save_strategy, cluster_components, kubeconfig)
+    # Only the fresh-write paths (new file, or overwrite) consume the
+    # recommendation; skip/merge of an existing file discard it. Gate here so a
+    # routine re-run doesn't pay for recommend_enabled_scenarios, which
+    # instantiates every scenario and, when PVCs exist, makes a live API call
+    # (df in a pod) to read usage. Mirrors save_discovery's own branch.
+    will_write_fresh = (not os.path.exists(output)) or save_strategy.lower() == "overwrite"
+    recommended = (
+        ScenarioFactory.recommend_enabled_scenarios(cluster_components, kubeconfig)
+        if will_write_fresh
+        else None
+    )
+    save_discovery(
+        output,
+        save_strategy,
+        cluster_components,
+        kubeconfig,
+        dynamic={"scenarios": recommended},
+    )

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -290,15 +290,10 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
-    # Only the fresh-write paths (new file, or overwrite) consume the
-    # recommendation; skip/merge of an existing file discard it. Gate here so a
-    # routine re-run doesn't pay for recommend_enabled_scenarios, which
-    # instantiates every scenario and, when PVCs exist, makes a live API call
-    # (df in a pod) to read usage. Mirrors save_discovery's own branch.
-    will_write_fresh = (not os.path.exists(output)) or save_strategy.lower() == "overwrite"
+    # recommend calls only for overwrite and if no file exists for other strategies
     recommended = (
         ScenarioFactory.recommend_enabled_scenarios(cluster_components, kubeconfig)
-        if will_write_fresh
+        if not os.path.exists(output) or save_strategy.lower() == "overwrite"
         else None
     )
     save_discovery(

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     field_validator,
     model_serializer,
@@ -76,6 +77,8 @@ class BaselineConfig(BaseModel):
 
 
 class ScenarioConfig(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     application_outages: Optional[AppOutageScenarioConfig] = Field(
         alias="application-outages", default=None
     )

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -33,9 +33,7 @@ logger = get_logger(__name__)
 
 @contextlib.contextmanager
 def _suppressed_factory_warnings():
-    """Temporarily raise this module's log level so the per-scenario validation
-    warnings (one per scenario that fails to initialize) stay quiet during
-    discover-time recommendation. The run path keeps its warnings."""
+    # suppress warnings for discover
     previous = logger.level
     logger.setLevel(logging.ERROR)
     try:
@@ -149,15 +147,7 @@ class ScenarioFactory:
     def recommend_enabled_scenarios(
         cluster_components: ClusterComponents, kubeconfig: str
     ) -> Optional[Set[str]]:
-        """Recommend which scenarios to enable for a discovered cluster.
-
-        Builds a temporary config with every scenario enabled and reuses
-        ``generate_valid_scenarios`` to keep only the ones that can initialize
-        against the discovered components. Returns the set of template keys
-        (hyphenated, e.g. ``"pod-scenarios"``) that are valid, or ``None`` to
-        signal that the caller should fall back to the static defaults (no
-        scenarios validated, or recommendation failed). Never raises.
-        """
+        # Recommend which scenarios to enable for a discovered cluster
         aliases = [name.replace("_", "-") for name, _ in scenario_specs]
         try:
             config = ConfigFile(

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -1,6 +1,8 @@
-from typing import List, Tuple
+import contextlib
+import logging
+from typing import List, Optional, Set, Tuple
 from krkn_ai.models.cluster_components import ClusterComponents
-from krkn_ai.models.config import ConfigFile
+from krkn_ai.models.config import ConfigFile, FitnessFunction, ScenarioConfig
 from krkn_ai.models.custom_errors import (
     MissingScenarioError,
     ScenarioInitError,
@@ -27,6 +29,20 @@ from krkn_ai.models.scenario.scenario_kubevirt import KubevirtDisruptionScenario
 from krkn_ai.models.scenario.scenario_storage_throttle import StorageThrottleScenario
 
 logger = get_logger(__name__)
+
+
+@contextlib.contextmanager
+def _suppressed_factory_warnings():
+    """Temporarily raise this module's log level so the per-scenario validation
+    warnings (one per scenario that fails to initialize) stay quiet during
+    discover-time recommendation. The run path keeps its warnings."""
+    previous = logger.level
+    logger.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        logger.setLevel(previous)
+
 
 scenario_specs = [
     ("pod_scenarios", PodScenario),
@@ -128,3 +144,34 @@ class ScenarioFactory:
     @staticmethod
     def create_dummy_scenario():
         return DummyScenario(cluster_components=ClusterComponents())
+
+    @staticmethod
+    def recommend_enabled_scenarios(
+        cluster_components: ClusterComponents, kubeconfig: str
+    ) -> Optional[Set[str]]:
+        """Recommend which scenarios to enable for a discovered cluster.
+
+        Builds a temporary config with every scenario enabled and reuses
+        ``generate_valid_scenarios`` to keep only the ones that can initialize
+        against the discovered components. Returns the set of template keys
+        (hyphenated, e.g. ``"pod-scenarios"``) that are valid, or ``None`` to
+        signal that the caller should fall back to the static defaults (no
+        scenarios validated, or recommendation failed). Never raises.
+        """
+        aliases = [name.replace("_", "-") for name, _ in scenario_specs]
+        try:
+            config = ConfigFile(
+                kubeconfig_file_path=kubeconfig,
+                fitness_function=FitnessFunction(query="placeholder"),
+                scenario=ScenarioConfig(**{a: {"enable": True} for a in aliases}),
+                cluster_components=cluster_components,
+            )
+            with _suppressed_factory_warnings():
+                valid = ScenarioFactory.generate_valid_scenarios(config)
+        except MissingScenarioError:
+            return None
+        except Exception as error:
+            # Recommendation must never break discovery; fall back to static.
+            logger.debug("Scenario recommendation failed: %s", error)
+            return None
+        return {name.replace("_", "-") for name, _ in valid}

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Tuple
 from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.models.config import ConfigFile, FitnessFunction, ScenarioConfig
 from krkn_ai.models.custom_errors import (
@@ -146,22 +146,27 @@ class ScenarioFactory:
     @staticmethod
     def recommend_enabled_scenarios(
         cluster_components: ClusterComponents, kubeconfig: str
-    ) -> Optional[Set[str]]:
-        # Recommend which scenarios to enable for a discovered cluster
-        aliases = [name.replace("_", "-") for name, _ in scenario_specs]
+    ) -> Dict[str, bool]:
+        names = [name for name, _ in scenario_specs]
+        all_disabled = {n: False for n in names}
         try:
             config = ConfigFile(
                 kubeconfig_file_path=kubeconfig,
                 fitness_function=FitnessFunction(query="placeholder"),
-                scenario=ScenarioConfig(**{a: {"enable": True} for a in aliases}),
+                scenario=ScenarioConfig(**{n: {"enable": True} for n in names}),
                 cluster_components=cluster_components,
             )
             with _suppressed_factory_warnings():
                 valid = ScenarioFactory.generate_valid_scenarios(config)
         except MissingScenarioError:
-            return None
+            logger.warning(
+                "No valid scenarios found for this cluster. "
+                "All scenarios disabled. "
+                "Check your cluster components or re-run discover."
+            )
+            return all_disabled
         except Exception as error:
-            # Recommendation must never break discovery; fall back to static.
             logger.debug("Scenario recommendation failed: %s", error)
-            return None
-        return {name.replace("_", "-") for name, _ in valid}
+            return all_disabled
+        valid_names = {name for name, _ in valid}
+        return {n: n in valid_names for n in names}

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -8,9 +8,30 @@ environment = jinja2.Environment()
 # Add enumerate to the template environment so it's available in templates
 environment.globals["enumerate"] = enumerate
 
+# Source of truth for the default scenario enables. The krkn-ai.yaml.j2 template
+# only fixes the key names and order; the values come from here (rendered via
+# {{ scenario_enables[...] }}). Values are YAML literal strings ("true"/"false")
+# on purpose: Jinja renders a Python bool as "True"/"False", which would change
+# the output.
+STATIC_SCENARIO_ENABLES = {
+    "pod-scenarios": "true",
+    "application-outages": "true",
+    "container-scenarios": "true",
+    "node-cpu-hog": "false",
+    "node-memory-hog": "false",
+    "node-io-hog": "false",
+    "time-scenarios": "false",
+    "network-scenarios": "false",
+    "dns-outage": "true",
+    "syn-flood": "false",
+    "pvc-scenarios": "false",
+    "kubevirt-scenarios": "false",
+    "storage-throttle": "false",
+}
+
 
 def create_krkn_ai_template(
-    kubeconfig_file_path: str, cluster_component_data: dict
+    kubeconfig_file_path: str, cluster_component_data: dict, dynamic: dict = None
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -36,7 +57,19 @@ def create_krkn_ai_template(
 
     cluster_components_indented = "\n".join(indented_lines)
 
+    # Scenario enables: fall back to the static defaults (byte-identical output)
+    # when discovery did not determine them.
+    scenarios = dynamic.get("scenarios") if dynamic else None
+    if scenarios is None:
+        scenario_enables = STATIC_SCENARIO_ENABLES
+    else:
+        scenario_enables = {
+            key: ("true" if key in scenarios else "false")
+            for key in STATIC_SCENARIO_ENABLES
+        }
+
     return template.render(
         kubeconfig_file_path=kubeconfig_file_path,
         cluster_components=cluster_components_indented,
+        scenario_enables=scenario_enables,
     )

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -3,31 +3,18 @@ import os
 import jinja2
 import yaml
 
+from krkn_ai.models.scenario.factory import scenario_specs
+
 environment = jinja2.Environment()
 
 # Add enumerate to the template environment so it's available in templates
 environment.globals["enumerate"] = enumerate
 
-# default enables copied from static template
-STATIC_SCENARIO_ENABLES = {
-    "pod-scenarios": "true",
-    "application-outages": "true",
-    "container-scenarios": "true",
-    "node-cpu-hog": "false",
-    "node-memory-hog": "false",
-    "node-io-hog": "false",
-    "time-scenarios": "false",
-    "network-scenarios": "false",
-    "dns-outage": "true",
-    "syn-flood": "false",
-    "pvc-scenarios": "false",
-    "kubevirt-scenarios": "false",
-    "storage-throttle": "false",
-}
-
 
 def create_krkn_ai_template(
-    kubeconfig_file_path: str, cluster_component_data: dict, dynamic: dict = None
+    kubeconfig_file_path: str,
+    cluster_component_data: dict,
+    scenario_enables: dict = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -53,15 +40,8 @@ def create_krkn_ai_template(
 
     cluster_components_indented = "\n".join(indented_lines)
 
-    # Scenario enables: fall back to the static defaults
-    scenarios = dynamic.get("scenarios") if dynamic else None
-    if scenarios is None:
-        scenario_enables = STATIC_SCENARIO_ENABLES
-    else:
-        scenario_enables = {
-            key: ("true" if key in scenarios else "false")
-            for key in STATIC_SCENARIO_ENABLES
-        }
+    if scenario_enables is None:
+        scenario_enables = {name: False for name, _ in scenario_specs}
 
     return template.render(
         kubeconfig_file_path=kubeconfig_file_path,

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -8,11 +8,7 @@ environment = jinja2.Environment()
 # Add enumerate to the template environment so it's available in templates
 environment.globals["enumerate"] = enumerate
 
-# Source of truth for the default scenario enables. The krkn-ai.yaml.j2 template
-# only fixes the key names and order; the values come from here (rendered via
-# {{ scenario_enables[...] }}). Values are YAML literal strings ("true"/"false")
-# on purpose: Jinja renders a Python bool as "True"/"False", which would change
-# the output.
+# default enables copied from static template
 STATIC_SCENARIO_ENABLES = {
     "pod-scenarios": "true",
     "application-outages": "true",
@@ -57,8 +53,7 @@ def create_krkn_ai_template(
 
     cluster_components_indented = "\n".join(indented_lines)
 
-    # Scenario enables: fall back to the static defaults (byte-identical output)
-    # when discovery did not determine them.
+    # Scenario enables: fall back to the static defaults
     scenarios = dynamic.get("scenarios") if dynamic else None
     if scenarios is None:
         scenario_enables = STATIC_SCENARIO_ENABLES

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -65,31 +65,31 @@ fitness_function:
 
 scenario:
   pod-scenarios:
-    enable: true
+    enable: {{ scenario_enables['pod-scenarios'] }}
   application-outages:
-    enable: true
+    enable: {{ scenario_enables['application-outages'] }}
   container-scenarios:
-    enable: true
+    enable: {{ scenario_enables['container-scenarios'] }}
   node-cpu-hog:
-    enable: false
+    enable: {{ scenario_enables['node-cpu-hog'] }}
   node-memory-hog:
-    enable: false
+    enable: {{ scenario_enables['node-memory-hog'] }}
   node-io-hog:
-    enable: false
+    enable: {{ scenario_enables['node-io-hog'] }}
   time-scenarios:
-    enable: false
+    enable: {{ scenario_enables['time-scenarios'] }}
   network-scenarios:
-    enable: false
+    enable: {{ scenario_enables['network-scenarios'] }}
   dns-outage:
-    enable: true
+    enable: {{ scenario_enables['dns-outage'] }}
   syn-flood:
-    enable: false
+    enable: {{ scenario_enables['syn-flood'] }}
   pvc-scenarios:
-    enable: false
+    enable: {{ scenario_enables['pvc-scenarios'] }}
   kubevirt-scenarios:
-    enable: false
+    enable: {{ scenario_enables['kubevirt-scenarios'] }}
   storage-throttle:
-    enable: false
+    enable: {{ scenario_enables['storage-throttle'] }}
 
 cluster_components:
 {{ cluster_components }}

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -64,32 +64,10 @@ fitness_function:
 
 
 scenario:
-  pod-scenarios:
-    enable: {{ scenario_enables['pod-scenarios'] }}
-  application-outages:
-    enable: {{ scenario_enables['application-outages'] }}
-  container-scenarios:
-    enable: {{ scenario_enables['container-scenarios'] }}
-  node-cpu-hog:
-    enable: {{ scenario_enables['node-cpu-hog'] }}
-  node-memory-hog:
-    enable: {{ scenario_enables['node-memory-hog'] }}
-  node-io-hog:
-    enable: {{ scenario_enables['node-io-hog'] }}
-  time-scenarios:
-    enable: {{ scenario_enables['time-scenarios'] }}
-  network-scenarios:
-    enable: {{ scenario_enables['network-scenarios'] }}
-  dns-outage:
-    enable: {{ scenario_enables['dns-outage'] }}
-  syn-flood:
-    enable: {{ scenario_enables['syn-flood'] }}
-  pvc-scenarios:
-    enable: {{ scenario_enables['pvc-scenarios'] }}
-  kubevirt-scenarios:
-    enable: {{ scenario_enables['kubevirt-scenarios'] }}
-  storage-throttle:
-    enable: {{ scenario_enables['storage-throttle'] }}
+{%- for name, enabled in scenario_enables.items() %}
+  {{ name | replace("_", "-") }}:
+    enable: {{ "true" if enabled else "false" }}
+{%- endfor %}
 
 cluster_components:
 {{ cluster_components }}

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -165,16 +165,15 @@ def _build_merged_config(
             e,
         )
         return None
+    # edit the raw file so user fields aren't dropped on a model dump
+    with open(output, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
     merged = merge_components(config.cluster_components, discovered)
-    data = config.model_dump(
-        mode="json", by_alias=True, warnings="none", exclude_none=True
-    )
-    # dump components like a fresh write
-    data["cluster_components"] = merged.model_dump(
+    raw["cluster_components"] = merged.model_dump(
         mode="json", warnings="none", exclude_defaults=True
     )
-    return yaml.dump(
-        data, default_flow_style=False, sort_keys=False, allow_unicode=True
+    return yaml.safe_dump(
+        raw, default_flow_style=False, sort_keys=False, allow_unicode=True
     )
 
 

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -181,11 +181,11 @@ def _write_fresh(
     output: str,
     components: ClusterComponents,
     kubeconfig: str,
-    dynamic: dict = None,
+    scenario_enables: dict = None,
 ):
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    template = create_krkn_ai_template(kubeconfig, data, dynamic)
+    template = create_krkn_ai_template(kubeconfig, data, scenario_enables)
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
     logger.info("Saved component configuration to %s", output)
@@ -196,7 +196,7 @@ def save_discovery(
     strategy: str,
     components: ClusterComponents,
     kubeconfig: str,
-    dynamic: dict = None,
+    scenario_enables: dict = None,
 ):
     """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
     strategy = strategy.lower()
@@ -222,4 +222,4 @@ def save_discovery(
     if exists and strategy == "overwrite":
         logger.warning("Overwriting existing %s", output)
 
-    _write_fresh(output, components, kubeconfig, dynamic)
+    _write_fresh(output, components, kubeconfig, scenario_enables)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -154,9 +154,10 @@ def merge_components(
 def _build_merged_config(
     output: str, discovered: ClusterComponents, kubeconfig: str
 ) -> Union[str, None]:
-    """Merge discovered components into the existing file; returns None if unreadable."""
+    """Merge discovered components into the existing config, keeping the user's
+    edits."""
     try:
-        config = read_config_from_file(output)
+        config = read_config_from_file(output, kubeconfig=kubeconfig)
     except (yaml.YAMLError, ValueError, ValidationError) as e:
         logger.warning(
             "Could not read existing config %s (%s); leaving file unchanged.",
@@ -165,8 +166,17 @@ def _build_merged_config(
         )
         return None
     merged = merge_components(config.cluster_components, discovered)
-    data = merged.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    return create_krkn_ai_template(kubeconfig, data)
+    config.cluster_components = merged
+    data = config.model_dump(
+        mode="json", by_alias=True, warnings="none", exclude_none=True
+    )
+    # dump components like a fresh write
+    data["cluster_components"] = merged.model_dump(
+        mode="json", warnings="none", exclude_defaults=True
+    )
+    return yaml.dump(
+        data, default_flow_style=False, sort_keys=False, allow_unicode=True
+    )
 
 
 def _write_fresh(output: str, components: ClusterComponents, kubeconfig: str):

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -166,7 +166,6 @@ def _build_merged_config(
         )
         return None
     merged = merge_components(config.cluster_components, discovered)
-    config.cluster_components = merged
     data = config.model_dump(
         mode="json", by_alias=True, warnings="none", exclude_none=True
     )
@@ -179,10 +178,15 @@ def _build_merged_config(
     )
 
 
-def _write_fresh(output: str, components: ClusterComponents, kubeconfig: str):
+def _write_fresh(
+    output: str,
+    components: ClusterComponents,
+    kubeconfig: str,
+    dynamic: dict = None,
+):
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    template = create_krkn_ai_template(kubeconfig, data)
+    template = create_krkn_ai_template(kubeconfig, data, dynamic)
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
     logger.info("Saved component configuration to %s", output)
@@ -193,8 +197,14 @@ def save_discovery(
     strategy: str,
     components: ClusterComponents,
     kubeconfig: str,
+    dynamic: dict = None,
 ):
-    """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
+    """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new).
+
+    ``dynamic`` carries discovery-derived values (e.g. recommended scenarios)
+    and is applied only to fresh writes. The merge-of-an-existing-file path
+    preserves the user's edits and ignores it.
+    """
     strategy = strategy.lower()
     exists = os.path.exists(output)
 
@@ -218,4 +228,4 @@ def save_discovery(
     if exists and strategy == "overwrite":
         logger.warning("Overwriting existing %s", output)
 
-    _write_fresh(output, components, kubeconfig)
+    _write_fresh(output, components, kubeconfig, dynamic)

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -199,12 +199,7 @@ def save_discovery(
     kubeconfig: str,
     dynamic: dict = None,
 ):
-    """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new).
-
-    ``dynamic`` carries discovery-derived values (e.g. recommended scenarios)
-    and is applied only to fresh writes. The merge-of-an-existing-file path
-    preserves the user's edits and ignores it.
-    """
+    """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
     strategy = strategy.lower()
     exists = os.path.exists(output)
 

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -5,6 +5,9 @@ CLI command tests
 import os
 import tempfile
 from unittest.mock import Mock, patch
+
+import pytest
+import yaml
 from click.testing import CliRunner
 from pydantic import ValidationError
 
@@ -419,68 +422,96 @@ class TestDiscoverCommand:
         finally:
             os.unlink(kubeconfig_path)
 
-    def test_discover_threads_recommended_scenarios(
-        self, mock_cluster_components, temp_output_dir
+    @pytest.mark.parametrize(
+        "strategy, file_exists, expect_recommend_calls",
+        [
+            ("skip", False, 1),  # new file
+            ("skip", True, 0),  # existing
+            ("overwrite", False, 1),  # no file
+            ("overwrite", True, 1),  # always writes fresh
+            ("merge", False, 1),  # nothing to merge
+            ("merge", True, 0),  # merge preserves existing
+        ],
+    )
+    def test_discover_recommends_only_on_fresh_write(
+        self,
+        strategy,
+        file_exists,
+        expect_recommend_calls,
+        mock_cluster_components,
+        temp_output_dir,
     ):
-        """discover computes recommended scenarios and threads them as dynamic."""
+        """recommend runs only when discover writes a fresh config."""
         runner = CliRunner()
+        output_file = os.path.join(temp_output_dir, "output.yaml")
+        if file_exists:
+            with open(output_file, "w") as f:
+                f.write("existing: true\n")
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             f.write("apiVersion: v1\nkind: Config")
             kubeconfig_path = f.name
 
         try:
-            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
-                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
-                    with patch(
-                        "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
-                        return_value={"pod-scenarios", "pvc-scenarios"},
-                    ) as mock_rec:
-                        mock_manager_class.return_value.discover_components.return_value = (
-                            mock_cluster_components
-                        )
-                        output_file = os.path.join(temp_output_dir, "output.yaml")
-                        result = runner.invoke(
-                            main, ["discover", "-k", kubeconfig_path, "-o", output_file]
-                        )
-
-                        assert result.exit_code == 0
-                        mock_rec.assert_called_once()
-                        assert mock_save.call_args.kwargs["dynamic"] == {
-                            "scenarios": {"pod-scenarios", "pvc-scenarios"}
-                        }
+            with (
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class,
+                patch("krkn_ai.cli.cmd.save_discovery"),
+                patch(
+                    "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                    return_value={"pod-scenarios"},
+                ) as mock_rec,
+            ):
+                mock_manager_class.return_value.discover_components.return_value = (
+                    mock_cluster_components
+                )
+                result = runner.invoke(
+                    main,
+                    [
+                        "discover",
+                        "-k",
+                        kubeconfig_path,
+                        "-o",
+                        output_file,
+                        "--save-strategy",
+                        strategy,
+                    ],
+                )
+                assert result.exit_code == 0
+                assert mock_rec.call_count == expect_recommend_calls
         finally:
             os.unlink(kubeconfig_path)
 
-    def test_discover_threads_none_when_no_recommendation(
+    def test_discover_writes_recommended_scenarios_to_file(
         self, mock_cluster_components, temp_output_dir
     ):
-        """When recommendation falls back (None), dynamic still carries None."""
+        """Fresh discover writes the recommended scenarios to the output file."""
         runner = CliRunner()
+        output_file = os.path.join(temp_output_dir, "output.yaml")
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             f.write("apiVersion: v1\nkind: Config")
             kubeconfig_path = f.name
 
         try:
-            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
-                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
-                    with patch(
-                        "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
-                        return_value=None,
-                    ):
-                        mock_manager_class.return_value.discover_components.return_value = (
-                            mock_cluster_components
-                        )
-                        output_file = os.path.join(temp_output_dir, "output.yaml")
-                        result = runner.invoke(
-                            main, ["discover", "-k", kubeconfig_path, "-o", output_file]
-                        )
+            with (
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class,
+                patch(
+                    "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                    return_value={"pvc-scenarios"},
+                ),
+            ):
+                mock_manager_class.return_value.discover_components.return_value = (
+                    mock_cluster_components
+                )
+                result = runner.invoke(
+                    main, ["discover", "-k", kubeconfig_path, "-o", output_file]
+                )
 
-                        assert result.exit_code == 0
-                        assert mock_save.call_args.kwargs["dynamic"] == {
-                            "scenarios": None
-                        }
+                assert result.exit_code == 0
+                data = yaml.safe_load(open(output_file))
+                # recommended scenario enabled; an unrecommended one stays off
+                assert data["scenario"]["pvc-scenarios"]["enable"] is True
+                assert data["scenario"]["pod-scenarios"]["enable"] is False
         finally:
             os.unlink(kubeconfig_path)
 

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -458,7 +458,7 @@ class TestDiscoverCommand:
                 patch("krkn_ai.cli.cmd.save_discovery"),
                 patch(
                     "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
-                    return_value={"pod-scenarios"},
+                    return_value={"pod_scenarios": True, "pvc_scenarios": False},
                 ) as mock_rec,
             ):
                 mock_manager_class.return_value.discover_components.return_value = (
@@ -497,7 +497,10 @@ class TestDiscoverCommand:
                 patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class,
                 patch(
                     "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
-                    return_value={"pvc-scenarios"},
+                    return_value={
+                        "pvc_scenarios": True,
+                        "pod_scenarios": False,
+                    },
                 ),
             ):
                 mock_manager_class.return_value.discover_components.return_value = (

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -419,6 +419,71 @@ class TestDiscoverCommand:
         finally:
             os.unlink(kubeconfig_path)
 
+    def test_discover_threads_recommended_scenarios(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """discover computes recommended scenarios and threads them as dynamic."""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
+                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
+                    with patch(
+                        "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                        return_value={"pod-scenarios", "pvc-scenarios"},
+                    ) as mock_rec:
+                        mock_manager_class.return_value.discover_components.return_value = (
+                            mock_cluster_components
+                        )
+                        output_file = os.path.join(temp_output_dir, "output.yaml")
+                        result = runner.invoke(
+                            main, ["discover", "-k", kubeconfig_path, "-o", output_file]
+                        )
+
+                        assert result.exit_code == 0
+                        mock_rec.assert_called_once()
+                        assert mock_save.call_args.kwargs["dynamic"] == {
+                            "scenarios": {"pod-scenarios", "pvc-scenarios"}
+                        }
+        finally:
+            os.unlink(kubeconfig_path)
+
+    def test_discover_threads_none_when_no_recommendation(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """When recommendation falls back (None), dynamic still carries None."""
+        runner = CliRunner()
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class:
+                with patch("krkn_ai.cli.cmd.save_discovery") as mock_save:
+                    with patch(
+                        "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                        return_value=None,
+                    ):
+                        mock_manager_class.return_value.discover_components.return_value = (
+                            mock_cluster_components
+                        )
+                        output_file = os.path.join(temp_output_dir, "output.yaml")
+                        result = runner.invoke(
+                            main, ["discover", "-k", kubeconfig_path, "-o", output_file]
+                        )
+
+                        assert result.exit_code == 0
+                        assert mock_save.call_args.kwargs["dynamic"] == {
+                            "scenarios": None
+                        }
+        finally:
+            os.unlink(kubeconfig_path)
+
     def test_discover_rejects_invalid_strategy(self):
         """An unknown --save-strategy value is rejected by click."""
         runner = CliRunner()

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -125,20 +125,8 @@ class TestRecommendEnabledScenarios:
     """Test ScenarioFactory.recommend_enabled_scenarios"""
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
-    def test_returns_hyphenated_set_for_populated_cluster(self, _mock_init):
-        """A populated cluster yields a non-empty set of template (hyphen) keys."""
-        cluster = ClusterComponents(
-            namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
-            nodes=[Node(name="n1")],
-        )
-        result = ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
-        assert isinstance(result, set) and result
-        # Keys are template aliases (hyphenated), not factory field names.
-        assert all("_" not in key for key in result)
-
-    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_node_scenarios_depend_on_nodes(self, _mock_init):
-        """Node-hog scenarios are recommended only when nodes are present."""
+        """Node scenarios are recommended only with nodes."""
         with_nodes = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(
                 namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
@@ -157,7 +145,7 @@ class TestRecommendEnabledScenarios:
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_namespace_scenarios_depend_on_pods(self, _mock_init):
-        """Namespace/pod scenarios (e.g. dns-outage) need a namespace with pods."""
+        """Pod scenarios are recommended only with pods."""
         with_pods = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(
                 namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
@@ -173,7 +161,7 @@ class TestRecommendEnabledScenarios:
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_returns_none_for_empty_cluster(self, _mock_init):
-        """No components -> nothing validates -> None (fall back to static)."""
+        """Empty cluster returns None."""
         result = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(), "/tmp/kubeconfig"
         )
@@ -181,22 +169,10 @@ class TestRecommendEnabledScenarios:
 
     @patch(
         "krkn_ai.models.scenario.factory.ScenarioFactory.generate_valid_scenarios",
-        side_effect=MissingScenarioError("none"),
-    )
-    def test_returns_none_on_missing_scenario_error(self, _mock_gen):
-        """MissingScenarioError is treated as a soft fallback, not a crash."""
-        cluster = ClusterComponents(namespaces=[Namespace(name="shop")])
-        assert (
-            ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
-            is None
-        )
-
-    @patch(
-        "krkn_ai.models.scenario.factory.ScenarioFactory.generate_valid_scenarios",
         side_effect=RuntimeError("boom"),
     )
     def test_returns_none_on_unexpected_error(self, _mock_gen):
-        """Any unexpected error must not break discovery; fall back to static."""
+        """Errors fall back to None instead of raising."""
         cluster = ClusterComponents(namespaces=[Namespace(name="shop")])
         assert (
             ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -6,7 +6,12 @@ import pytest
 from unittest.mock import patch
 from krkn_ai.models.scenario.factory import ScenarioFactory
 from krkn_ai.models.config import ConfigFile, FitnessFunction, ScenarioConfig
-from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.cluster_components import (
+    ClusterComponents,
+    Namespace,
+    Pod,
+    Node,
+)
 from krkn_ai.models.custom_errors import MissingScenarioError, ScenarioInitError
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 
@@ -114,3 +119,86 @@ class TestScenarioFactory:
         scenario = ScenarioFactory.create_dummy_scenario()
         assert isinstance(scenario, DummyScenario)
         assert scenario._cluster_components == ClusterComponents()
+
+
+class TestRecommendEnabledScenarios:
+    """Test ScenarioFactory.recommend_enabled_scenarios"""
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_returns_hyphenated_set_for_populated_cluster(self, _mock_init):
+        """A populated cluster yields a non-empty set of template (hyphen) keys."""
+        cluster = ClusterComponents(
+            namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
+            nodes=[Node(name="n1")],
+        )
+        result = ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
+        assert isinstance(result, set) and result
+        # Keys are template aliases (hyphenated), not factory field names.
+        assert all("_" not in key for key in result)
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_node_scenarios_depend_on_nodes(self, _mock_init):
+        """Node-hog scenarios are recommended only when nodes are present."""
+        with_nodes = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(
+                namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
+                nodes=[Node(name="n1")],
+            ),
+            "/tmp/kubeconfig",
+        )
+        without_nodes = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(
+                namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])]
+            ),
+            "/tmp/kubeconfig",
+        )
+        assert "node-cpu-hog" in with_nodes
+        assert "node-cpu-hog" not in without_nodes
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_namespace_scenarios_depend_on_pods(self, _mock_init):
+        """Namespace/pod scenarios (e.g. dns-outage) need a namespace with pods."""
+        with_pods = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(
+                namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
+                nodes=[Node(name="n1")],
+            ),
+            "/tmp/kubeconfig",
+        )
+        nodes_only = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(nodes=[Node(name="n1")]), "/tmp/kubeconfig"
+        )
+        assert "dns-outage" in with_pods
+        assert "dns-outage" not in nodes_only
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_returns_none_for_empty_cluster(self, _mock_init):
+        """No components -> nothing validates -> None (fall back to static)."""
+        result = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(), "/tmp/kubeconfig"
+        )
+        assert result is None
+
+    @patch(
+        "krkn_ai.models.scenario.factory.ScenarioFactory.generate_valid_scenarios",
+        side_effect=MissingScenarioError("none"),
+    )
+    def test_returns_none_on_missing_scenario_error(self, _mock_gen):
+        """MissingScenarioError is treated as a soft fallback, not a crash."""
+        cluster = ClusterComponents(namespaces=[Namespace(name="shop")])
+        assert (
+            ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
+            is None
+        )
+
+    @patch(
+        "krkn_ai.models.scenario.factory.ScenarioFactory.generate_valid_scenarios",
+        side_effect=RuntimeError("boom"),
+    )
+    def test_returns_none_on_unexpected_error(self, _mock_gen):
+        """Any unexpected error must not break discovery; fall back to static."""
+        cluster = ClusterComponents(namespaces=[Namespace(name="shop")])
+        assert (
+            ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
+            is None
+        )

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -33,6 +33,36 @@ class TestScenarioFactory:
         assert len(candidates) == 1
         assert candidates[0][0] == "pod_scenarios"
 
+    def test_scenario_config_accepts_underscore_names(self):
+        """ScenarioConfig accepts underscore field names (populate_by_name)."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(pod_scenarios={"enable": True}),
+            cluster_components=cluster,
+        )
+        candidates = ScenarioFactory.list_scenarios(config)
+        assert len(candidates) == 1
+        assert candidates[0][0] == "pod_scenarios"
+
+    def test_scenario_config_accepts_both_naming_conventions(self):
+        """ScenarioConfig accepts hyphen and underscore names in the same call."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(
+                **{"pod-scenarios": {"enable": True}},
+                node_cpu_hog={"enable": True},
+            ),
+            cluster_components=cluster,
+        )
+        candidates = ScenarioFactory.list_scenarios(config)
+        names = {name for name, _ in candidates}
+        assert "pod_scenarios" in names
+        assert "node_cpu_hog" in names
+
     def test_list_scenarios_filters_out_disabled_scenarios(self):
         """Test that list_scenarios excludes disabled scenarios"""
         cluster = ClusterComponents(namespaces=[], nodes=[])
@@ -140,8 +170,8 @@ class TestRecommendEnabledScenarios:
             ),
             "/tmp/kubeconfig",
         )
-        assert "node-cpu-hog" in with_nodes
-        assert "node-cpu-hog" not in without_nodes
+        assert with_nodes["node_cpu_hog"] is True
+        assert without_nodes["node_cpu_hog"] is False
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_namespace_scenarios_depend_on_pods(self, _mock_init):
@@ -156,25 +186,25 @@ class TestRecommendEnabledScenarios:
         nodes_only = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(nodes=[Node(name="n1")]), "/tmp/kubeconfig"
         )
-        assert "dns-outage" in with_pods
-        assert "dns-outage" not in nodes_only
+        assert with_pods["dns_outage"] is True
+        assert nodes_only["dns_outage"] is False
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
-    def test_returns_none_for_empty_cluster(self, _mock_init):
-        """Empty cluster returns None."""
+    def test_all_disabled_for_empty_cluster(self, _mock_init):
+        """Empty cluster disables all scenarios."""
         result = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(), "/tmp/kubeconfig"
         )
-        assert result is None
+        assert isinstance(result, dict)
+        assert not any(result.values())
 
     @patch(
         "krkn_ai.models.scenario.factory.ScenarioFactory.generate_valid_scenarios",
         side_effect=RuntimeError("boom"),
     )
-    def test_returns_none_on_unexpected_error(self, _mock_gen):
-        """Errors fall back to None instead of raising."""
+    def test_all_disabled_on_unexpected_error(self, _mock_gen):
+        """Errors return all-disabled dict instead of raising."""
         cluster = ClusterComponents(namespaces=[Namespace(name="shop")])
-        assert (
-            ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
-            is None
-        )
+        result = ScenarioFactory.recommend_enabled_scenarios(cluster, "/tmp/kubeconfig")
+        assert isinstance(result, dict)
+        assert not any(result.values())

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -2,13 +2,12 @@
 
 import yaml
 
-from krkn_ai.templates.generator import (
-    create_krkn_ai_template,
-    STATIC_SCENARIO_ENABLES,
-)
+from krkn_ai.templates.generator import create_krkn_ai_template
+from krkn_ai.models.scenario.factory import scenario_specs
 
 KUBECONFIG = "/tmp/kubeconfig"
 DATA: dict = {"namespaces": []}
+ALL_NAMES = [name for name, _ in scenario_specs]
 
 
 def _scenario_block(rendered: str) -> dict:
@@ -18,45 +17,39 @@ def _scenario_block(rendered: str) -> dict:
 
 
 class TestScenarioRendering:
-    def test_none_falls_back_to_static_defaults(self):
-        """dynamic=None renders the static defaults."""
+    def test_none_falls_back_to_all_disabled(self):
+        """scenario_enables=None renders all scenarios disabled."""
         rendered = create_krkn_ai_template(KUBECONFIG, DATA, None)
         enables = _scenario_block(rendered)
-        expected = {k: (v == "true") for k, v in STATIC_SCENARIO_ENABLES.items()}
-        assert enables == expected
-        # spot-check a couple of defaults
-        assert enables["pod-scenarios"] is True
-        assert enables["dns-outage"] is True
-        assert enables["pvc-scenarios"] is False
+        assert not any(enables.values())
 
-    def test_no_dynamic_arg_matches_none(self):
-        """Omitting dynamic matches dynamic=None."""
+    def test_no_arg_matches_none(self):
+        """Omitting scenario_enables matches None."""
         assert create_krkn_ai_template(KUBECONFIG, DATA) == create_krkn_ai_template(
             KUBECONFIG, DATA, None
         )
 
-    def test_set_enables_only_listed_scenarios(self):
-        """A set enables exactly the listed scenarios."""
-        rendered = create_krkn_ai_template(
-            KUBECONFIG, DATA, {"scenarios": {"pvc-scenarios", "node-cpu-hog"}}
-        )
+    def test_dict_enables_only_true_scenarios(self):
+        """A dict enables exactly the True scenarios."""
+        enables_dict = {n: n in {"pvc_scenarios", "node_cpu_hog"} for n in ALL_NAMES}
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, enables_dict)
         enables = _scenario_block(rendered)
         assert enables["pvc-scenarios"] is True
         assert enables["node-cpu-hog"] is True
         assert enables["pod-scenarios"] is False
         assert sum(enables.values()) == 2
 
-    def test_empty_set_disables_all(self):
-        """An empty set disables every scenario."""
-        rendered = create_krkn_ai_template(KUBECONFIG, DATA, {"scenarios": set()})
+    def test_all_false_disables_all(self):
+        """All-false dict disables every scenario."""
+        enables_dict = {n: False for n in ALL_NAMES}
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, enables_dict)
         enables = _scenario_block(rendered)
         assert not any(enables.values())
 
     def test_rendered_output_is_valid_yaml_and_lowercase(self):
         """Booleans render lowercase and output is valid YAML."""
-        rendered = create_krkn_ai_template(
-            KUBECONFIG, DATA, {"scenarios": {"pod-scenarios"}}
-        )
+        enables_dict = {n: n == "pod_scenarios" for n in ALL_NAMES}
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, enables_dict)
         assert "enable: true" in rendered
         assert "enable: True" not in rendered
         yaml.safe_load(rendered)  # does not raise

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -1,0 +1,62 @@
+"""Tests for templates/generator.py scenario rendering."""
+
+import yaml
+
+from krkn_ai.templates.generator import (
+    create_krkn_ai_template,
+    STATIC_SCENARIO_ENABLES,
+)
+
+KUBECONFIG = "/tmp/kubeconfig"
+DATA: dict = {"namespaces": []}
+
+
+def _scenario_block(rendered: str) -> dict:
+    """Return the {scenario: enable} mapping from rendered YAML."""
+    doc = yaml.safe_load(rendered)
+    return {k: v["enable"] for k, v in doc["scenario"].items()}
+
+
+class TestScenarioRendering:
+    def test_none_falls_back_to_static_defaults(self):
+        """dynamic=None renders the static defaults."""
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None)
+        enables = _scenario_block(rendered)
+        expected = {k: (v == "true") for k, v in STATIC_SCENARIO_ENABLES.items()}
+        assert enables == expected
+        # spot-check a couple of defaults
+        assert enables["pod-scenarios"] is True
+        assert enables["dns-outage"] is True
+        assert enables["pvc-scenarios"] is False
+
+    def test_no_dynamic_arg_matches_none(self):
+        """Omitting dynamic matches dynamic=None."""
+        assert create_krkn_ai_template(KUBECONFIG, DATA) == create_krkn_ai_template(
+            KUBECONFIG, DATA, None
+        )
+
+    def test_set_enables_only_listed_scenarios(self):
+        """A set enables exactly the listed scenarios."""
+        rendered = create_krkn_ai_template(
+            KUBECONFIG, DATA, {"scenarios": {"pvc-scenarios", "node-cpu-hog"}}
+        )
+        enables = _scenario_block(rendered)
+        assert enables["pvc-scenarios"] is True
+        assert enables["node-cpu-hog"] is True
+        assert enables["pod-scenarios"] is False
+        assert sum(enables.values()) == 2
+
+    def test_empty_set_disables_all(self):
+        """An empty set disables every scenario."""
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, {"scenarios": set()})
+        enables = _scenario_block(rendered)
+        assert not any(enables.values())
+
+    def test_rendered_output_is_valid_yaml_and_lowercase(self):
+        """Booleans render lowercase and output is valid YAML."""
+        rendered = create_krkn_ai_template(
+            KUBECONFIG, DATA, {"scenarios": {"pod-scenarios"}}
+        )
+        assert "enable: true" in rendered
+        assert "enable: True" not in rendered
+        yaml.safe_load(rendered)  # does not raise

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -341,6 +341,49 @@ class TestSaveDiscovery:
         names = [n["name"] for n in data["cluster_components"]["namespaces"]]
         assert "shop" in names
 
+    def test_overwrite_applies_dynamic_scenarios(self, tmp_path):
+        """Overwrite applies dynamic scenario enables."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        with open(path, "w") as f:
+            f.write("original: true\n")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(
+            path,
+            "overwrite",
+            components,
+            KUBECONFIG,
+            dynamic={"scenarios": {"pvc-scenarios"}},
+        )
+        data = yaml.safe_load(open(path))
+        assert data["scenario"]["pvc-scenarios"]["enable"] is True
+        assert data["scenario"]["pod-scenarios"]["enable"] is False
+
+    def test_overwrite_without_dynamic_uses_static_defaults(self, tmp_path):
+        """No dynamic keeps the static enables."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        save_discovery(path, "overwrite", components, KUBECONFIG)
+        data = yaml.safe_load(open(path))
+        assert data["scenario"]["pod-scenarios"]["enable"] is True
+        assert data["scenario"]["pvc-scenarios"]["enable"] is False
+
+    def test_merge_existing_ignores_dynamic_scenarios(self, tmp_path):
+        """Merge keeps the user's scenario flags."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        _write_existing(path, ClusterComponents(namespaces=[Namespace(name="shop")]))
+        discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
+        # merge keeps the existing flag, not the dynamic one
+        save_discovery(
+            path,
+            "merge",
+            discovered,
+            KUBECONFIG,
+            dynamic={"scenarios": {"pvc-scenarios"}},
+        )
+        data = yaml.safe_load(open(path))
+        assert data["scenario"]["pvc-scenarios"]["enable"] is False
+        assert data["scenario"]["pod-scenarios"]["enable"] is True
+
     def test_strategy_is_case_insensitive(self, tmp_path):
         """Strategy matching ignores case (e.g. SKIP behaves like skip)."""
         path = str(tmp_path / "krkn-ai.yaml")

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -262,6 +262,33 @@ class TestSaveDiscovery:
         names = [n["name"] for n in data["cluster_components"]["namespaces"]]
         assert "pay" in names
 
+    def test_merge_preserves_non_component_edits(self, tmp_path):
+        """Merge keeps non-component edits."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        existing = ClusterComponents(namespaces=[Namespace(name="shop")])
+        _write_existing(path, existing)
+        # edit a few non-component fields
+        doc = yaml.safe_load(open(path))
+        doc["generations"] = 50
+        doc["population_size"] = 30
+        doc["fitness_function"]["query"] = "sum(my_custom_metric)"
+        doc["scenario"]["pvc-scenarios"]["enable"] = True
+        with open(path, "w") as f:
+            yaml.safe_dump(doc, f)
+
+        discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+
+        result = yaml.safe_load(open(path))
+        # edits survived
+        assert result["generations"] == 50
+        assert result["population_size"] == 30
+        assert result["fitness_function"]["query"] == "sum(my_custom_metric)"
+        assert result["scenario"]["pvc-scenarios"]["enable"] is True
+        # new component added
+        names = [n["name"] for n in result["cluster_components"]["namespaces"]]
+        assert "pay" in names and "shop" in names
+
     def test_merge_safe_to_repeat(self, tmp_path):
         """Running merge twice produces the same result."""
         path = str(tmp_path / "krkn-ai.yaml")

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -360,48 +360,53 @@ class TestSaveDiscovery:
         names = [n["name"] for n in data["cluster_components"]["namespaces"]]
         assert "shop" in names
 
-    def test_overwrite_applies_dynamic_scenarios(self, tmp_path):
-        """Overwrite applies dynamic scenario enables."""
+    def test_overwrite_applies_scenario_enables(self, tmp_path):
+        """Overwrite applies scenario enables."""
         path = str(tmp_path / "krkn-ai.yaml")
         with open(path, "w") as f:
             f.write("original: true\n")
         components = ClusterComponents(namespaces=[Namespace(name="shop")])
+        from krkn_ai.models.scenario.factory import scenario_specs
+
+        enables = {n: n == "pvc_scenarios" for n, _ in scenario_specs}
         save_discovery(
             path,
             "overwrite",
             components,
             KUBECONFIG,
-            dynamic={"scenarios": {"pvc-scenarios"}},
+            scenario_enables=enables,
         )
         data = yaml.safe_load(open(path))
         assert data["scenario"]["pvc-scenarios"]["enable"] is True
         assert data["scenario"]["pod-scenarios"]["enable"] is False
 
-    def test_overwrite_without_dynamic_uses_static_defaults(self, tmp_path):
-        """No dynamic keeps the static enables."""
+    def test_overwrite_without_enables_disables_all(self, tmp_path):
+        """No scenario_enables disables all scenarios."""
         path = str(tmp_path / "krkn-ai.yaml")
         components = ClusterComponents(namespaces=[Namespace(name="shop")])
         save_discovery(path, "overwrite", components, KUBECONFIG)
         data = yaml.safe_load(open(path))
-        assert data["scenario"]["pod-scenarios"]["enable"] is True
+        assert data["scenario"]["pod-scenarios"]["enable"] is False
         assert data["scenario"]["pvc-scenarios"]["enable"] is False
 
-    def test_merge_existing_ignores_dynamic_scenarios(self, tmp_path):
+    def test_merge_existing_ignores_scenario_enables(self, tmp_path):
         """Merge keeps the user's scenario flags."""
         path = str(tmp_path / "krkn-ai.yaml")
         _write_existing(path, ClusterComponents(namespaces=[Namespace(name="shop")]))
         discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
-        # merge keeps the existing flag, not the dynamic one
+        from krkn_ai.models.scenario.factory import scenario_specs
+
+        enables = {n: n == "pvc_scenarios" for n, _ in scenario_specs}
         save_discovery(
             path,
             "merge",
             discovered,
             KUBECONFIG,
-            dynamic={"scenarios": {"pvc-scenarios"}},
+            scenario_enables=enables,
         )
         data = yaml.safe_load(open(path))
         assert data["scenario"]["pvc-scenarios"]["enable"] is False
-        assert data["scenario"]["pod-scenarios"]["enable"] is True
+        assert data["scenario"]["pod-scenarios"]["enable"] is False
 
     def test_strategy_is_case_insensitive(self, tmp_path):
         """Strategy matching ignores case (e.g. SKIP behaves like skip)."""

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -289,6 +289,25 @@ class TestSaveDiscovery:
         names = [n["name"] for n in result["cluster_components"]["namespaces"]]
         assert "pay" in names and "shop" in names
 
+    def test_merge_keeps_secrets_and_parameters(self, tmp_path):
+        """Merge keeps elastic.password and parameters."""
+        path = str(tmp_path / "krkn-ai.yaml")
+        _write_existing(path, ClusterComponents(namespaces=[Namespace(name="shop")]))
+        doc = yaml.safe_load(open(path))
+        doc["elastic"] = {"enable": True, "server": "https://es", "password": "s3cret"}
+        doc["parameters"] = {"TOKEN": {"value": "abc", "is_private": False}}
+        with open(path, "w") as f:
+            yaml.safe_dump(doc, f)
+
+        discovered = ClusterComponents(namespaces=[Namespace(name="pay")])
+        save_discovery(path, "merge", discovered, KUBECONFIG)
+
+        result = yaml.safe_load(open(path))
+        assert result["elastic"]["password"] == "s3cret"  # not dropped
+        assert result["parameters"]["TOKEN"]["value"] == "abc"  # not collapsed
+        names = [n["name"] for n in result["cluster_components"]["namespaces"]]
+        assert "pay" in names and "shop" in names
+
     def test_merge_safe_to_repeat(self, tmp_path):
         """Running merge twice produces the same result."""
         path = str(tmp_path / "krkn-ai.yaml")


### PR DESCRIPTION
## Description
This PR introduces two things:
1. Fixes `--save-strategy merge` , it now keeps more than just `cluster_components`, i.e. scenario flags, fitness function, GA params etc.
2. Advances the scenario flags from being static to now being dynamic (enabled based on what's actually in the cluster, with fallback to the old static defaults).

Recommendation only runs on fresh writes (new file / overwrite) not on skip/merge.
Docs are a follow up PR.

Week 3,4 #364 

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
Added unit tests for the recommend logic, generator, save_discovery (merge + dynamic), and the discover CLI. All 424 unit tests pass locally.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors