### PR TITLE
fix: validate prometheus token presence during client creation

### DIFF
--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -86,6 +86,13 @@ def create_prometheus_client(kubeconfig: str) -> KrknPrometheus:
             "  export PROMETHEUS_TOKEN=$(oc whoami -t)"
         )
 
+    if is_ocp and not token:
+        raise PrometheusConnectionError(
+            "Automatic Prometheus token discovery failed on OpenShift.\n"
+            "Please set the token explicitly:\n"
+            "  export PROMETHEUS_TOKEN=$(oc whoami -t)"
+        )
+
     return _validate_and_create_client(url, token)
 
 


### PR DESCRIPTION
## Description
Fixes #372

Previously, `get_prometheus_client` validated that a Prometheus URL was provided or discovered, but failed to apply the same validation for the authentication token. If token auto-discovery failed on OpenShift, it would silently pass an empty token, leading to deferred and unhelpful authentication errors during the first actual query execution.

This adds an explicit token check that raises a clear `PrometheusConnectionError` with actionable instructions when a token is missing, mirroring the existing URL validation behavior.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
