### PR TITLE
config: handle partial elastic parameter defaults

### DIFF
--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -67,29 +67,17 @@ def read_config_from_file(
             if "url" in app:
                 app["url"] = preprocess_param_string(app["url"], raw)
 
-        # Replace parameter in elastic configuration
-        if "elastic" in config and "server" in config["elastic"]:
-            config["elastic"]["enable"] = is_truthy(
-                preprocess_param_string(config["elastic"]["enable"], raw)
-            )
-            config["elastic"]["verify_certs"] = is_truthy(
-                preprocess_param_string(config["elastic"]["verify_certs"], raw)
-            )
-            config["elastic"]["server"] = preprocess_param_string(
-                config["elastic"]["server"], raw
-            )
-            config["elastic"]["port"] = preprocess_param_string(
-                config["elastic"]["port"], raw
-            )
-            config["elastic"]["username"] = preprocess_param_string(
-                config["elastic"]["username"], raw
-            )
-            config["elastic"]["password"] = preprocess_param_string(
-                config["elastic"]["password"], raw
-            )
-            config["elastic"]["index"] = preprocess_param_string(
-                config["elastic"]["index"], raw
-            )
+        # Replace parameters in elastic configuration without forcing optional keys.
+        if isinstance(config.get("elastic"), dict):
+            bool_fields = {"enable", "verify_certs"}
+            for key, value in config["elastic"].items():
+                if isinstance(value, str):
+                    value = preprocess_param_string(value, raw)
+                config["elastic"][key] = (
+                    is_truthy(value)
+                    if key in bool_fields and value is not None
+                    else value
+                )
 
         config["parameters"] = params
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -124,6 +124,43 @@ class TestReadConfigFromFileHeaders:
         assert result.health_checks.headers is None
         assert result.health_checks.applications[0].headers is None
 
+    def test_partial_elastic_config_uses_defaults_with_params(self, tmp_path):
+        """Partial elastic config should not fail before Pydantic applies defaults."""
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "elastic": {"server": "https://$ES_HOST"},
+        }
+        config_file = str(tmp_path / "config.yaml")
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+
+        result = read_config_from_file(config_file, param=["ES_HOST=example.com"])
+
+        assert result.elastic.server == "https://example.com"
+        assert result.elastic.enable is False
+        assert result.elastic.port == 9200
+        assert result.elastic.verify_certs is True
+
+    def test_elastic_null_values_are_not_stringified_with_params(self, tmp_path):
+        """Explicit elastic nulls should remain null so validation catches them."""
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "elastic": {
+                "server": "https://$ES_HOST",
+                "username": None,
+            },
+        }
+        config_file = str(tmp_path / "config.yaml")
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+
+        with pytest.raises(ValidationError):
+            read_config_from_file(config_file, param=["ES_HOST=example.com"])
+
 
 class TestReadConfigValidation:
     def test_read_config_empty_file(self, tmp_path):


### PR DESCRIPTION
## Summary

- avoid direct indexing of optional Elasticsearch config keys during parameter preprocessing
- keep parameter substitution for keys that are present while allowing model defaults to fill omitted fields
- add regression coverage for partial `elastic:` config with `-p` substitution

Fixes #394

## Testing

- `uv run pytest tests/unit/utils/test_fs.py`
- `uv run pre-commit run --files krkn_ai/utils/fs.py tests/unit/utils/test_fs.py`