### PR TITLE
fix: include dependency in CompositeScenario identity (#380)

### DIFF
--- a/krkn_ai/models/scenario/base.py
+++ b/krkn_ai/models/scenario/base.py
@@ -77,4 +77,6 @@ class CompositeScenario(BaseScenario):
         return self.name == other.name and hash(other) == hash(self)
 
     def __hash__(self):
-        return hash(tuple([self.scenario_a, self.scenario_b]))
+        # `dependency` changes the execution graph, so it is part of identity.
+        # __eq__ derives from this hash, so including it here fixes both. See #380.
+        return hash((self.scenario_a, self.scenario_b, self.dependency))

--- a/tests/unit/models/scenario/test_base_scenario.py
+++ b/tests/unit/models/scenario/test_base_scenario.py
@@ -126,8 +126,8 @@ class TestCompositeScenario:
         assert composite1 == composite1
         assert composite1 != "not-a-composite"
 
-        # Test hash: different dependencies but same scenarios should have same hash
-        assert hash(composite1) == hash(composite2)
+        # Different dependency changes the execution graph, so identity must differ (#380)
+        assert hash(composite1) != hash(composite2)
         # Different scenario order should have different hash
         assert hash(composite1) != hash(composite3)
 

--- a/tests/unit/models/scenario/test_composite_scenario_identity.py
+++ b/tests/unit/models/scenario/test_composite_scenario_identity.py
@@ -1,0 +1,48 @@
+"""Regression tests for #380.
+
+`CompositeScenario` identity must include the ``dependency`` field. Two
+composites with the same children but a different dependency execute as
+different graphs (`KrknRunner.__expand_composite_json`), so they must not
+collide as the same hash/equality key — otherwise the GA fitness cache
+(`GeneticAlgorithm.seen_population`, keyed by scenario) returns the wrong
+scenario's cached result.
+"""
+
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
+from krkn_ai.models.scenario.base import CompositeScenario, CompositeDependency
+
+
+def _pair():
+    cluster = ClusterComponents(namespaces=[], nodes=[])
+    a = DummyScenario(cluster_components=cluster)
+    b = DummyScenario(cluster_components=cluster)
+    none = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
+    a_on_b = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.A_ON_B)
+    return none, a_on_b
+
+
+def test_different_dependency_not_equal():
+    none, a_on_b = _pair()
+    assert none != a_on_b
+
+
+def test_different_dependency_distinct_hash():
+    none, a_on_b = _pair()
+    assert hash(none) != hash(a_on_b)
+
+
+def test_different_dependency_distinct_cache_keys():
+    none, a_on_b = _pair()
+    cache = {none: "result_for_NONE"}
+    assert a_on_b not in cache
+
+
+def test_same_dependency_still_collides():
+    cluster = ClusterComponents(namespaces=[], nodes=[])
+    a = DummyScenario(cluster_components=cluster)
+    b = DummyScenario(cluster_components=cluster)
+    c1 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
+    c2 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
+    assert c1 == c2
+    assert hash(c1) == hash(c2)

--- a/tests/unit/models/scenario/test_composite_scenario_identity.py
+++ b/tests/unit/models/scenario/test_composite_scenario_identity.py
@@ -17,8 +17,18 @@ def _pair():
     cluster = ClusterComponents(namespaces=[], nodes=[])
     a = DummyScenario(cluster_components=cluster)
     b = DummyScenario(cluster_components=cluster)
-    none = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
-    a_on_b = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.A_ON_B)
+    none = CompositeScenario(
+        name="composite",
+        scenario_a=a,
+        scenario_b=b,
+        dependency=CompositeDependency.NONE,
+    )
+    a_on_b = CompositeScenario(
+        name="composite",
+        scenario_a=a,
+        scenario_b=b,
+        dependency=CompositeDependency.A_ON_B,
+    )
     return none, a_on_b
 
 
@@ -42,7 +52,17 @@ def test_same_dependency_still_collides():
     cluster = ClusterComponents(namespaces=[], nodes=[])
     a = DummyScenario(cluster_components=cluster)
     b = DummyScenario(cluster_components=cluster)
-    c1 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
-    c2 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
+    c1 = CompositeScenario(
+        name="composite",
+        scenario_a=a,
+        scenario_b=b,
+        dependency=CompositeDependency.NONE,
+    )
+    c2 = CompositeScenario(
+        name="composite",
+        scenario_a=a,
+        scenario_b=b,
+        dependency=CompositeDependency.NONE,
+    )
     assert c1 == c2
     assert hash(c1) == hash(c2)


### PR DESCRIPTION
## What

`CompositeScenario.__hash__` hashes only `(scenario_a, scenario_b)`, and `__eq__` derives from that hash. So two composites with the **same children but a different `dependency`** (`NONE` / `A_ON_B` / `B_ON_A`) collide as the same key:

```python
c1 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.NONE)
c2 = CompositeScenario(name="composite", scenario_a=a, scenario_b=b, dependency=CompositeDependency.A_ON_B)
c1 == c2                       # True  (should be False)
c2 in {c1: "result_for_NONE"}  # True  -> returns the NONE result for the A_ON_B run
```

`dependency` changes what actually runs (`KrknRunner.__expand_composite_json` builds a different execution graph per dependency), and `GeneticAlgorithm.seen_population` caches fitness keyed by scenario. Because the key ignores `dependency`, the second variant is never run and the GA returns the first variant's fitness for a genuinely different experiment — corrupting fitness values and best-of-generation selection.

## Fix

Include `dependency` in `__hash__` (and therefore `__eq__`, which is derived from it).

## Tests

- New `tests/unit/models/scenario/test_composite_scenario_identity.py` covering: different dependency → not equal, distinct hash, distinct cache keys; and same dependency → still collides.
- Corrected `test_base_scenario.py::test_composite_scenario_equality_and_hash`, which previously asserted *"different dependencies but same scenarios should have same hash"* — i.e. it encoded the bug.

Relevant unit suite: **331 passed**. (`tests/unit/dashboard` is skipped here only because of an unrelated missing `bs4` dependency in my environment — it fails to collect on a clean checkout too, independent of this change.)

Closes #380
