### PR TITLE
fix: use raw strings for markdown legends in anomalies.py

### DIFF
--- a/krkn_ai/dashboard/tabs/anomalies.py
+++ b/krkn_ai/dashboard/tabs/anomalies.py
@@ -1321,7 +1321,7 @@ def render_anomalies(
 
     # Legend & Detection Methods
     if mode == MODE_ZSCORE:
-        legend_md = """
+        legend_md = r"""
 ### Z-Score Detection — How It Works
 
 For each metric **x** across *N* non-baseline runs:
@@ -1360,7 +1360,7 @@ Upper fence = Q3 + 1.5 × IQR
 *Duration uses RMS deviation: `σ_rms = √[ Σ(dᵢ − baseline)² / N ]` when a baseline is available; falls back to population σ otherwise.*
 """
     else:
-        legend_md = """
+        legend_md = r"""
 ### % Deviation from Baseline — How It Works
 
 For each value **x** and its baseline reference **b**:


### PR DESCRIPTION
## Description

This PR fixes the invalid escape sequence warnings caused by `\|` in the markdown legend strings in `krkn_ai/dashboard/tabs/anomalies.py`. 

The multiline markdown strings are changed to raw strings (`r"""..."""`) so the markdown renders as before while avoiding invalid escape sequence warnings.

Fixes #371

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

- Verified with:
  ```bash
  python -Wd -m py_compile krkn_ai/dashboard/tabs/anomalies.py
  ```
- No invalid escape sequence warnings were emitted.
- Pre-commit hooks passed.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
