### PR TITLE
fix(scenario): skip pods with no containers in ContainerScenario (#237)

### DIFF
--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -45,15 +45,18 @@ class ContainerScenario(Scenario):
     def mutate(self):
         namespace_pod_tuple: List[Tuple[Namespace, Pod]] = []
 
-        # look for pods with labels
+        # look for pods with labels and at least one container. A pod without
+        # containers cannot be targeted by a container scenario and would make the
+        # ``rng.randint(1, len(pod.containers))`` call below crash with
+        # "ValueError: low >= high", terminating the whole GA run.
         for namespace in self._cluster_components.namespaces:
             for pod in namespace.pods:
-                if len(pod.labels) > 0:
+                if len(pod.labels) > 0 and len(pod.containers) > 0:
                     namespace_pod_tuple.append((namespace, pod))
 
         if len(namespace_pod_tuple) == 0:
             raise ScenarioParameterInitError(
-                "No pods found with labels for container scenario"
+                "No pods found with labels and containers for container scenario"
             )
 
         # Select a random namespace and pod from the tuple list

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -106,6 +106,36 @@ class TestContainerScenario:
         ):
             ContainerScenario(cluster_components=cluster)
 
+    def test_container_scenario_raises_error_when_pod_has_no_containers(self):
+        """Regression test for #237.
+
+        A labeled pod with an empty ``containers`` list must not crash with
+        ``ValueError: low >= high`` (from ``rng.randint(1, 0)``); it should raise the
+        graceful ``ScenarioParameterInitError`` instead.
+        """
+        pod = Pod(name="test-pod", labels={"app": "web"}, containers=[])
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        with pytest.raises(
+            ScenarioParameterInitError,
+            match="No pods found with labels and containers",
+        ):
+            ContainerScenario(cluster_components=cluster)
+
+    def test_container_scenario_skips_pods_without_containers(self):
+        """A labeled pod without containers is skipped in favour of a valid one."""
+        empty = Pod(name="empty", labels={"app": "web"}, containers=[])
+        good = Pod(
+            name="good", labels={"app": "db"}, containers=[Container(name="c1")]
+        )
+        namespace = Namespace(name="test-ns", pods=[empty, good])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        for _ in range(50):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.label_selector.value == "app=db"
+
 
 class TestNodeCPUHogScenario:
     """Test NodeCPUHogScenario class"""

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -126,9 +126,7 @@ class TestContainerScenario:
     def test_container_scenario_skips_pods_without_containers(self):
         """A labeled pod without containers is skipped in favour of a valid one."""
         empty = Pod(name="empty", labels={"app": "web"}, containers=[])
-        good = Pod(
-            name="good", labels={"app": "db"}, containers=[Container(name="c1")]
-        )
+        good = Pod(name="good", labels={"app": "db"}, containers=[Container(name="c1")])
         namespace = Namespace(name="test-ns", pods=[empty, good])
         cluster = ClusterComponents(namespaces=[namespace], nodes=[])
 


### PR DESCRIPTION
Fixes #237.

`ContainerScenario.mutate()` builds its candidate list from any pod that has labels, then does:

```python
self.disruption_count.value = rng.randint(1, len(pod.containers))
```

If a selected pod has an empty `containers` list (e.g. init-only or misconfigured pods surfaced by cluster discovery), this is `rng.randint(1, 0)`, which raises `ValueError: low >= high` during scenario initialisation and terminates the entire genetic-algorithm run.

Reproducer (raises on `main`):

```python
from krkn_ai.models.cluster_components import ClusterComponents, Namespace, Pod
from krkn_ai.models.scenario.scenario_container import ContainerScenario

pod = Pod(name="p", labels={"app": "x"}, containers=[])
cluster = ClusterComponents(namespaces=[Namespace(name="ns", pods=[pod])], nodes=[])
ContainerScenario(cluster_components=cluster)   # ValueError: low >= high
```

The fix requires a candidate pod to have at least one container in addition to labels. Container-less pods are then skipped, and if none qualify the existing `ScenarioParameterInitError` is raised — the same graceful path already used when no labeled pods exist — instead of crashing the run.

Added two regression tests: one asserting a labeled pod with no containers raises `ScenarioParameterInitError` (not `ValueError`), and one asserting a container-less pod is skipped in favour of a valid one. Both fail on `main` and pass with this change; the unit suite passes (431 tests) and `ruff` is clean.

*Disclosure: written with AI assistance; reviewed and tested before submitting.*
