### PR TITLE
fix: make adaptive mutation rate reduction reachable

### DIFF
--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -230,11 +230,12 @@ class GeneticAlgorithm(BaseEngine):
 
         if improvement < cfg.threshold:
             self.stagnant_generations += 1
+            if self.stagnant_generations < cfg.generations:
+                return
+            rate_factor = 1.2
         else:
             self.stagnant_generations = 0
-
-        if self.stagnant_generations < cfg.generations:
-            return
+            rate_factor = 0.9
 
         if cfg.min > cfg.max:
             raise ValueError(
@@ -243,20 +244,19 @@ class GeneticAlgorithm(BaseEngine):
             )
 
         # Increase rate when stagnating, decrease when improving
-        if improvement < cfg.threshold:
-            self.current_scenario_mutation_rate *= 1.2
-        else:
-            self.current_scenario_mutation_rate *= 0.9
+        old_rate = self.current_scenario_mutation_rate
+        self.current_scenario_mutation_rate *= rate_factor
 
         # Clamp to configured bounds
         self.current_scenario_mutation_rate = max(
             cfg.min, min(self.current_scenario_mutation_rate, cfg.max)
         )
 
-        logger.info(
-            "Adaptive mutation triggered | scenario_mutation_rate=%.4f",
-            self.current_scenario_mutation_rate,
-        )
+        if self.current_scenario_mutation_rate != old_rate:
+            logger.info(
+                "Adaptive mutation triggered | scenario_mutation_rate=%.4f",
+                self.current_scenario_mutation_rate,
+            )
 
         self.stagnant_generations = 0
 

--- a/tests/unit/algorithm/test_adaptive_mutation.py
+++ b/tests/unit/algorithm/test_adaptive_mutation.py
@@ -124,6 +124,27 @@ class TestAdaptMutationRateUpdate:
         assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.36)
         assert genetic_algorithm.stagnant_generations == 0
 
+    def test_decreases_rate_when_improving(self, genetic_algorithm):
+        """Should multiply rate by 0.9 when fitness is improving above threshold"""
+        genetic_algorithm.algo_config.adaptive_mutation = AdaptiveMutation(
+            enable=True, threshold=0.5, generations=5, min=0.05, max=0.9
+        )
+        genetic_algorithm.algo_config.scenario_mutation_rate = 0.3
+        genetic_algorithm.current_scenario_mutation_rate = 0.3
+        genetic_algorithm.best_of_generation = [
+            make_generation_result(10.0),
+            make_generation_result(11.0),  # 1.0 improvement >= 0.5 threshold
+        ]
+        genetic_algorithm.stagnant_generations = 2
+
+        genetic_algorithm.adapt_mutation_rate()
+
+        assert genetic_algorithm.algo_config.scenario_mutation_rate == pytest.approx(
+            0.3
+        )
+        assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.27)
+        assert genetic_algorithm.stagnant_generations == 0
+
     def test_clamps_current_rate_only(self, genetic_algorithm):
         """Should clamp the current rate while preserving the configured rate"""
         genetic_algorithm.algo_config.adaptive_mutation = AdaptiveMutation(


### PR DESCRIPTION

## Description
This PR resolves a logical bug in the genetic algorithm's adaptive mutation controller (`GeneticAlgorithm.adapt_mutation_rate()`). 

Previously, if the population's fitness score improved above the threshold, `self.stagnant_generations` was reset to `0`. Consequently, the check `if self.stagnant_generations < cfg.generations: return` would always evaluate to `True` (since `cfg.generations` is a positive integer configuration, default `5`), returning early and preventing the mutation rate from ever being reduced (cooled down). This limited the algorithm's capability to switch from exploration to exploitation mode.

With this fix, the early return check is scoped correctly to the stagnating case. When significant fitness improvements occur, the mutation rate is immediately reduced by `0.9` to focus on exploitation.

#402 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- Added a new unit test `test_decreases_rate_when_improving` to `tests/unit/algorithm/test_adaptive_mutation.py` validating the cooling down transition.
- Executed the unit tests locally:
  ```bash
  uv run pytest tests/unit/algorithm/test_adaptive_mutation.py
  ```
  Result: **14 passed**
- Verified the full core suite:
  ```bash
  uv run pytest tests/unit/algorithm tests/unit/chaos_engines tests/unit/cli tests/unit/models tests/unit/reporter tests/unit/templates tests/unit/utils
  ```
  Result: **357 passed**

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors

