### PR TITLE
feat(fitness): add pre-flight validation for prometheus queries

### DIFF
--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -28,7 +28,7 @@ class FitnessCalculator:
         now = datetime.datetime.now()
         start = now - datetime.timedelta(minutes=5)
         
-        if self.fitness_function.query:
+        if self.fitness_function.query is not None:
             self._validate_query(self.fitness_function.query, "fitness_function.query", start, now)
         
         for item in self.fitness_function.items:

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -20,6 +20,53 @@ class FitnessCalculator:
         self.prom_client = prom_client
         self.fitness_function = fitness_function
 
+    def preflight_check(self) -> None:
+        """Validate all fitness queries return data before the experiment starts."""
+        if env_is_truthy("MOCK_FITNESS"):
+            return
+
+        now = datetime.datetime.now()
+        start = now - datetime.timedelta(minutes=5)
+        
+        if self.fitness_function.query:
+            self._validate_query(self.fitness_function.query, "fitness_function.query", start, now)
+        
+        for item in self.fitness_function.items:
+            self._validate_query(item.query, f"fitness_function.items[{item.id}]", start, now)
+
+    def _validate_query(self, query: str, context: str, start: datetime.datetime, end: datetime.datetime):
+        """Run a dry-run query and raise if Prometheus returns no data or multiple series."""
+        test_query = query.replace("$range$", "5m") if "$range$" in query else query
+        
+        try:
+            result = self.prom_client.process_prom_query_in_range(
+                test_query,
+                start_time=start,
+                end_time=end,
+                granularity=100,
+            )
+            
+            series_list = result or []
+            if len(series_list) > 1:
+                raise FitnessFunctionConfigurationError(
+                    f"Pre-flight check failed: query '{query}' ({context}) "
+                    f"returned {len(series_list)} series. Fitness queries must return exactly "
+                    f"one series. Use sum(), max(), avg(), or another PromQL aggregate."
+                )
+            if not series_list or not series_list[0].get("values"):
+                raise FitnessFunctionConfigurationError(
+                    f"Pre-flight check failed: query '{query}' ({context}) "
+                    f"returned no data. This query will fail during the experiment. "
+                    f"Verify the metric exists and the namespace selector is correct."
+                )
+        except FitnessFunctionConfigurationError:
+            raise
+        except Exception as e:
+            raise FitnessFunctionConfigurationError(
+                f"Pre-flight check failed: query '{query}' ({context}) "
+                f"errored: {e}. Fix this before starting the experiment."
+            )
+
     def calculate_fitness_value(self, start, end, query, fitness_type):
         """Calculate fitness score for scenario run"""
         if env_is_truthy("MOCK_FITNESS"):

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -27,45 +27,71 @@ class FitnessCalculator:
 
         now = datetime.datetime.now()
         start = now - datetime.timedelta(minutes=5)
-        
-        if self.fitness_function.query is not None:
-            self._validate_query(self.fitness_function.query, "fitness_function.query", start, now)
-        
-        for item in self.fitness_function.items:
-            self._validate_query(item.query, f"fitness_function.items[{item.id}]", start, now)
 
-    def _validate_query(self, query: str, context: str, start: datetime.datetime, end: datetime.datetime):
+        if getattr(self.fitness_function, "query", None) is not None:
+            self._validate_query(
+                self.fitness_function.query, "fitness_function.query", start, now
+            )
+
+        for item in getattr(self.fitness_function, "items", []):
+            self._validate_query(
+                item.query, f"fitness_function.items[{item.id}]", start, now
+            )
+
+    def _validate_query(
+        self, query: str, context: str, start: datetime.datetime, end: datetime.datetime
+    ):
         """Run a dry-run query and raise if Prometheus returns no data or multiple series."""
         test_query = query.replace("$range$", "5m") if "$range$" in query else query
-        
-        try:
-            result = self.prom_client.process_prom_query_in_range(
-                test_query,
-                start_time=start,
-                end_time=end,
-                granularity=100,
-            )
-            
-            series_list = result or []
-            if len(series_list) > 1:
-                raise FitnessFunctionConfigurationError(
-                    f"Pre-flight check failed: query '{query}' ({context}) "
-                    f"returned {len(series_list)} series. Fitness queries must return exactly "
-                    f"one series. Use sum(), max(), avg(), or another PromQL aggregate."
+
+        retries = 3
+        retry_delay = 5
+
+        for attempt in range(retries):
+            try:
+                result = self.prom_client.process_prom_query_in_range(
+                    test_query,
+                    start_time=start,
+                    end_time=end,
+                    granularity=100,
                 )
-            if not series_list or not series_list[0].get("values"):
-                raise FitnessFunctionConfigurationError(
-                    f"Pre-flight check failed: query '{query}' ({context}) "
-                    f"returned no data. This query will fail during the experiment. "
-                    f"Verify the metric exists and the namespace selector is correct."
-                )
-        except FitnessFunctionConfigurationError:
-            raise
-        except Exception as e:
-            raise FitnessFunctionConfigurationError(
-                f"Pre-flight check failed: query '{query}' ({context}) "
-                f"errored: {e}. Fix this before starting the experiment."
-            )
+
+                series_list = result or []
+                if len(series_list) > 1:
+                    raise FitnessFunctionConfigurationError(
+                        f"Pre-flight check failed: query '{query}' ({context}) "
+                        f"returned {len(series_list)} series. Fitness queries must return exactly "
+                        f"one series. Use sum(), max(), avg(), or another PromQL aggregate."
+                    )
+                if not series_list or not series_list[0].get("values"):
+                    if attempt < retries - 1:
+                        logger.warning(
+                            f"Pre-flight check: query '{query}' returned no data. Retrying... ({attempt + 1}/{retries})"
+                        )
+                        time.sleep(retry_delay)
+                        continue
+                    else:
+                        raise FitnessFunctionConfigurationError(
+                            f"Pre-flight check failed: query '{query}' ({context}) "
+                            f"returned no data. This query will fail during the experiment. "
+                            f"Verify the metric exists and the namespace selector is correct."
+                        )
+                # Success
+                return
+            except FitnessFunctionConfigurationError:
+                raise
+            except Exception as e:
+                if attempt < retries - 1:
+                    logger.warning(
+                        f"Pre-flight check errored: {e}. Retrying... ({attempt + 1}/{retries})"
+                    )
+                    time.sleep(retry_delay)
+                    continue
+                else:
+                    raise FitnessFunctionConfigurationError(
+                        f"Pre-flight check failed: query '{query}' ({context}) "
+                        f"errored: {e}. Fix this before starting the experiment."
+                    )
 
     def calculate_fitness_value(self, start, end, query, fitness_type):
         """Calculate fitness score for scenario run"""

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -40,7 +40,7 @@ class KrknRunner:
         self.fitness_calculator = FitnessCalculator(
             self.prom_client, config.fitness_function
         )
-        
+
         if not env_is_truthy("MOCK_FITNESS"):
             logger.info("Running pre-flight fitness function validation...")
             self.fitness_calculator.preflight_check()

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -40,6 +40,12 @@ class KrknRunner:
         self.fitness_calculator = FitnessCalculator(
             self.prom_client, config.fitness_function
         )
+        
+        if not env_is_truthy("MOCK_FITNESS"):
+            logger.info("Running pre-flight fitness function validation...")
+            self.fitness_calculator.preflight_check()
+            logger.info("Pre-flight fitness validation passed.")
+
         self.output_dir = output_dir
         if runner_type is None:
             self.runner_type = self.__check_runner_availability()

--- a/tests/unit/chaos_engines/test_preflight.py
+++ b/tests/unit/chaos_engines/test_preflight.py
@@ -1,36 +1,40 @@
-import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from krkn_ai.chaos_engines.fitness import FitnessCalculator
-from krkn_ai.models.config import FitnessFunction, FitnessFunctionItem, FitnessFunctionType
+from krkn_ai.models.config import FitnessFunction, FitnessFunctionItem
 from krkn_ai.models.custom_errors import FitnessFunctionConfigurationError
+
 
 class TestPreflightCheck:
     def setup_method(self):
+        self.mock_sleep = patch("time.sleep").start()
+
         self.mock_prom_client = MagicMock()
-        
+
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_mock_fitness_skips_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = True
         fitness_function = FitnessFunction(query="up")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         calculator.preflight_check()
-        
+
         self.mock_prom_client.process_prom_query_in_range.assert_not_called()
 
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_valid_query_passes_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
-        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
-        
+        self.mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {}, "values": [[1620000000, "1"]]}
+        ]
+
         fitness_function = FitnessFunction(query="up")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         calculator.preflight_check()
-        
+
         self.mock_prom_client.process_prom_query_in_range.assert_called_once()
         args, kwargs = self.mock_prom_client.process_prom_query_in_range.call_args
         assert args[0] == "up"
@@ -39,13 +43,15 @@ class TestPreflightCheck:
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_range_variable_substituted(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
-        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
-        
+        self.mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {}, "values": [[1620000000, "1"]]}
+        ]
+
         fitness_function = FitnessFunction(query="sum(rate(up[$range$]))")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         calculator.preflight_check()
-        
+
         args, _ = self.mock_prom_client.process_prom_query_in_range.call_args
         assert args[0] == "sum(rate(up[5m]))"
 
@@ -53,49 +59,55 @@ class TestPreflightCheck:
     def test_empty_results_raises_error(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = []
-        
+
         fitness_function = FitnessFunction(query="non_existent_metric")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         with pytest.raises(FitnessFunctionConfigurationError, match="returned no data"):
             calculator.preflight_check()
+
+        assert self.mock_prom_client.process_prom_query_in_range.call_count == 3
 
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_multiple_series_raises_error(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = [
             {"metric": {"instance": "a"}, "values": [[1620000000, "1"]]},
-            {"metric": {"instance": "b"}, "values": [[1620000000, "1"]]}
+            {"metric": {"instance": "b"}, "values": [[1620000000, "1"]]},
         ]
-        
+
         fitness_function = FitnessFunction(query="up")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
-        with pytest.raises(FitnessFunctionConfigurationError, match="returned 2 series"):
+
+        with pytest.raises(
+            FitnessFunctionConfigurationError, match="returned 2 series"
+        ):
             calculator.preflight_check()
 
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_validates_multiple_items(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
-        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
-        
+        self.mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {}, "values": [[1620000000, "1"]]}
+        ]
+
         item1 = FitnessFunctionItem(query="up")
         item2 = FitnessFunctionItem(query="kube_pod_status_ready")
         fitness_function = FitnessFunction(items=[item1, item2])
-        
+
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         calculator.preflight_check()
-        
+
         assert self.mock_prom_client.process_prom_query_in_range.call_count == 2
 
     @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
     def test_empty_query_fails_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = []
-        
+
         fitness_function = FitnessFunction(query="")
         calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
-        
+
         with pytest.raises(FitnessFunctionConfigurationError, match="returned no data"):
             calculator.preflight_check()

--- a/tests/unit/chaos_engines/test_preflight.py
+++ b/tests/unit/chaos_engines/test_preflight.py
@@ -88,3 +88,14 @@ class TestPreflightCheck:
         calculator.preflight_check()
         
         assert self.mock_prom_client.process_prom_query_in_range.call_count == 2
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_empty_query_fails_preflight(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = []
+        
+        fitness_function = FitnessFunction(query="")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        with pytest.raises(FitnessFunctionConfigurationError, match="returned no data"):
+            calculator.preflight_check()

--- a/tests/unit/chaos_engines/test_preflight.py
+++ b/tests/unit/chaos_engines/test_preflight.py
@@ -1,0 +1,90 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from krkn_ai.chaos_engines.fitness import FitnessCalculator
+from krkn_ai.models.config import FitnessFunction, FitnessFunctionItem, FitnessFunctionType
+from krkn_ai.models.custom_errors import FitnessFunctionConfigurationError
+
+class TestPreflightCheck:
+    def setup_method(self):
+        self.mock_prom_client = MagicMock()
+        
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_mock_fitness_skips_preflight(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = True
+        fitness_function = FitnessFunction(query="up")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        calculator.preflight_check()
+        
+        self.mock_prom_client.process_prom_query_in_range.assert_not_called()
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_valid_query_passes_preflight(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
+        
+        fitness_function = FitnessFunction(query="up")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        calculator.preflight_check()
+        
+        self.mock_prom_client.process_prom_query_in_range.assert_called_once()
+        args, kwargs = self.mock_prom_client.process_prom_query_in_range.call_args
+        assert args[0] == "up"
+        assert kwargs["granularity"] == 100
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_range_variable_substituted(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
+        
+        fitness_function = FitnessFunction(query="sum(rate(up[$range$]))")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        calculator.preflight_check()
+        
+        args, _ = self.mock_prom_client.process_prom_query_in_range.call_args
+        assert args[0] == "sum(rate(up[5m]))"
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_empty_results_raises_error(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = []
+        
+        fitness_function = FitnessFunction(query="non_existent_metric")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        with pytest.raises(FitnessFunctionConfigurationError, match="returned no data"):
+            calculator.preflight_check()
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_multiple_series_raises_error(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = [
+            {"metric": {"instance": "a"}, "values": [[1620000000, "1"]]},
+            {"metric": {"instance": "b"}, "values": [[1620000000, "1"]]}
+        ]
+        
+        fitness_function = FitnessFunction(query="up")
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        with pytest.raises(FitnessFunctionConfigurationError, match="returned 2 series"):
+            calculator.preflight_check()
+
+    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    def test_validates_multiple_items(self, mock_env_is_truthy):
+        mock_env_is_truthy.return_value = False
+        self.mock_prom_client.process_prom_query_in_range.return_value = [{"metric": {}, "values": [[1620000000, "1"]]}]
+        
+        item1 = FitnessFunctionItem(query="up")
+        item2 = FitnessFunctionItem(query="kube_pod_status_ready")
+        fitness_function = FitnessFunction(items=[item1, item2])
+        
+        calculator = FitnessCalculator(self.mock_prom_client, fitness_function)
+        
+        calculator.preflight_check()
+        
+        assert self.mock_prom_client.process_prom_query_in_range.call_count == 2


### PR DESCRIPTION
Fixes #404

## Description
This PR adds a pre-flight validation step to check every configured fitness query against Prometheus before the genetic algorithm starts running scenarios. If a PromQL query returns no data or fails to execute, it fails fast with a clear error message instead of wasting hours of compute.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
Added unit tests covering:
- Valid queries passing validation
- Empty results raising `FitnessFunctionConfigurationError`
- Multi-series results raising `FitnessFunctionConfigurationError`
- `$range$` substitution logic
- Bypassing validation when `MOCK_FITNESS` is enabled.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
