### PR TITLE
fix(core): prevent silent exception swallowing in file and network operations

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -183,8 +183,8 @@ def run(
                 try:
                     with open(os.path.join(new_output_path, "results.json"), "w") as f:
                         json.dump({"status": STATUS_FAILED}, f)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.error("Failed to write results.json: %s", e)
             logger.info("Check run.log file in '%s' for more details.", new_output_path)
             if monitoring:
                 logger.info(

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -184,7 +184,7 @@ def run(
                     with open(os.path.join(new_output_path, "results.json"), "w") as f:
                         json.dump({"status": STATUS_FAILED}, f)
                 except Exception as e:
-                    logger.error("Failed to write results.json: %s", e)
+                    logger.exception("Failed to write results.json: %s", e)
             logger.info("Check run.log file in '%s' for more details.", new_output_path)
             if monitoring:
                 logger.info(

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -282,8 +282,8 @@ class ClusterManager:
                 "Filtered %d vmis in namespace %s", len(vmi_list), namespace.name
             )
             return vmi_list
-        except Exception:
-            logger.warning("Unable to find VMIs in namespace %s", namespace.name)
+        except Exception as e:
+            logger.warning("Unable to find VMIs in namespace %s: %s", namespace.name, e)
             return []
 
     def list_nodes(

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -283,7 +283,12 @@ class ClusterManager:
             )
             return vmi_list
         except Exception as e:
-            logger.warning("Unable to find VMIs in namespace %s: %s", namespace.name, e)
+            logger.warning(
+                "Unable to find VMIs in namespace %s: %s",
+                namespace.name,
+                e,
+                exc_info=True,
+            )
             return []
 
     def list_nodes(

--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -242,4 +242,4 @@ class HealthCheckReporter:
                 df.to_csv(report_path, index=False)
                 logger.debug("Fitness result CSV sorted by fitness_score")
             except Exception as e:
-                logger.warning("Unable to sort fitness results: %s", e)
+                logger.exception("Unable to sort fitness results: %s", e)

--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -241,5 +241,5 @@ class HealthCheckReporter:
                 df = df.sort_values(by="fitness_score", ascending=False)
                 df.to_csv(report_path, index=False)
                 logger.debug("Fitness result CSV sorted by fitness_score")
-            except Exception:
-                logger.warning("Unable to sort fitness results")
+            except Exception as e:
+                logger.warning("Unable to sort fitness results: %s", e)


### PR DESCRIPTION
## Description

Fixes #400

This PR improves observability by capturing and logging the exception payload instead of silently swallowing it in several core modules. 

Currently, if an API call fails or a file permission error occurs, the user only sees a generic warning (or nothing at all), making it extremely difficult to debug environment or access issues.

**Specific Fixes:**
- `cluster_manager.py`: Kubernetes API failures when listing VMIs are now logged instead of swallowed.
- `cmd.py`: File permission/disk errors when writing `results.json` are now logged instead of ignored with a silent `pass`.
- `health_check_reporter.py`: Pandas CSV read/sort failures are now logged with the full exception trace.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings