### PR TITLE
fix: pass Elasticsearch config to composite scenarios via graph node env

### DIFF
--- a/krkn_ai/chaos_engines/commands.py
+++ b/krkn_ai/chaos_engines/commands.py
@@ -1,5 +1,5 @@
 from krkn_ai.models.app import KrknRunnerType
-from krkn_ai.models.config import ConfigFile
+from krkn_ai.models.config import ConfigFile, ElasticConfig
 from krkn_ai.models.scenario.base import Scenario
 
 PODMAN_TEMPLATE = 'podman run -e PUBLISH_KRAKEN_STATUS="False" -e TELEMETRY_PROMETHEUS_BACKUP="False" -e WAIT_DURATION={wait_duration} {env_list} {{es_env_list}} --net=host -v {kubeconfig}:/home/krkn/.kube/config:Z {image}'
@@ -9,6 +9,19 @@ PODMAN_ES_TEMPLATE = ' -e ENABLE_ES="True" -e ES_SERVER="{server}" -e ES_PORT="{
 KRKNCTL_TEMPLATE = "krknctl run {name} --telemetry-prometheus-backup False --wait-duration {wait_duration} --kubeconfig {kubeconfig} {env_list} {{es_env_list}}"
 
 KRKNCTL_ES_TEMPLATE = ' --enable-es True --es-server "{server}" --es-port "{port}" --es-username "{username}" --es-password "{password}" --es-verify-certs "{verify_certs}" '
+
+
+def es_env_vars(elastic: ElasticConfig) -> dict[str, str]:
+    # krknctl graph run accepts no ES flags, so composite scenario nodes receive the
+    # ES settings through their env block. Names match PODMAN_ES_TEMPLATE.
+    return {
+        "ENABLE_ES": "True",
+        "ES_SERVER": elastic.server,
+        "ES_PORT": str(elastic.port),
+        "ES_USERNAME": elastic.username,
+        "ES_PASSWORD": elastic.password,
+        "ES_VERIFY_CERTS": str(elastic.verify_certs),
+    }
 
 
 def build_scenario_command(

--- a/krkn_ai/chaos_engines/composite.py
+++ b/krkn_ai/chaos_engines/composite.py
@@ -2,6 +2,8 @@ import json
 import os
 import tempfile
 
+from krkn_ai.chaos_engines.commands import es_env_vars
+from krkn_ai.models.config import ElasticConfig
 from krkn_ai.models.scenario.base import (
     Scenario,
     CompositeDependency,
@@ -16,12 +18,15 @@ KRKNCTL_GRAPH_RUN_TEMPLATE = "krknctl graph run {path} --kubeconfig {kubeconfig}
 
 
 def build_graph_command(
-    scenario: CompositeScenario, kubeconfig_path: str, output_dir: str
+    scenario: CompositeScenario,
+    kubeconfig_path: str,
+    output_dir: str,
+    elastic: ElasticConfig | None = None,
 ) -> str:
     graph_json_directory = os.path.join(output_dir, "graphs")
     os.makedirs(graph_json_directory, exist_ok=True)
 
-    scenario_json = _expand_composite_json(scenario)
+    scenario_json = _expand_composite_json(scenario, elastic=elastic)
     with tempfile.NamedTemporaryFile(
         suffix=".json",
         dir=graph_json_directory,
@@ -41,7 +46,10 @@ def build_graph_command(
 
 
 def _expand_composite_json(
-    scenario: CompositeScenario, root: str = "$", depends_on: str = None
+    scenario: CompositeScenario,
+    root: str = "$",
+    depends_on: str = None,
+    elastic: ElasticConfig | None = None,
 ):
     result = {}
     scenario_a = scenario.scenario_a
@@ -53,7 +61,9 @@ def _expand_composite_json(
 
     if scenario.dependency == CompositeDependency.NONE:
         result[key_root] = _generate_scenario_json(
-            ScenarioFactory.create_dummy_scenario(), depends_on=depends_on
+            ScenarioFactory.create_dummy_scenario(),
+            depends_on=depends_on,
+            elastic=elastic,
         )
 
     if isinstance(scenario_a, CompositeScenario):
@@ -65,7 +75,9 @@ def _expand_composite_json(
         elif scenario.dependency == CompositeDependency.NONE:
             key = key_root
 
-        result.update(_expand_composite_json(scenario_a, key_a, depends_on=key))
+        result.update(
+            _expand_composite_json(scenario_a, key_a, depends_on=key, elastic=elastic)
+        )
     elif isinstance(scenario_a, Scenario):
         key = None
         if scenario.dependency == CompositeDependency.A_ON_B:
@@ -78,6 +90,7 @@ def _expand_composite_json(
         result[key_a] = _generate_scenario_json(
             scenario_a,
             depends_on=key,
+            elastic=elastic,
         )
 
     if isinstance(scenario_b, CompositeScenario):
@@ -89,7 +102,9 @@ def _expand_composite_json(
         elif scenario.dependency == CompositeDependency.NONE:
             key = key_root
 
-        result.update(_expand_composite_json(scenario_b, key_b, depends_on=key))
+        result.update(
+            _expand_composite_json(scenario_b, key_b, depends_on=key, elastic=elastic)
+        )
     elif isinstance(scenario_b, Scenario):
         key = None
         if scenario.dependency == CompositeDependency.A_ON_B:
@@ -101,16 +116,23 @@ def _expand_composite_json(
         result[key_b] = _generate_scenario_json(
             scenario_b,
             depends_on=key,
+            elastic=elastic,
         )
 
     return result
 
 
-def _generate_scenario_json(scenario: Scenario, depends_on: str = None):
+def _generate_scenario_json(
+    scenario: Scenario,
+    depends_on: str = None,
+    elastic: ElasticConfig | None = None,
+):
     env = {
         param.get_name(return_krknhub_name=True): str(param.get_value())
         for param in scenario.parameters
     }
+    if elastic is not None and elastic.enable:
+        env.update(es_env_vars(elastic))
     result = {
         "image": scenario.krknhub_image,
         "name": scenario.krknctl_name,

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -193,5 +193,8 @@ class KrknRunner:
 
     def graph_command(self, scenario: CompositeScenario) -> str:
         return build_graph_command(
-            scenario, self.config.kubeconfig_file_path, self.output_dir
+            scenario,
+            self.config.kubeconfig_file_path,
+            self.output_dir,
+            self.config.elastic,
         )

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -2,6 +2,7 @@
 KrknRunner core functionality tests
 """
 
+import json
 import os
 import datetime
 import pytest
@@ -10,6 +11,7 @@ from unittest.mock import Mock, patch
 from krkn_ai.chaos_engines.krkn_runner import KrknRunner
 from krkn_ai.models.app import KrknRunnerType
 from krkn_ai.models.config import (
+    ElasticConfig,
     FitnessFunction,
     FitnessFunctionType,
     HealthCheckConfig,
@@ -213,3 +215,92 @@ class TestKrknRunnerCommandGeneration:
             assert os.path.exists(graph_dir)
             json_files = [f for f in os.listdir(graph_dir) if f.endswith(".json")]
             assert len(json_files) > 0
+
+
+class TestElasticsearchConfiguration:
+    """Test Elasticsearch settings reach both single and composite scenario runs"""
+
+    def _build_runner(self, config, output_dir):
+        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client"):
+            return KrknRunner(
+                config=config,
+                output_dir=output_dir,
+                runner_type=KrknRunnerType.CLI_RUNNER,
+            )
+
+    def _composite_scenario(self):
+        return CompositeScenario(
+            scenario_a=DummyScenario(cluster_components=ClusterComponents()),
+            scenario_b=DummyScenario(cluster_components=ClusterComponents()),
+            dependency=CompositeDependency.NONE,
+        )
+
+    def _load_graph_json(self, output_dir):
+        graph_dir = os.path.join(output_dir, "graphs")
+        json_files = [f for f in os.listdir(graph_dir) if f.endswith(".json")]
+        assert len(json_files) == 1
+        with open(os.path.join(graph_dir, json_files[0]), encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_es_flags_injected_into_single_scenario_command(
+        self, minimal_config, temp_output_dir
+    ):
+        """A single-scenario command carries the {es_env_list} placeholder, so the
+        ES flags are substituted into it."""
+        minimal_config.elastic = ElasticConfig(
+            enable=True, server="https://es.example.com"
+        )
+        runner = self._build_runner(minimal_config, temp_output_dir)
+
+        command = "krknctl run test --kubeconfig /tmp/kubeconfig {es_env_list}"
+        result = runner.process_es_env_string(command, True)
+
+        assert "{es_env_list}" not in result
+        # Prove the ES flags were actually injected, not blanked with an empty string
+        assert "--enable-es True" in result
+        assert '--es-server "https://es.example.com"' in result
+
+    def test_graph_json_includes_es_env_when_elastic_enabled(
+        self, minimal_config, temp_output_dir
+    ):
+        """krknctl graph run accepts no ES flags, so every scenario node in the
+        graph JSON must carry the ES settings as krknhub env vars."""
+        minimal_config.kubeconfig_file_path = "/tmp/kubeconfig"
+        minimal_config.elastic = ElasticConfig(
+            enable=True,
+            server="https://es.example.com",
+            port=9200,
+            username="elastic",
+            password="secret",
+            verify_certs=False,
+        )
+        runner = self._build_runner(minimal_config, temp_output_dir)
+
+        runner.graph_command(self._composite_scenario())
+
+        graph = self._load_graph_json(temp_output_dir)
+        assert graph
+        for node in graph.values():
+            env = node["env"]
+            assert env["ENABLE_ES"] == "True"
+            assert env["ES_SERVER"] == "https://es.example.com"
+            assert env["ES_PORT"] == "9200"
+            assert env["ES_USERNAME"] == "elastic"
+            assert env["ES_PASSWORD"] == "secret"
+            assert env["ES_VERIFY_CERTS"] == "False"
+
+    def test_graph_json_omits_es_env_when_elastic_disabled(
+        self, minimal_config, temp_output_dir
+    ):
+        """No ES settings should leak into the graph JSON when ES is disabled."""
+        minimal_config.kubeconfig_file_path = "/tmp/kubeconfig"
+        minimal_config.elastic = ElasticConfig(enable=False)
+        runner = self._build_runner(minimal_config, temp_output_dir)
+
+        runner.graph_command(self._composite_scenario())
+
+        graph = self._load_graph_json(temp_output_dir)
+        assert graph
+        for node in graph.values():
+            assert "ENABLE_ES" not in node["env"]
+            assert "ES_SERVER" not in node["env"]


### PR DESCRIPTION
### Description

Fixes #388.

When `elastic.enable` is set, single scenarios get the Elasticsearch settings injected into their run command, but composite (graph) scenarios never did. `process_es_env_string()` injects ES by replacing an `{es_env_list}` placeholder, and `KRKNCTL_GRAPH_RUN_TEMPLATE` has no such placeholder, so the replace was a no-op and the ES config was silently dropped.

`krknctl graph run` accepts only `--kubeconfig`, `--alerts-profile`, `--metrics-profile` and `--exit-on-error`, so there is no ES flag to pass on the command line. The scenario nodes in the graph JSON already carry an `env` dict in krknhub naming, the same naming `PODMAN_ES_TEMPLATE` uses. This PR puts the ES settings into each node's `env` when ES is enabled, so composite runs report telemetry the way single scenarios do.

An earlier revision of this PR only logged a warning, detected by checking for the placeholder string. That was dropped after review: the scenario type, not a magic string, is the reliable signal, and the real support is the better fix.

Notes for reviewers:

- Every node gets the ES env, including the dummy root node inserted for `CompositeDependency.NONE`. That matches single scenario runs, where the baseline dummy also runs with ES enabled.
- The graph JSON is written under the run output directory, so `ES_PASSWORD` is now present in that file. The single scenario path already places it in the command string. If persisting it on disk is a concern I can look at another approach, though krknctl does not appear to offer one for graph runs.

### Type of Change
- [x] Bug fix

### Testing

- `test_graph_json_includes_es_env_when_elastic_enabled`: builds a composite scenario, calls `graph_command`, and asserts every node in the generated JSON carries `ENABLE_ES`, `ES_SERVER`, `ES_PORT`, `ES_USERNAME`, `ES_PASSWORD` and `ES_VERIFY_CERTS`. Fails on the previous code with `KeyError: 'ENABLE_ES'`.
- `test_graph_json_omits_es_env_when_elastic_disabled`: asserts no ES keys appear when ES is disabled.
- `test_es_flags_injected_into_single_scenario_command`: asserts the single scenario path still substitutes the real ES flags rather than an empty string.

Full unit suite passes locally (436 passed). The three `tests/unit/cli/test_cmd.py` failures are a pre-existing Windows-only file handle issue and reproduce on a clean checkout. `ruff check`, `ruff format --check` and `mypy krkn_ai` are clean.

### Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
