### PR TITLE
feat(discover): dynamic health check discovery

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -297,9 +297,16 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
+    # recommend only for overwrite, or when no file exists for other strategies
+    fresh_write = not os.path.exists(output) or save_strategy.lower() == "overwrite"
     scenario_enables = (
         ScenarioFactory.recommend_enabled_scenarios(cluster_components, kubeconfig)
-        if not os.path.exists(output) or save_strategy.lower() == "overwrite"
+        if fresh_write
+        else None
+    )
+    health_checks = (
+        cluster_manager.recommend_health_checks(cluster_components)
+        if fresh_write
         else None
     )
     save_discovery(
@@ -308,4 +315,5 @@ def discover(
         cluster_components,
         kubeconfig,
         scenario_enables=scenario_enables,
+        health_checks=health_checks,
     )

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -223,6 +223,102 @@ class ClusterManager:
         )
         return service_list
 
+    def recommend_health_checks(
+        self, cluster_components: ClusterComponents
+    ) -> List[Dict[str, str]]:
+        """Suggest health-check URLs for LoadBalancer services."""
+        try:
+            recommendations: List[Dict[str, str]] = []
+            for namespace in cluster_components.get_active_components().namespaces:
+                services = self.core_api.list_namespaced_service(
+                    namespace=namespace.name
+                ).items
+                pods = self.core_api.list_namespaced_pod(
+                    namespace=namespace.name, field_selector="status.phase=Running"
+                ).items
+
+                for svc in services:
+                    if svc.spec.type != "LoadBalancer" or not svc.spec.ports:
+                        continue
+                    address = self._external_address(svc)
+                    if address is None:
+                        continue
+
+                    probe, container = self._backing_probe(svc, pods)
+                    port, scheme, path = self._endpoint_from_probe(
+                        svc, probe, container
+                    )
+                    recommendations.append(
+                        {
+                            "name": svc.metadata.name,
+                            "url": f"{scheme}://{address}:{port}{path}",
+                        }
+                    )
+            return recommendations
+        except Exception as error:
+            # Never let this break discovery.
+            logger.debug("Health check recommendation failed: %s", error)
+            return []
+
+    @staticmethod
+    def _external_address(svc) -> Optional[str]:
+        # The LoadBalancer's external IP or hostname.
+        if not svc.status or not svc.status.load_balancer:
+            return None
+        for entry in svc.status.load_balancer.ingress or []:
+            if entry.ip or entry.hostname:
+                return entry.ip or entry.hostname
+        return None
+
+    def _backing_probe(self, svc, pods):
+        # Find the first httpGet probe on the pods behind this service.
+        selector = svc.spec.selector or {}
+        if not selector:
+            return None, None
+        for pod in pods:
+            labels = pod.metadata.labels or {}
+            if not all(labels.get(key) == value for key, value in selector.items()):
+                continue
+            for container in pod.spec.containers:
+                for probe in (container.readiness_probe, container.liveness_probe):
+                    if probe and probe.http_get:
+                        return probe.http_get, container
+        return None, None
+
+    @staticmethod
+    def _endpoint_from_probe(svc, probe, container):
+        # Match the probe's port to a service port; else the first port at root.
+        port = svc.spec.ports[0].port
+        path = "/"
+        scheme = None
+        probe_port = (
+            ClusterManager._resolve_port(probe.port, container)
+            if probe is not None
+            else None
+        )
+        if probe_port is not None:
+            for svc_port in svc.spec.ports:
+                target = svc_port.target_port
+                target = svc_port.port if target is None else target
+                if ClusterManager._resolve_port(target, container) == probe_port:
+                    port = svc_port.port
+                    path = probe.path or "/"
+                    scheme = (probe.scheme or "HTTP").lower()
+                    break
+        if scheme is None:
+            scheme = "https" if port in (443, 8443) else "http"
+        return port, scheme, path
+
+    @staticmethod
+    def _resolve_port(value, container):
+        # Turn an int or named port into a port number.
+        if isinstance(value, int):
+            return value
+        for port in container.ports or []:
+            if port.name == value:
+                return port.container_port
+        return None
+
     def list_pvcs(self, namespace: Namespace) -> List[PVC]:
         """List all PVCs in the namespace"""
         try:

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -1,4 +1,5 @@
 import re
+import ipaddress
 import concurrent.futures
 from typing import Dict, List, Optional, Union
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
@@ -245,13 +246,17 @@ class ClusterManager:
                         continue
 
                     probe, container = self._backing_probe(svc, pods)
+                    if probe is None:
+                        continue
+
                     port, scheme, path = self._endpoint_from_probe(
                         svc, probe, container
                     )
+                    host = self._format_host(address)
                     recommendations.append(
                         {
                             "name": svc.metadata.name,
-                            "url": f"{scheme}://{address}:{port}{path}",
+                            "url": f"{scheme}://{host}:{port}{path}",
                         }
                     )
             return recommendations
@@ -270,8 +275,19 @@ class ClusterManager:
                 return entry.ip or entry.hostname
         return None
 
+    @staticmethod
+    def _format_host(address: str) -> str:
+        # Wrap IPv6 literals in brackets so the URL stays valid.
+        try:
+            if isinstance(ipaddress.ip_address(address), ipaddress.IPv6Address):
+                return f"[{address}]"
+        except ValueError:
+            pass
+        return address
+
     def _backing_probe(self, svc, pods):
-        # Find the first httpGet probe on the pods behind this service.
+        # First httpGet probe behind the service, preferring readiness over
+        # liveness across all containers.
         selector = svc.spec.selector or {}
         if not selector:
             return None, None
@@ -279,8 +295,9 @@ class ClusterManager:
             labels = pod.metadata.labels or {}
             if not all(labels.get(key) == value for key, value in selector.items()):
                 continue
-            for container in pod.spec.containers:
-                for probe in (container.readiness_probe, container.liveness_probe):
+            for attr in ("readiness_probe", "liveness_probe"):
+                for container in pod.spec.containers:
+                    probe = getattr(container, attr)
                     if probe and probe.http_get:
                         return probe.http_get, container
         return None, None

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -226,10 +226,10 @@ class ClusterManager:
 
     def recommend_health_checks(
         self, cluster_components: ClusterComponents
-    ) -> List[Dict[str, str]]:
+    ) -> List[Dict[str, Union[str, bool]]]:
         """Suggest health-check URLs for LoadBalancer services."""
         try:
-            recommendations: List[Dict[str, str]] = []
+            recommendations: List[Dict[str, Union[str, bool]]] = []
             for namespace in cluster_components.get_active_components().namespaces:
                 services = self.core_api.list_namespaced_service(
                     namespace=namespace.name
@@ -246,9 +246,6 @@ class ClusterManager:
                         continue
 
                     probe, container = self._backing_probe(svc, pods)
-                    if probe is None:
-                        continue
-
                     port, scheme, path = self._endpoint_from_probe(
                         svc, probe, container
                     )
@@ -257,6 +254,7 @@ class ClusterManager:
                         {
                             "name": svc.metadata.name,
                             "url": f"{scheme}://{host}:{port}{path}",
+                            "discovered_only": probe is None,
                         }
                     )
             return recommendations

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -2,6 +2,8 @@ import re
 import ipaddress
 import concurrent.futures
 from typing import Dict, List, Optional, Union
+
+import requests
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
 from krkn_ai.utils import run_shell
@@ -250,11 +252,13 @@ class ClusterManager:
                         svc, probe, container
                     )
                     host = self._format_host(address)
+                    url = f"{scheme}://{host}:{port}{path}"
                     recommendations.append(
                         {
                             "name": svc.metadata.name,
-                            "url": f"{scheme}://{host}:{port}{path}",
-                            "discovered_only": probe is None,
+                            "url": url,
+                            "probe": probe is not None,
+                            "active": self._check_reachable(url),
                         }
                     )
             return recommendations
@@ -282,6 +286,14 @@ class ClusterManager:
         except ValueError:
             pass
         return address
+
+    @staticmethod
+    def _check_reachable(url: str) -> bool:
+        try:
+            resp = requests.get(url, timeout=3, verify=False)
+            return resp.status_code < 500
+        except Exception:
+            return False
 
     def _backing_probe(self, svc, pods):
         # First httpGet probe behind the service, preferring readiness over

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -15,6 +15,7 @@ def create_krkn_ai_template(
     kubeconfig_file_path: str,
     cluster_component_data: dict,
     scenario_enables: dict = None,
+    health_checks: list = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -47,4 +48,5 @@ def create_krkn_ai_template(
         kubeconfig_file_path=kubeconfig_file_path,
         cluster_components=cluster_components_indented,
         scenario_enables=scenario_enables,
+        health_check_apps=health_checks,
     )

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -71,14 +71,30 @@ fitness_function:
   include_krkn_failure: true
   include_health_check_failure: true
   include_health_check_response_time: true
-{% if health_check_apps %}
+{%- set active_apps = health_check_apps | default([]) | selectattr('discovered_only', 'equalto', false) | list -%}
+{%- set discovered_apps = health_check_apps | default([]) | selectattr('discovered_only') | list %}
+{% if active_apps %}
 health_checks:
   stop_watcher_on_failure: false
   stop_timeout: 5
   applications:
-{%- for app in health_check_apps %}
+{%- for app in active_apps %}
   - name: "{{ app.name }}"
     url: "{{ app.url }}"
+{%- endfor %}
+{%- for app in discovered_apps %}
+  # Discovered service — verify the URL and uncomment to enable:
+  # - name: "{{ app.name }}"
+  #   url: "{{ app.url }}"
+{%- endfor %}
+{% elif discovered_apps %}
+# health_checks:
+#   stop_watcher_on_failure: false
+#   stop_timeout: 5
+#   applications:
+{%- for app in discovered_apps %}
+#   - name: "{{ app.name }}"
+#     url: "{{ app.url }}"
 {%- endfor %}
 {% else %}
 # health_checks:

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -71,7 +71,16 @@ fitness_function:
   include_krkn_failure: true
   include_health_check_failure: true
   include_health_check_response_time: true
-
+{% if health_check_apps %}
+health_checks:
+  stop_watcher_on_failure: false
+  stop_timeout: 5
+  applications:
+{%- for app in health_check_apps %}
+  - name: {{ app.name }}
+    url: "{{ app.url }}"
+{%- endfor %}
+{% else %}
 # health_checks:
 #   stop_watcher_on_failure: false
 #   stop_timeout: 5
@@ -88,7 +97,7 @@ fitness_function:
 #     url: "$HOST/user/uniqueid"
 #   - name: ratings
 #     url: "$HOST/ratings/api/fetch/Watson"
-
+{% endif %}
 
 scenario:
 {%- for name, enabled in scenario_enables.items() %}

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -71,28 +71,29 @@ fitness_function:
   include_krkn_failure: true
   include_health_check_failure: true
   include_health_check_response_time: true
-{%- set active_apps = health_check_apps | default([]) | selectattr('discovered_only', 'equalto', false) | list -%}
-{%- set discovered_apps = health_check_apps | default([]) | selectattr('discovered_only') | list %}
-{% if active_apps %}
+{%- set enabled_apps = health_check_apps | default([]) | selectattr('probe') | selectattr('active') | list -%}
+{%- set disabled_apps = health_check_apps | default([]) | rejectattr('probe') | list + health_check_apps | default([]) | selectattr('probe') | rejectattr('active') | list %}
+{% if enabled_apps %}
 health_checks:
   stop_watcher_on_failure: false
   stop_timeout: 5
   applications:
-{%- for app in active_apps %}
+{%- for app in enabled_apps %}
   - name: "{{ app.name }}"
     url: "{{ app.url }}"
 {%- endfor %}
-{%- for app in discovered_apps %}
-  # Discovered service — verify the URL and uncomment to enable:
+{%- for app in disabled_apps %}
+  # ({% if not app.probe and not app.active %}no probe, unreachable{% elif not app.probe %}no probe{% else %}unreachable{% endif %})
   # - name: "{{ app.name }}"
   #   url: "{{ app.url }}"
 {%- endfor %}
-{% elif discovered_apps %}
+{% elif disabled_apps %}
 # health_checks:
 #   stop_watcher_on_failure: false
 #   stop_timeout: 5
 #   applications:
-{%- for app in discovered_apps %}
+{%- for app in disabled_apps %}
+#   ({% if not app.probe and not app.active %}no probe, unreachable{% elif not app.probe %}no probe{% else %}unreachable{% endif %})
 #   - name: "{{ app.name }}"
 #     url: "{{ app.url }}"
 {%- endfor %}

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -77,7 +77,7 @@ health_checks:
   stop_timeout: 5
   applications:
 {%- for app in health_check_apps %}
-  - name: {{ app.name }}
+  - name: "{{ app.name }}"
     url: "{{ app.url }}"
 {%- endfor %}
 {% else %}

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -182,10 +182,13 @@ def _write_fresh(
     components: ClusterComponents,
     kubeconfig: str,
     scenario_enables: dict = None,
+    health_checks: list = None,
 ):
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    template = create_krkn_ai_template(kubeconfig, data, scenario_enables)
+    template = create_krkn_ai_template(
+        kubeconfig, data, scenario_enables, health_checks
+    )
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
     logger.info("Saved component configuration to %s", output)
@@ -197,6 +200,7 @@ def save_discovery(
     components: ClusterComponents,
     kubeconfig: str,
     scenario_enables: dict = None,
+    health_checks: list = None,
 ):
     """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
     strategy = strategy.lower()
@@ -222,4 +226,4 @@ def save_discovery(
     if exists and strategy == "overwrite":
         logger.warning("Overwriting existing %s", output)
 
-    _write_fresh(output, components, kubeconfig, scenario_enables)
+    _write_fresh(output, components, kubeconfig, scenario_enables, health_checks)

--- a/scripts/nginx/configmap.yaml
+++ b/scripts/nginx/configmap.yaml
@@ -101,6 +101,11 @@ data:
                 proxy_set_header X-Forwarded-Proto $scheme;
             }
 
+            location /healthz {
+                access_log off;
+                return 200 'ok';
+            }
+
             # Optional: fallback
             location / {
                 return 404;

--- a/scripts/nginx/deployment.yaml
+++ b/scripts/nginx/deployment.yaml
@@ -17,6 +17,18 @@ spec:
           image: mirror.gcr.io/nginx:latest
           ports:
             - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/nginx.conf

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -585,7 +585,13 @@ class TestDiscoverCommand:
         """Fresh discover writes the recommended health checks to the output file."""
         runner = CliRunner()
         output_file = os.path.join(temp_output_dir, "output.yaml")
-        apps = [{"name": "cart", "url": "http://1.2.3.4:80/health"}]
+        apps = [
+            {
+                "name": "cart",
+                "url": "http://1.2.3.4:80/health",
+                "discovered_only": False,
+            }
+        ]
 
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             f.write("apiVersion: v1\nkind: Config")
@@ -608,7 +614,9 @@ class TestDiscoverCommand:
 
                 assert result.exit_code == 0
                 data = yaml.safe_load(open(output_file))
-                assert data["health_checks"]["applications"] == apps
+                assert data["health_checks"]["applications"] == [
+                    {"name": "cart", "url": "http://1.2.3.4:80/health"}
+                ]
         finally:
             os.unlink(kubeconfig_path)
 

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -503,9 +503,9 @@ class TestDiscoverCommand:
                     },
                 ),
             ):
-                mock_manager_class.return_value.discover_components.return_value = (
-                    mock_cluster_components
-                )
+                manager = mock_manager_class.return_value
+                manager.discover_components.return_value = mock_cluster_components
+                manager.recommend_health_checks.return_value = []
                 result = runner.invoke(
                     main, ["discover", "-k", kubeconfig_path, "-o", output_file]
                 )
@@ -515,6 +515,100 @@ class TestDiscoverCommand:
                 # recommended scenario enabled; an unrecommended one stays off
                 assert data["scenario"]["pvc-scenarios"]["enable"] is True
                 assert data["scenario"]["pod-scenarios"]["enable"] is False
+        finally:
+            os.unlink(kubeconfig_path)
+
+    @pytest.mark.parametrize(
+        "strategy, file_exists, expect_recommend_calls",
+        [
+            ("skip", False, 1),
+            ("skip", True, 0),
+            ("overwrite", False, 1),
+            ("overwrite", True, 1),
+            ("merge", False, 1),
+            ("merge", True, 0),
+        ],
+    )
+    def test_discover_recommends_health_checks_only_on_fresh_write(
+        self,
+        strategy,
+        file_exists,
+        expect_recommend_calls,
+        mock_cluster_components,
+        temp_output_dir,
+    ):
+        """Health-check recommendation runs only on a fresh write, like scenarios."""
+        runner = CliRunner()
+        output_file = os.path.join(temp_output_dir, "output.yaml")
+        if file_exists:
+            with open(output_file, "w") as f:
+                f.write("existing: true\n")
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with (
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class,
+                patch("krkn_ai.cli.cmd.save_discovery"),
+                patch(
+                    "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                    return_value={},
+                ),
+            ):
+                manager = mock_manager_class.return_value
+                manager.discover_components.return_value = mock_cluster_components
+                manager.recommend_health_checks.return_value = []
+                result = runner.invoke(
+                    main,
+                    [
+                        "discover",
+                        "-k",
+                        kubeconfig_path,
+                        "-o",
+                        output_file,
+                        "--save-strategy",
+                        strategy,
+                    ],
+                )
+                assert result.exit_code == 0
+                assert (
+                    manager.recommend_health_checks.call_count == expect_recommend_calls
+                )
+        finally:
+            os.unlink(kubeconfig_path)
+
+    def test_discover_writes_recommended_health_checks_to_file(
+        self, mock_cluster_components, temp_output_dir
+    ):
+        """Fresh discover writes the recommended health checks to the output file."""
+        runner = CliRunner()
+        output_file = os.path.join(temp_output_dir, "output.yaml")
+        apps = [{"name": "cart", "url": "http://1.2.3.4:80/health"}]
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("apiVersion: v1\nkind: Config")
+            kubeconfig_path = f.name
+
+        try:
+            with (
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_manager_class,
+                patch(
+                    "krkn_ai.cli.cmd.ScenarioFactory.recommend_enabled_scenarios",
+                    return_value={},
+                ),
+            ):
+                manager = mock_manager_class.return_value
+                manager.discover_components.return_value = mock_cluster_components
+                manager.recommend_health_checks.return_value = apps
+                result = runner.invoke(
+                    main, ["discover", "-k", kubeconfig_path, "-o", output_file]
+                )
+
+                assert result.exit_code == 0
+                data = yaml.safe_load(open(output_file))
+                assert data["health_checks"]["applications"] == apps
         finally:
             os.unlink(kubeconfig_path)
 

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -589,7 +589,8 @@ class TestDiscoverCommand:
             {
                 "name": "cart",
                 "url": "http://1.2.3.4:80/health",
-                "discovered_only": False,
+                "probe": True,
+                "active": True,
             }
         ]
 

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -720,14 +720,30 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "https://1.2.3.4:9443/health"
 
-    def test_selectorless_service_uses_root_path(self, cluster_manager):
-        """A service without a selector cannot resolve a probe path."""
+    def test_service_without_probe_is_skipped(self, cluster_manager):
+        """A service with no backing httpGet probe is not recommended."""
         svc = _svc("cart", selector=None, ports=[_svc_port(80, 8080)])
         self._set(cluster_manager, [svc], [])
 
+        assert cluster_manager.recommend_health_checks(self._components()) == []
+
+    def test_ipv6_address_is_bracketed(self, cluster_manager):
+        """An IPv6 external address is wrapped in brackets in the URL."""
+        svc = _svc(
+            "cart",
+            ip="2001:db8::1",
+            selector={"app": "cart"},
+            ports=[_svc_port(80, 8080)],
+        )
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
         result = cluster_manager.recommend_health_checks(self._components())
 
-        assert result == [{"name": "cart", "url": "http://1.2.3.4:80/"}]
+        assert result[0]["url"] == "http://[2001:db8::1]:80/health"
 
     def test_pending_load_balancer_is_skipped(self, cluster_manager):
         """A LoadBalancer without an external address is skipped."""

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -650,7 +650,8 @@ class TestRecommendHealthChecks:
         cluster_manager.core_api.list_namespaced_service.return_value.items = services
         cluster_manager.core_api.list_namespaced_pod.return_value.items = pods
 
-    def test_stitches_service_port_and_probe_path(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_stitches_service_port_and_probe_path(self, _mock_reach, cluster_manager):
         """URL uses the service port that maps to the probe's container port."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
         pod = _pod(
@@ -665,11 +666,13 @@ class TestRecommendHealthChecks:
             {
                 "name": "cart",
                 "url": "http://1.2.3.4:80/health",
-                "discovered_only": False,
+                "probe": True,
+                "active": True,
             }
         ]
 
-    def test_falls_back_to_liveness_probe(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_falls_back_to_liveness_probe(self, _mock_reach, cluster_manager):
         """Liveness probe is used when there is no readiness probe."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
         pod = _pod(
@@ -682,7 +685,8 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "http://1.2.3.4:80/live"
 
-    def test_unmapped_probe_port_falls_back_to_root(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_unmapped_probe_port_falls_back_to_root(self, _mock_reach, cluster_manager):
         """A probe port that no service port targets yields the root path."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
         pod = _pod(
@@ -695,7 +699,10 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "http://1.2.3.4:80/"
 
-    def test_named_probe_port_resolved_via_container(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_named_probe_port_resolved_via_container(
+        self, _mock_reach, cluster_manager
+    ):
         """A named probe port is resolved through the container's ports."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
         pod = _pod(
@@ -713,7 +720,8 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "http://1.2.3.4:80/health"
 
-    def test_scheme_taken_from_probe(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_scheme_taken_from_probe(self, _mock_reach, cluster_manager):
         """Scheme comes from the probe, even on a non-standard port."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(9443, 8080)])
         pod = _pod(
@@ -726,42 +734,20 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "https://1.2.3.4:9443/health"
 
-    def test_service_without_selector_generates_discovered_only(self, cluster_manager):
-        """A service with no selector still gets a discovered_only entry."""
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_no_probe_sets_probe_false(self, _mock_reach, cluster_manager):
+        """A service with no selector has probe=False."""
         svc = _svc("cart", selector=None, ports=[_svc_port(80, 8080)])
         self._set(cluster_manager, [svc], [])
 
         result = cluster_manager.recommend_health_checks(self._components())
 
-        assert result == [
-            {"name": "cart", "url": "http://1.2.3.4:80/", "discovered_only": True}
-        ]
+        assert result[0]["probe"] is False
+        assert result[0]["active"] is True
 
-    def test_no_probe_generates_discovered_only_entry(self, cluster_manager):
-        """A LB with no httpGet probe still generates an entry marked discovered_only."""
-        svc = _svc("web", selector={"app": "web"}, ports=[_svc_port(8080, 8080)])
-        pod = _pod({"app": "web"}, [_container()])
-        self._set(cluster_manager, [svc], [pod])
-
-        result = cluster_manager.recommend_health_checks(self._components())
-
-        assert result == [
-            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True}
-        ]
-
-    def test_no_probe_https_on_443(self, cluster_manager):
-        """A probe-less service on port 443 gets https scheme."""
-        svc = _svc("web", selector={"app": "web"}, ports=[_svc_port(443, 443)])
-        pod = _pod({"app": "web"}, [_container()])
-        self._set(cluster_manager, [svc], [pod])
-
-        result = cluster_manager.recommend_health_checks(self._components())
-
-        assert result[0]["url"] == "https://1.2.3.4:443/"
-        assert result[0]["discovered_only"] is True
-
-    def test_probe_entry_is_not_discovered_only(self, cluster_manager):
-        """A service with a real probe has discovered_only=False."""
+    @patch.object(ClusterManager, "_check_reachable", return_value=False)
+    def test_unreachable_sets_active_false(self, _mock_reach, cluster_manager):
+        """An unreachable endpoint has active=False."""
         svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
         pod = _pod(
             {"app": "cart"},
@@ -771,9 +757,38 @@ class TestRecommendHealthChecks:
 
         result = cluster_manager.recommend_health_checks(self._components())
 
-        assert result[0]["discovered_only"] is False
+        assert result[0]["probe"] is True
+        assert result[0]["active"] is False
 
-    def test_ipv6_address_is_bracketed(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_probe_and_reachable_sets_both_true(self, _mock_reach, cluster_manager):
+        """A service with probe and reachable endpoint has both flags True."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["probe"] is True
+        assert result[0]["active"] is True
+
+    @patch.object(ClusterManager, "_check_reachable", return_value=False)
+    def test_no_probe_unreachable_sets_both_false(self, _mock_reach, cluster_manager):
+        """A probe-less unreachable service has both flags False."""
+        svc = _svc("web", selector={"app": "web"}, ports=[_svc_port(8080, 8080)])
+        pod = _pod({"app": "web"}, [_container()])
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["probe"] is False
+        assert result[0]["active"] is False
+
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_ipv6_address_is_bracketed(self, _mock_reach, cluster_manager):
         """An IPv6 external address is wrapped in brackets in the URL."""
         svc = _svc(
             "cart",
@@ -791,14 +806,16 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "http://[2001:db8::1]:80/health"
 
-    def test_pending_load_balancer_is_skipped(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_pending_load_balancer_is_skipped(self, _mock_reach, cluster_manager):
         """A LoadBalancer without an external address is skipped."""
         svc = _svc("cart", ip=None, hostname=None, ports=[_svc_port(80, 8080)])
         self._set(cluster_manager, [svc], [])
 
         assert cluster_manager.recommend_health_checks(self._components()) == []
 
-    def test_non_load_balancer_services_ignored(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_non_load_balancer_services_ignored(self, _mock_reach, cluster_manager):
         """ClusterIP services are not health-check candidates."""
         svc = _svc("cart", svc_type="ClusterIP", ports=[_svc_port(80, 8080)])
         self._set(cluster_manager, [svc], [])
@@ -813,7 +830,8 @@ class TestRecommendHealthChecks:
 
         assert cluster_manager.recommend_health_checks(self._components()) == []
 
-    def test_same_name_across_namespaces_all_kept(self, cluster_manager):
+    @patch.object(ClusterManager, "_check_reachable", return_value=True)
+    def test_same_name_across_namespaces_all_kept(self, _mock_reach, cluster_manager):
         """Distinct services sharing a name across namespaces are all kept."""
         components = ClusterComponents(
             namespaces=[Namespace(name="shop"), Namespace(name="store")]
@@ -829,3 +847,21 @@ class TestRecommendHealthChecks:
         result = cluster_manager.recommend_health_checks(components)
 
         assert len(result) == 2
+
+    def test_check_reachable_returns_true_on_200(self):
+        """_check_reachable returns True for a 200 response."""
+        with patch("krkn_ai.cluster.cluster_manager.requests.get") as mock_get:
+            mock_get.return_value.status_code = 200
+            assert ClusterManager._check_reachable("http://example.com") is True
+
+    def test_check_reachable_returns_false_on_500(self):
+        """_check_reachable returns False for a 500 response."""
+        with patch("krkn_ai.cluster.cluster_manager.requests.get") as mock_get:
+            mock_get.return_value.status_code = 500
+            assert ClusterManager._check_reachable("http://example.com") is False
+
+    def test_check_reachable_returns_false_on_connection_error(self):
+        """_check_reachable returns False on connection failure."""
+        with patch("krkn_ai.cluster.cluster_manager.requests.get") as mock_get:
+            mock_get.side_effect = ConnectionError("refused")
+            assert ClusterManager._check_reachable("http://example.com") is False

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import Mock, patch
 
 from krkn_ai.cluster import ClusterManager
-from krkn_ai.models.cluster_components import Namespace
+from krkn_ai.models.cluster_components import ClusterComponents, Namespace
 
 
 class TestClusterManager:
@@ -560,3 +560,210 @@ class TestClusterManager:
         by_name = {n.name: n for n in nodes}
         assert by_name["good-node"].interfaces == ["eth0"]
         assert by_name["bad-node"].interfaces == []
+
+
+def _http_get(path, port, scheme="HTTP"):
+    hg = Mock()
+    hg.path = path
+    hg.port = port
+    hg.scheme = scheme
+    return hg
+
+
+def _probe(http_get):
+    probe = Mock()
+    probe.http_get = http_get
+    return probe
+
+
+def _container(readiness=None, liveness=None, ports=None):
+    container = Mock()
+    container.readiness_probe = readiness
+    container.liveness_probe = liveness
+    container.ports = ports or []
+    return container
+
+
+def _container_port(name, container_port):
+    cp = Mock()
+    cp.name = name
+    cp.container_port = container_port
+    return cp
+
+
+def _pod(labels, containers):
+    pod = Mock()
+    pod.metadata.labels = labels
+    pod.spec.containers = containers
+    return pod
+
+
+def _svc_port(port, target_port=None):
+    sp = Mock()
+    sp.port = port
+    sp.target_port = target_port
+    return sp
+
+
+def _svc(
+    name,
+    svc_type="LoadBalancer",
+    ip="1.2.3.4",
+    hostname=None,
+    selector=None,
+    ports=None,
+):
+    svc = Mock()
+    svc.metadata.name = name
+    svc.spec.type = svc_type
+    svc.spec.selector = selector
+    svc.spec.ports = ports or []
+    if ip or hostname:
+        ingress = Mock(ip=ip, hostname=hostname)
+        svc.status.load_balancer.ingress = [ingress]
+    else:
+        svc.status.load_balancer.ingress = []
+    return svc
+
+
+class TestRecommendHealthChecks:
+    """Health-check endpoint discovery for LoadBalancer services."""
+
+    @pytest.fixture
+    def mock_krkn_k8s(self):
+        mock_k8s = Mock()
+        mock_k8s.cli = Mock()
+        return mock_k8s
+
+    @pytest.fixture
+    def cluster_manager(self, mock_krkn_k8s):
+        with patch(
+            "krkn_ai.cluster.cluster_manager.KrknKubernetes",
+            return_value=mock_krkn_k8s,
+        ):
+            return ClusterManager(kubeconfig="/tmp/test-kubeconfig")
+
+    def _components(self):
+        return ClusterComponents(namespaces=[Namespace(name="shop")])
+
+    def _set(self, cluster_manager, services, pods):
+        cluster_manager.core_api.list_namespaced_service.return_value.items = services
+        cluster_manager.core_api.list_namespaced_pod.return_value.items = pods
+
+    def test_stitches_service_port_and_probe_path(self, cluster_manager):
+        """URL uses the service port that maps to the probe's container port."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result == [{"name": "cart", "url": "http://1.2.3.4:80/health"}]
+
+    def test_falls_back_to_liveness_probe(self, cluster_manager):
+        """Liveness probe is used when there is no readiness probe."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(liveness=_probe(_http_get("/live", 8080)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["url"] == "http://1.2.3.4:80/live"
+
+    def test_unmapped_probe_port_falls_back_to_root(self, cluster_manager):
+        """A probe port that no service port targets yields the root path."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 9090)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["url"] == "http://1.2.3.4:80/"
+
+    def test_named_probe_port_resolved_via_container(self, cluster_manager):
+        """A named probe port is resolved through the container's ports."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [
+                _container(
+                    readiness=_probe(_http_get("/health", "web")),
+                    ports=[_container_port("web", 8080)],
+                )
+            ],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["url"] == "http://1.2.3.4:80/health"
+
+    def test_scheme_taken_from_probe(self, cluster_manager):
+        """Scheme comes from the probe, even on a non-standard port."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(9443, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080, scheme="HTTPS")))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["url"] == "https://1.2.3.4:9443/health"
+
+    def test_selectorless_service_uses_root_path(self, cluster_manager):
+        """A service without a selector cannot resolve a probe path."""
+        svc = _svc("cart", selector=None, ports=[_svc_port(80, 8080)])
+        self._set(cluster_manager, [svc], [])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result == [{"name": "cart", "url": "http://1.2.3.4:80/"}]
+
+    def test_pending_load_balancer_is_skipped(self, cluster_manager):
+        """A LoadBalancer without an external address is skipped."""
+        svc = _svc("cart", ip=None, hostname=None, ports=[_svc_port(80, 8080)])
+        self._set(cluster_manager, [svc], [])
+
+        assert cluster_manager.recommend_health_checks(self._components()) == []
+
+    def test_non_load_balancer_services_ignored(self, cluster_manager):
+        """ClusterIP services are not health-check candidates."""
+        svc = _svc("cart", svc_type="ClusterIP", ports=[_svc_port(80, 8080)])
+        self._set(cluster_manager, [svc], [])
+
+        assert cluster_manager.recommend_health_checks(self._components()) == []
+
+    def test_failure_returns_empty_list(self, cluster_manager):
+        """A cluster read error never breaks discovery."""
+        cluster_manager.core_api.list_namespaced_service.side_effect = RuntimeError(
+            "boom"
+        )
+
+        assert cluster_manager.recommend_health_checks(self._components()) == []
+
+    def test_same_name_across_namespaces_all_kept(self, cluster_manager):
+        """Distinct services sharing a name across namespaces are all kept."""
+        components = ClusterComponents(
+            namespaces=[Namespace(name="shop"), Namespace(name="store")]
+        )
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080)))],
+        )
+        cluster_manager.core_api.list_namespaced_service.return_value.items = [svc]
+        cluster_manager.core_api.list_namespaced_pod.return_value.items = [pod]
+
+        result = cluster_manager.recommend_health_checks(components)
+
+        assert len(result) == 2

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -661,7 +661,13 @@ class TestRecommendHealthChecks:
 
         result = cluster_manager.recommend_health_checks(self._components())
 
-        assert result == [{"name": "cart", "url": "http://1.2.3.4:80/health"}]
+        assert result == [
+            {
+                "name": "cart",
+                "url": "http://1.2.3.4:80/health",
+                "discovered_only": False,
+            }
+        ]
 
     def test_falls_back_to_liveness_probe(self, cluster_manager):
         """Liveness probe is used when there is no readiness probe."""
@@ -720,12 +726,52 @@ class TestRecommendHealthChecks:
 
         assert result[0]["url"] == "https://1.2.3.4:9443/health"
 
-    def test_service_without_probe_is_skipped(self, cluster_manager):
-        """A service with no backing httpGet probe is not recommended."""
+    def test_service_without_selector_generates_discovered_only(self, cluster_manager):
+        """A service with no selector still gets a discovered_only entry."""
         svc = _svc("cart", selector=None, ports=[_svc_port(80, 8080)])
         self._set(cluster_manager, [svc], [])
 
-        assert cluster_manager.recommend_health_checks(self._components()) == []
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result == [
+            {"name": "cart", "url": "http://1.2.3.4:80/", "discovered_only": True}
+        ]
+
+    def test_no_probe_generates_discovered_only_entry(self, cluster_manager):
+        """A LB with no httpGet probe still generates an entry marked discovered_only."""
+        svc = _svc("web", selector={"app": "web"}, ports=[_svc_port(8080, 8080)])
+        pod = _pod({"app": "web"}, [_container()])
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result == [
+            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True}
+        ]
+
+    def test_no_probe_https_on_443(self, cluster_manager):
+        """A probe-less service on port 443 gets https scheme."""
+        svc = _svc("web", selector={"app": "web"}, ports=[_svc_port(443, 443)])
+        pod = _pod({"app": "web"}, [_container()])
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["url"] == "https://1.2.3.4:443/"
+        assert result[0]["discovered_only"] is True
+
+    def test_probe_entry_is_not_discovered_only(self, cluster_manager):
+        """A service with a real probe has discovered_only=False."""
+        svc = _svc("cart", selector={"app": "cart"}, ports=[_svc_port(80, 8080)])
+        pod = _pod(
+            {"app": "cart"},
+            [_container(readiness=_probe(_http_get("/health", 8080)))],
+        )
+        self._set(cluster_manager, [svc], [pod])
+
+        result = cluster_manager.recommend_health_checks(self._components())
+
+        assert result[0]["discovered_only"] is False
 
     def test_ipv6_address_is_bracketed(self, cluster_manager):
         """An IPv6 external address is wrapped in brackets in the URL."""

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -77,19 +77,58 @@ class TestHealthCheckRendering:
     def test_discovered_apps_render_live_block(self):
         """Discovered endpoints render an active, valid health_checks block."""
         apps = [
-            {"name": "cart", "url": "http://1.2.3.4:80/health"},
-            {"name": "user", "url": "https://1.2.3.4:443/user/ready"},
+            {
+                "name": "cart",
+                "url": "http://1.2.3.4:80/health",
+                "discovered_only": False,
+            },
+            {
+                "name": "user",
+                "url": "https://1.2.3.4:443/user/ready",
+                "discovered_only": False,
+            },
         ]
         rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
         block = _health_checks(rendered)
-        assert block["applications"] == apps
+        assert len(block["applications"]) == 2
         HealthCheckConfig(**block)
 
     def test_boolean_like_name_stays_a_string(self):
         """A name like 'on' stays a string, not a bool."""
         rendered = create_krkn_ai_template(
-            KUBECONFIG, DATA, None, [{"name": "on", "url": "http://x/y"}]
+            KUBECONFIG,
+            DATA,
+            None,
+            [{"name": "on", "url": "http://x/y", "discovered_only": False}],
         )
         block = _health_checks(rendered)
         assert block["applications"][0]["name"] == "on"
+        HealthCheckConfig(**block)
+
+    def test_discovered_only_entries_render_as_comments(self):
+        """Entries with discovered_only=True render the entire block commented."""
+        apps = [
+            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True},
+        ]
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
+        assert "# health_checks:" in rendered
+        assert '#   - name: "web"' in rendered
+        assert '#     url: "http://1.2.3.4:8080/"' in rendered
+        assert _health_checks(rendered) is None
+
+    def test_mixed_active_and_discovered_only(self):
+        """Active entries render as YAML, discovered_only entries as comments."""
+        apps = [
+            {
+                "name": "cart",
+                "url": "http://1.2.3.4:80/health",
+                "discovered_only": False,
+            },
+            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True},
+        ]
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
+        block = _health_checks(rendered)
+        assert len(block["applications"]) == 1
+        assert block["applications"][0]["name"] == "cart"
+        assert '# - name: "web"' in rendered
         HealthCheckConfig(**block)

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -4,6 +4,7 @@ import yaml
 
 from krkn_ai.templates.generator import create_krkn_ai_template
 from krkn_ai.models.scenario.factory import scenario_specs
+from krkn_ai.models.config import HealthCheckConfig
 
 KUBECONFIG = "/tmp/kubeconfig"
 DATA: dict = {"namespaces": []}
@@ -53,3 +54,33 @@ class TestScenarioRendering:
         assert "enable: true" in rendered
         assert "enable: True" not in rendered
         yaml.safe_load(rendered)  # does not raise
+
+
+def _health_checks(rendered: str):
+    """Return the health_checks mapping from rendered YAML (None if commented)."""
+    return yaml.safe_load(rendered).get("health_checks")
+
+
+class TestHealthCheckRendering:
+    def test_none_keeps_commented_example(self):
+        """health_checks=None leaves the block commented out."""
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA)
+        assert _health_checks(rendered) is None
+        assert "# health_checks:" in rendered
+
+    def test_empty_list_falls_back_identically(self):
+        """An empty recommendation renders the same as None."""
+        assert create_krkn_ai_template(
+            KUBECONFIG, DATA, None, []
+        ) == create_krkn_ai_template(KUBECONFIG, DATA)
+
+    def test_discovered_apps_render_live_block(self):
+        """Discovered endpoints render an active, valid health_checks block."""
+        apps = [
+            {"name": "cart", "url": "http://1.2.3.4:80/health"},
+            {"name": "user", "url": "https://1.2.3.4:443/user/ready"},
+        ]
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
+        block = _health_checks(rendered)
+        assert block["applications"] == apps
+        HealthCheckConfig(**block)

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -84,3 +84,12 @@ class TestHealthCheckRendering:
         block = _health_checks(rendered)
         assert block["applications"] == apps
         HealthCheckConfig(**block)
+
+    def test_boolean_like_name_stays_a_string(self):
+        """A name like 'on' stays a string, not a bool."""
+        rendered = create_krkn_ai_template(
+            KUBECONFIG, DATA, None, [{"name": "on", "url": "http://x/y"}]
+        )
+        block = _health_checks(rendered)
+        assert block["applications"][0]["name"] == "on"
+        HealthCheckConfig(**block)

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -74,18 +74,20 @@ class TestHealthCheckRendering:
             KUBECONFIG, DATA, None, []
         ) == create_krkn_ai_template(KUBECONFIG, DATA)
 
-    def test_discovered_apps_render_live_block(self):
-        """Discovered endpoints render an active, valid health_checks block."""
+    def test_enabled_apps_render_live_block(self):
+        """Endpoints with probe+active render an active health_checks block."""
         apps = [
             {
                 "name": "cart",
                 "url": "http://1.2.3.4:80/health",
-                "discovered_only": False,
+                "probe": True,
+                "active": True,
             },
             {
                 "name": "user",
                 "url": "https://1.2.3.4:443/user/ready",
-                "discovered_only": False,
+                "probe": True,
+                "active": True,
             },
         ]
         rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
@@ -99,36 +101,76 @@ class TestHealthCheckRendering:
             KUBECONFIG,
             DATA,
             None,
-            [{"name": "on", "url": "http://x/y", "discovered_only": False}],
+            [{"name": "on", "url": "http://x/y", "probe": True, "active": True}],
         )
         block = _health_checks(rendered)
         assert block["applications"][0]["name"] == "on"
         HealthCheckConfig(**block)
 
-    def test_discovered_only_entries_render_as_comments(self):
-        """Entries with discovered_only=True render the entire block commented."""
+    def test_no_probe_comments_with_reason(self):
+        """An entry with probe=False renders commented with '(no probe)'."""
         apps = [
-            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True},
+            {
+                "name": "web",
+                "url": "http://1.2.3.4:8080/",
+                "probe": False,
+                "active": True,
+            },
         ]
         rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
         assert "# health_checks:" in rendered
-        assert '#   - name: "web"' in rendered
-        assert '#     url: "http://1.2.3.4:8080/"' in rendered
+        assert "(no probe)" in rendered
         assert _health_checks(rendered) is None
 
-    def test_mixed_active_and_discovered_only(self):
-        """Active entries render as YAML, discovered_only entries as comments."""
+    def test_unreachable_comments_with_reason(self):
+        """An entry with active=False renders commented with '(unreachable)'."""
         apps = [
             {
                 "name": "cart",
                 "url": "http://1.2.3.4:80/health",
-                "discovered_only": False,
+                "probe": True,
+                "active": False,
             },
-            {"name": "web", "url": "http://1.2.3.4:8080/", "discovered_only": True},
+        ]
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
+        assert "# health_checks:" in rendered
+        assert "(unreachable)" in rendered
+        assert _health_checks(rendered) is None
+
+    def test_no_probe_unreachable_comments_with_both_reasons(self):
+        """An entry with both False renders '(no probe, unreachable)'."""
+        apps = [
+            {
+                "name": "web",
+                "url": "http://1.2.3.4:8080/",
+                "probe": False,
+                "active": False,
+            },
+        ]
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
+        assert "(no probe, unreachable)" in rendered
+        assert _health_checks(rendered) is None
+
+    def test_mixed_enabled_and_disabled(self):
+        """Enabled entries render as YAML, disabled as comments with reason."""
+        apps = [
+            {
+                "name": "cart",
+                "url": "http://1.2.3.4:80/health",
+                "probe": True,
+                "active": True,
+            },
+            {
+                "name": "web",
+                "url": "http://1.2.3.4:8080/",
+                "probe": False,
+                "active": True,
+            },
         ]
         rendered = create_krkn_ai_template(KUBECONFIG, DATA, None, apps)
         block = _health_checks(rendered)
         assert len(block["applications"]) == 1
         assert block["applications"][0]["name"] == "cart"
         assert '# - name: "web"' in rendered
+        assert "(no probe)" in rendered
         HealthCheckConfig(**block)


### PR DESCRIPTION
## Description
Makes `discover` recommend `health_checks` when it generates a fresh template.

For each LoadBalancer service with an external IP, it finds the backing pods, reads their readiness/liveness `httpGet` probe, picks the service port that exposes it, and writes a URL like `http://<external-ip>:<port>/<path>`. These go through `save_discovery` into `create_krkn_ai_template` next to the scenario recommendations. If nothing suitable is found, the commented example block stays as-is.




Week 5 #364 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- Unit tests for the recommendation logic, template rendering, `save_discovery`, and the discover CLI. 
- Ran it on Minikube against a LoadBalancer service with a readiness probe and confirmed the template came out with the right health check URL. Unit tests pass locally.

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors