### PR TITLE
chore: use centralized stale workflow from krkn-chaos/actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,44 +12,4 @@ permissions:
 
 jobs:
   stale:
-    concurrency:
-      group: stale-issues-prs
-      cancel-in-progress: true
-    name: Mark and Close Stale Issues and PRs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Mark and close stale issues and PRs
-        uses: actions/stale@v9
-        with:
-          days-before-issue-stale: 60
-          days-before-issue-close: 14
-          stale-issue-label: 'stale'
-          stale-issue-message: |
-            This issue has been automatically marked as stale because it has not had any activity in the last 60 days.
-            It will be closed in 14 days if no further activity occurs.
-            If this issue is still relevant, please leave a comment or remove the stale label.
-            Thank you for your contributions to krkn!
-          close-issue-message: |
-            This issue has been automatically closed due to inactivity.
-            If you believe this issue is still relevant, please feel free to reopen it or create a new issue with updated information.
-            Thank you for your understanding!
-          close-issue-reason: 'not_planned'
-
-          days-before-pr-stale: 90
-          days-before-pr-close: 14
-          stale-pr-label: 'stale'
-          stale-pr-message: |
-            This pull request has been automatically marked as stale because it has not had any activity in the last 90 days.
-            It will be closed in 14 days if no further activity occurs.
-            If this PR is still relevant, please rebase it, address any pending reviews, or leave a comment.
-            Thank you for your contributions to krkn!
-          close-pr-message: |
-            This pull request has been automatically closed due to inactivity.
-            If you believe this PR is still relevant, please feel free to reopen it or create a new pull request with updated changes.
-            Thank you for your understanding!
-
-          # Exempt labels
-          exempt-issue-labels: 'bug,help wanted,good first issue'
-          exempt-pr-labels: 'pending discussions,hold'
-
-          remove-stale-when-updated: true
+    uses: krkn-chaos/actions/.github/workflows/stale.yml@main


### PR DESCRIPTION
## Description
Swaps our local stale-issue/PR workflow for the shared one in krkn-chaos/actions, since that's where these are being centralized now. Functionally the same behavior, just calling out instead of duplicating the job definition. krkn, krkn-hub, krkn-dashboard, krkn-lib, and website have already made this same swap.

One label difference to flag: the central workflow exempts `enhancement` instead of `help wanted` for stale issues - going with whatever the central config has rather than carrying over our local override.

Closes #326

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Other: CI workflow change

## Testing
Diffed against the caller pattern used in the other krkn-chaos repos to confirm it matches. No local test since this only runs on GitHub's scheduler/workflow_dispatch - will verify it triggers correctly once merged.

Manually dispatched the workflow on this branch to confirm it resolves correctly:
https://github.com/Ayush-Patel-56/krkn-ai/actions/runs/28578077079 


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
