### PR TITLE
feat(discover): dynamic fitness_function recommendations

### DIFF
--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -23,6 +23,9 @@ from krkn_ai.reporter.json_summary_reporter import JSONSummaryReporter
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.utils.output import format_duration
 from krkn_ai.utils.rng import rng
+from krkn_ai.utils.weight_learning import learn_weights, save_learned_weights
+
+LEARNED_WEIGHTS_FILE = "learned_weights.json"
 
 logger = get_logger(__name__)
 
@@ -209,10 +212,24 @@ class GeneticAlgorithm(BaseEngine):
         )
         summary_reporter.save(self.output_dir)
 
+        self._save_learned_weights()
+
         if self.elastic_client is not None:
             self.elastic_client.index_run_summary(
                 summary_reporter.generate_summary(), self.run_uuid
             )
+
+    def _save_learned_weights(self):
+        """Learn per-query weights from this run's scenarios for future runs to seed."""
+        items = self.config.fitness_function.items
+        if not items:
+            return
+        weights = learn_weights(self.seen_population.values(), items)
+        if not weights:
+            return
+        path = os.path.join(self.output_dir, LEARNED_WEIGHTS_FILE)
+        save_learned_weights(weights, path)
+        logger.info("Saved learned fitness weights to %s", path)
 
     def adapt_mutation_rate(self):
         cfg = self.algo_config.adaptive_mutation

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -324,7 +324,7 @@ def discover(
                 "Prometheus unavailable; using static fitness default (%s).", e
             )
         except Exception as e:
-            logger.debug("Fitness query recommendation failed: %s", e)
+            logger.warning("Fitness query recommendation failed: %s", e)
     save_discovery(
         output,
         save_strategy,

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -24,6 +24,7 @@ from krkn_ai.models.custom_errors import (
 from krkn_ai.utils.fs import read_config_from_file, save_discovery
 from krkn_ai.utils.prometheus import create_prometheus_client
 from krkn_ai.utils.catalog import recommend_fitness_queries
+from krkn_ai.utils.weight_learning import load_learned_weights
 from krkn_ai.cluster import ClusterManager
 from krkn_ai.models.scenario.factory import ScenarioFactory
 
@@ -261,6 +262,11 @@ def monitor(ctx, output: str, port: int):
     default="skip",
     help="How to save: skip, overwrite (replace), or merge (add new components, keep your edits). Note: merge does not preserve comments.",
 )
+@click.option(
+    "--learned-weights",
+    help="Path to a learned_weights.json from a previous run, to prioritize fitness queries.",
+    default=None,
+)
 @click.pass_context
 def discover(
     ctx,
@@ -272,6 +278,7 @@ def discover(
     verbose: int = 0,
     skip_pod_name: str = None,
     save_strategy: str = "skip",
+    learned_weights: str = None,
 ):
     init_logger(None, verbose >= 2)
     logger = get_logger(__name__)
@@ -311,18 +318,19 @@ def discover(
         if fresh_write
         else None
     )
-    # suggest fitness queries from the cluster; fall back to the static default.
+    # recommend fitness queries on fresh writes and merges; else keep the static default.
+    recommend_fitness = fresh_write or save_strategy.lower() == "merge"
     fitness_queries = None
-    if fresh_write:
+    if recommend_fitness:
         try:
             prom_client = create_prometheus_client(kubeconfig)
             fitness_queries = recommend_fitness_queries(
-                cluster_components, prom_client
+                cluster_components,
+                prom_client,
+                load_learned_weights(learned_weights),
             )
         except PrometheusConnectionError as e:
-            logger.info(
-                "Prometheus unavailable; using static fitness default (%s).", e
-            )
+            logger.info("Prometheus unavailable; using static fitness default (%s).", e)
         except Exception as e:
             logger.warning("Fitness query recommendation failed: %s", e)
     save_discovery(

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -22,6 +22,8 @@ from krkn_ai.models.custom_errors import (
     UniqueScenariosError,
 )
 from krkn_ai.utils.fs import read_config_from_file, save_discovery
+from krkn_ai.utils.prometheus import create_prometheus_client
+from krkn_ai.utils.catalog import recommend_fitness_queries
 from krkn_ai.cluster import ClusterManager
 from krkn_ai.models.scenario.factory import ScenarioFactory
 
@@ -297,15 +299,31 @@ def discover(
         logger.error("An unexpected error occurred during discovery: %s", e)
         sys.exit(1)
 
+    fresh_write = not os.path.exists(output) or save_strategy.lower() == "overwrite"
     scenario_enables = (
         ScenarioFactory.recommend_enabled_scenarios(cluster_components, kubeconfig)
-        if not os.path.exists(output) or save_strategy.lower() == "overwrite"
+        if fresh_write
         else None
     )
+    # suggest fitness queries from the cluster; fall back to the static default.
+    fitness_queries = None
+    if fresh_write:
+        try:
+            prom_client = create_prometheus_client(kubeconfig)
+            fitness_queries = recommend_fitness_queries(
+                cluster_components, prom_client
+            )
+        except PrometheusConnectionError as e:
+            logger.info(
+                "Prometheus unavailable; using static fitness default (%s).", e
+            )
+        except Exception as e:
+            logger.debug("Fitness query recommendation failed: %s", e)
     save_discovery(
         output,
         save_strategy,
         cluster_components,
         kubeconfig,
         scenario_enables=scenario_enables,
+        fitness_queries=fitness_queries,
     )

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -15,6 +15,7 @@ def create_krkn_ai_template(
     kubeconfig_file_path: str,
     cluster_component_data: dict,
     scenario_enables: dict = None,
+    fitness_queries: list = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -47,4 +48,5 @@ def create_krkn_ai_template(
         kubeconfig_file_path=kubeconfig_file_path,
         cluster_components=cluster_components_indented,
         scenario_enables=scenario_enables,
+        fitness_queries=fitness_queries,
     )

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -15,8 +15,8 @@ def create_krkn_ai_template(
     kubeconfig_file_path: str,
     cluster_component_data: dict,
     scenario_enables: dict = None,
-    fitness_queries: list = None,
     health_checks: list = None,
+    fitness_queries: list = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -65,12 +65,33 @@ elastic:
 
 
 fitness_function:
-  # Use an aggregate query that returns one Prometheus series.
-  query: 'sum(kube_pod_container_status_restarts_total)'
-  type: point
   include_krkn_failure: true
   include_health_check_failure: true
   include_health_check_response_time: true
+{%- set enabled_ff = fitness_queries | default([]) | selectattr('enabled') | list %}
+{%- set disabled_ff = fitness_queries | default([]) | rejectattr('enabled') | list %}
+{%- if enabled_ff %}
+  # Fitness queries validated against the cluster's Prometheus.
+  items:
+{%- for f in enabled_ff %}
+  # {{ f.name }}
+  - query: '{{ f.query }}'
+    type: {{ f.type }}
+    weight: {{ f.weight }}
+{%- endfor %}
+{%- for f in disabled_ff %}
+  # {{ f.name }} ({{ f.reason }})
+  # - query: '{{ f.query }}'
+  #   type: {{ f.type }}
+{%- endfor %}
+{%- else %}
+  # Aggregate query returning one Prometheus series.
+  query: 'sum(kube_pod_container_status_restarts_total)'
+  type: point
+{%- for f in disabled_ff %}
+  # {{ f.name }} ({{ f.reason }}): {{ f.query }}
+{%- endfor %}
+{%- endif %}
 
 # health_checks:
 #   stop_watcher_on_failure: false

--- a/krkn_ai/utils/catalog.py
+++ b/krkn_ai/utils/catalog.py
@@ -1,15 +1,20 @@
 """Catalog of PromQL fitness queries and a recommender that adapts them per cluster."""
 
+import os
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, field_validator
+import yaml
+from pydantic import BaseModel
 
 from krkn_ai.models.cluster_components import ClusterComponents
 from krkn_ai.models.config import FitnessFunctionItem, FitnessFunctionType
 from krkn_ai.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_CATALOG_PATH = os.path.join(os.path.dirname(__file__), "catalog.yaml")
+_VALIDATION_RANGE = "5m"
 
 
 class FitnessCategory(str, Enum):
@@ -28,21 +33,13 @@ class CatalogEntry(BaseModel):
     """A fitness query template, where $ns is a namespace and $range$ the run window."""
 
     key: str
-    category: FitnessCategory
-    name: str
     query_template: str
+    category: Optional[FitnessCategory] = None
+    name: Optional[str] = None
     type: FitnessFunctionType = FitnessFunctionType.range
-    requires: List[str]
+    requires: List[str] = []
     scope: Scope = Scope.namespace
-    default_weight: float = 1.0
-
-    @field_validator("default_weight")
-    @classmethod
-    def _weight_range(cls, value: float) -> float:
-        # Match FitnessFunctionItem's [0.0, 1.0] constraint.
-        if value < 0 or value > 1:
-            raise ValueError(f"{value} is outside the range [0.0, 1.0]")
-        return value
+    default_weight: float = 1.0  # seed used when there's no learned weight
 
     def resolved_query(self, namespace: Optional[str] = None) -> str:
         """Fill $ns; $range$ is left for the runtime executor."""
@@ -58,84 +55,13 @@ class CatalogEntry(BaseModel):
         )
 
 
-# High-impact signals: restarts, downtime, OOM, CPU throttling, node and API health.
-BASE_CATALOG: List[CatalogEntry] = [
-    CatalogEntry(
-        key="pod-restarts",
-        category=FitnessCategory.availability,
-        name="Pod container restarts",
-        query_template=(
-            'sum(increase(kube_pod_container_status_restarts_total'
-            '{namespace="$ns"}[$range$]))'
-        ),
-        requires=["kube_pod_container_status_restarts_total"],
-        scope=Scope.namespace,
-    ),
-    CatalogEntry(
-        key="pod-unavailable",
-        category=FitnessCategory.availability,
-        name="Non-running pods (Pending/Failed/Unknown)",
-        query_template=(
-            'sum(kube_pod_status_phase'
-            '{namespace="$ns", phase=~"Pending|Failed|Unknown"})'
-        ),
-        requires=["kube_pod_status_phase"],
-        scope=Scope.namespace,
-    ),
-    CatalogEntry(
-        # 0 series until a container was last killed by OOM.
-        key="oom-kills",
-        category=FitnessCategory.resource,
-        name="Containers last terminated by OOMKilled",
-        query_template=(
-            'sum(kube_pod_container_status_last_terminated_reason'
-            '{namespace="$ns", reason="OOMKilled"})'
-        ),
-        requires=["kube_pod_container_status_last_terminated_reason"],
-        scope=Scope.namespace,
-    ),
-    CatalogEntry(
-        key="cpu-throttle",
-        category=FitnessCategory.resource,
-        name="Worst-container CPU throttling ratio",
-        query_template=(
-            "max("
-            "rate(container_cpu_cfs_throttled_periods_total"
-            '{namespace="$ns", container!=""}[$range$])'
-            " / "
-            "rate(container_cpu_cfs_periods_total"
-            '{namespace="$ns", container!=""}[$range$])'
-            ")"
-        ),
-        requires=[
-            "container_cpu_cfs_throttled_periods_total",
-            "container_cpu_cfs_periods_total",
-        ],
-        scope=Scope.namespace,
-    ),
-    CatalogEntry(
-        key="node-pressure",
-        category=FitnessCategory.node,
-        name="Nodes reporting a pressure condition",
-        query_template=(
-            "sum(kube_node_status_condition"
-            '{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})'
-        ),
-        requires=["kube_node_status_condition"],
-        scope=Scope.cluster,
-    ),
-    CatalogEntry(
-        key="apiserver-errors",
-        category=FitnessCategory.control_plane,
-        name="API server 5xx error fraction",
-        query_template=(
-            'sum(rate(apiserver_request_total{code=~"5.."}[$range$]))'
-            " / sum(rate(apiserver_request_total[$range$]))"
-        ),
-        requires=["apiserver_request_total"],
-        scope=Scope.cluster,
-    ),
-]
+def _load_catalog() -> List[CatalogEntry]:
+    with open(_CATALOG_PATH, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or []
+    return [CatalogEntry.model_validate(e) for e in data]
+
+
+BASE_CATALOG: List[CatalogEntry] = _load_catalog()
 
 
 def get_base_catalog() -> List[CatalogEntry]:
@@ -144,8 +70,6 @@ def get_base_catalog() -> List[CatalogEntry]:
 
 
 # Dynamic layer: adapt the catalog to a live cluster
-
-_VALIDATION_RANGE = "5m"
 
 
 def _safe_query(query: str) -> str:
@@ -165,10 +89,20 @@ def _validate_shape(prom_client, query: str) -> tuple:
     return True, ""
 
 
+def _assign_weights(enabled: List[dict]) -> None:
+    """Normalize seed weights across enabled items (equal when all are default)."""
+    total = sum(r["weight"] for r in enabled)
+    if total <= 0:
+        return
+    for r in enabled:
+        r["weight"] = round(r["weight"] / total, 4)
+
+
 def recommend_fitness_queries(
-    components: ClusterComponents, prom_client
+    components: ClusterComponents, prom_client, learned_weights: dict = None
 ) -> List[Dict[str, Union[str, bool, float]]]:
-    """Suggest fitness queries for the cluster, gated on which metrics exist."""
+    """Suggest fitness queries the cluster can run, seeded by learned_weights if given."""
+    learned_weights = learned_weights or {}
     try:
         available = set(prom_client.prom_cli.all_metrics())
     except Exception as error:
@@ -198,18 +132,11 @@ def recommend_fitness_queries(
                     "name": name,
                     "query": query,
                     "type": entry.type.value,
-                    "weight": entry.default_weight,
+                    "weight": learned_weights.get(query, entry.default_weight),
                     "enabled": enabled,
                     "reason": reason,
                 }
             )
 
-    # split weight evenly across enabled items
-    enabled_count = sum(1 for r in results if r["enabled"])
-    if enabled_count:
-        share = round(1.0 / enabled_count, 4)
-        for r in results:
-            if r["enabled"]:
-                r["weight"] = share
-
+    _assign_weights([r for r in results if r["enabled"]])
     return results

--- a/krkn_ai/utils/catalog.py
+++ b/krkn_ai/utils/catalog.py
@@ -1,0 +1,215 @@
+"""Catalog of PromQL fitness queries and a recommender that adapts them per cluster."""
+
+from enum import Enum
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, field_validator
+
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.config import FitnessFunctionItem, FitnessFunctionType
+from krkn_ai.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class FitnessCategory(str, Enum):
+    availability = "availability"
+    resource = "resource"
+    node = "node"
+    control_plane = "control_plane"
+
+
+class Scope(str, Enum):
+    namespace = "namespace"  # filtered by a discovered namespace ($ns)
+    cluster = "cluster"  # cluster-wide
+
+
+class CatalogEntry(BaseModel):
+    """A fitness query template, where $ns is a namespace and $range$ the run window."""
+
+    key: str
+    category: FitnessCategory
+    name: str
+    query_template: str
+    type: FitnessFunctionType = FitnessFunctionType.range
+    requires: List[str]
+    scope: Scope = Scope.namespace
+    default_weight: float = 1.0
+
+    @field_validator("default_weight")
+    @classmethod
+    def _weight_range(cls, value: float) -> float:
+        # Match FitnessFunctionItem's [0.0, 1.0] constraint.
+        if value < 0 or value > 1:
+            raise ValueError(f"{value} is outside the range [0.0, 1.0]")
+        return value
+
+    def resolved_query(self, namespace: Optional[str] = None) -> str:
+        """Fill $ns; $range$ is left for the runtime executor."""
+        if namespace:
+            return self.query_template.replace("$ns", namespace)
+        return self.query_template
+
+    def to_fitness_item(self, namespace: Optional[str] = None) -> FitnessFunctionItem:
+        return FitnessFunctionItem(
+            query=self.resolved_query(namespace),
+            type=self.type,
+            weight=self.default_weight,
+        )
+
+
+# High-impact signals: restarts, downtime, OOM, CPU throttling, node and API health.
+BASE_CATALOG: List[CatalogEntry] = [
+    CatalogEntry(
+        key="pod-restarts",
+        category=FitnessCategory.availability,
+        name="Pod container restarts",
+        query_template=(
+            'sum(increase(kube_pod_container_status_restarts_total'
+            '{namespace="$ns"}[$range$]))'
+        ),
+        requires=["kube_pod_container_status_restarts_total"],
+        scope=Scope.namespace,
+    ),
+    CatalogEntry(
+        key="pod-unavailable",
+        category=FitnessCategory.availability,
+        name="Non-running pods (Pending/Failed/Unknown)",
+        query_template=(
+            'sum(kube_pod_status_phase'
+            '{namespace="$ns", phase=~"Pending|Failed|Unknown"})'
+        ),
+        requires=["kube_pod_status_phase"],
+        scope=Scope.namespace,
+    ),
+    CatalogEntry(
+        # 0 series until a container was last killed by OOM.
+        key="oom-kills",
+        category=FitnessCategory.resource,
+        name="Containers last terminated by OOMKilled",
+        query_template=(
+            'sum(kube_pod_container_status_last_terminated_reason'
+            '{namespace="$ns", reason="OOMKilled"})'
+        ),
+        requires=["kube_pod_container_status_last_terminated_reason"],
+        scope=Scope.namespace,
+    ),
+    CatalogEntry(
+        key="cpu-throttle",
+        category=FitnessCategory.resource,
+        name="Worst-container CPU throttling ratio",
+        query_template=(
+            "max("
+            "rate(container_cpu_cfs_throttled_periods_total"
+            '{namespace="$ns", container!=""}[$range$])'
+            " / "
+            "rate(container_cpu_cfs_periods_total"
+            '{namespace="$ns", container!=""}[$range$])'
+            ")"
+        ),
+        requires=[
+            "container_cpu_cfs_throttled_periods_total",
+            "container_cpu_cfs_periods_total",
+        ],
+        scope=Scope.namespace,
+    ),
+    CatalogEntry(
+        key="node-pressure",
+        category=FitnessCategory.node,
+        name="Nodes reporting a pressure condition",
+        query_template=(
+            "sum(kube_node_status_condition"
+            '{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})'
+        ),
+        requires=["kube_node_status_condition"],
+        scope=Scope.cluster,
+    ),
+    CatalogEntry(
+        key="apiserver-errors",
+        category=FitnessCategory.control_plane,
+        name="API server 5xx error fraction",
+        query_template=(
+            'sum(rate(apiserver_request_total{code=~"5.."}[$range$]))'
+            " / sum(rate(apiserver_request_total[$range$]))"
+        ),
+        requires=["apiserver_request_total"],
+        scope=Scope.cluster,
+    ),
+]
+
+
+def get_base_catalog() -> List[CatalogEntry]:
+    """Return the base fitness-function catalog."""
+    return BASE_CATALOG
+
+
+# Dynamic layer: adapt the catalog to a live cluster
+
+_VALIDATION_RANGE = "5m"
+
+
+def _safe_query(query: str) -> str:
+    # `or vector(0)` returns 0 when nothing matches
+    return f"({query}) or vector(0)"
+
+
+def _validate_shape(prom_client, query: str) -> tuple:
+    """Run the query and keep it if it returns 0 or 1 series. Returns (enabled, reason)."""
+    runnable = query.replace("$range$", _VALIDATION_RANGE)
+    try:
+        result = prom_client.process_query(runnable) or []
+    except Exception as error:
+        return False, f"query failed to run: {error}"
+    if len(result) > 1:
+        return False, f"returns {len(result)} series, needs aggregation (sum/max/avg)"
+    return True, ""
+
+
+def recommend_fitness_queries(
+    components: ClusterComponents, prom_client
+) -> List[Dict[str, Union[str, bool, float]]]:
+    """Suggest fitness queries for the cluster, gated on which metrics exist."""
+    try:
+        available = set(prom_client.prom_cli.all_metrics())
+    except Exception as error:
+        logger.debug("Could not list Prometheus metrics: %s", error)
+        return []
+
+    active_namespaces = [
+        ns.name for ns in components.get_active_components().namespaces
+    ]
+
+    results: List[Dict[str, Union[str, bool, float]]] = []
+    for entry in get_base_catalog():
+        missing = [m for m in entry.requires if m not in available]
+        targets = active_namespaces if entry.scope is Scope.namespace else [None]
+
+        for namespace in targets:
+            query = _safe_query(entry.resolved_query(namespace))
+            name = f"{entry.key}:{namespace}" if namespace else entry.key
+
+            if missing:
+                enabled, reason = False, "metric(s) not scraped: " + ", ".join(missing)
+            else:
+                enabled, reason = _validate_shape(prom_client, query)
+
+            results.append(
+                {
+                    "name": name,
+                    "query": query,
+                    "type": entry.type.value,
+                    "weight": entry.default_weight,
+                    "enabled": enabled,
+                    "reason": reason,
+                }
+            )
+
+    # split weight evenly across enabled items
+    enabled_count = sum(1 for r in results if r["enabled"])
+    if enabled_count:
+        share = round(1.0 / enabled_count, 4)
+        for r in results:
+            if r["enabled"]:
+                r["weight"] = share
+
+    return results

--- a/krkn_ai/utils/catalog.yaml
+++ b/krkn_ai/utils/catalog.yaml
@@ -1,0 +1,42 @@
+# Fitness queries. Only key and query_template are required; $ns and $range$ are filled at runtime.
+- key: pod-restarts
+  category: availability
+  name: Pod container restarts
+  query_template: 'sum(increase(kube_pod_container_status_restarts_total{namespace="$ns"}[$range$]))'
+  requires: [kube_pod_container_status_restarts_total]
+  scope: namespace
+
+- key: pod-unavailable
+  category: availability
+  name: Non-running pods (Pending/Failed/Unknown)
+  query_template: 'sum(kube_pod_status_phase{namespace="$ns", phase=~"Pending|Failed|Unknown"})'
+  requires: [kube_pod_status_phase]
+  scope: namespace
+
+- key: oom-kills
+  category: resource
+  name: Containers last terminated by OOMKilled
+  query_template: 'sum(kube_pod_container_status_last_terminated_reason{namespace="$ns", reason="OOMKilled"})'
+  requires: [kube_pod_container_status_last_terminated_reason]
+  scope: namespace
+
+- key: cpu-throttle
+  category: resource
+  name: Worst-container CPU throttling ratio
+  query_template: 'max(rate(container_cpu_cfs_throttled_periods_total{namespace="$ns", container!=""}[$range$]) / rate(container_cpu_cfs_periods_total{namespace="$ns", container!=""}[$range$]))'
+  requires: [container_cpu_cfs_throttled_periods_total, container_cpu_cfs_periods_total]
+  scope: namespace
+
+- key: node-pressure
+  category: node
+  name: Nodes reporting a pressure condition
+  query_template: 'sum(kube_node_status_condition{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})'
+  requires: [kube_node_status_condition]
+  scope: cluster
+
+- key: apiserver-errors
+  category: control_plane
+  name: API server 5xx error fraction
+  query_template: 'sum(rate(apiserver_request_total{code=~"5.."}[$range$])) / sum(rate(apiserver_request_total[$range$]))'
+  requires: [apiserver_request_total]
+  scope: cluster

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -139,8 +139,28 @@ def merge_components(
     return ClusterComponents(namespaces=list(namespaces.values()), nodes=nodes)
 
 
+def _merge_fitness_items(raw: dict, fitness_queries: list = None) -> None:
+    """Add newly recommended enabled fitness items, keeping the user's existing ones."""
+    if not fitness_queries:
+        return
+    ff = raw.setdefault("fitness_function", {})
+    items = ff.get("items") or []
+    seen = {item.get("query") for item in items}
+    for f in fitness_queries:
+        if f.get("enabled") and f["query"] not in seen:
+            items.append(
+                {"query": f["query"], "type": f["type"], "weight": f["weight"]}
+            )
+            seen.add(f["query"])
+    if items:
+        ff["items"] = items
+
+
 def _build_merged_config(
-    output: str, discovered: ClusterComponents, kubeconfig: str
+    output: str,
+    discovered: ClusterComponents,
+    kubeconfig: str,
+    fitness_queries: list = None,
 ) -> Union[str, None]:
     """Merge discovered components into the existing config, keeping the user's
     edits."""
@@ -160,6 +180,7 @@ def _build_merged_config(
     raw["cluster_components"] = merged.model_dump(
         mode="json", warnings="none", exclude_defaults=True
     )
+    _merge_fitness_items(raw, fitness_queries)
     return yaml.safe_dump(
         raw, default_flow_style=False, sort_keys=False, allow_unicode=True
     )
@@ -176,7 +197,11 @@ def _write_fresh(
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
     template = create_krkn_ai_template(
-    kubeconfig, data, scenario_enables, fitness_queries, health_checks
+        kubeconfig,
+        data,
+        scenario_enables,
+        health_checks=health_checks,
+        fitness_queries=fitness_queries,
     )
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
@@ -205,7 +230,7 @@ def save_discovery(
         return
 
     if exists and strategy == "merge":
-        text = _build_merged_config(output, components, kubeconfig)
+        text = _build_merged_config(output, components, kubeconfig, fitness_queries)
         if text is None:
             return
         with open(output, "w", encoding="utf-8") as f:
@@ -216,5 +241,11 @@ def save_discovery(
     if exists and strategy == "overwrite":
         logger.warning("Overwriting existing %s", output)
 
-     _write_fresh(output, components, kubeconfig, scenario_enables, fitness_queries, health_checks)
-
+    _write_fresh(
+        output,
+        components,
+        kubeconfig,
+        scenario_enables,
+        fitness_queries,
+        health_checks,
+    )

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -182,10 +182,13 @@ def _write_fresh(
     components: ClusterComponents,
     kubeconfig: str,
     scenario_enables: dict = None,
+    fitness_queries: list = None,
 ):
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
-    template = create_krkn_ai_template(kubeconfig, data, scenario_enables)
+    template = create_krkn_ai_template(
+        kubeconfig, data, scenario_enables, fitness_queries
+    )
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
     logger.info("Saved component configuration to %s", output)
@@ -197,6 +200,7 @@ def save_discovery(
     components: ClusterComponents,
     kubeconfig: str,
     scenario_enables: dict = None,
+    fitness_queries: list = None,
 ):
     """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
     strategy = strategy.lower()
@@ -222,4 +226,4 @@ def save_discovery(
     if exists and strategy == "overwrite":
         logger.warning("Overwriting existing %s", output)
 
-    _write_fresh(output, components, kubeconfig, scenario_enables)
+    _write_fresh(output, components, kubeconfig, scenario_enables, fitness_queries)

--- a/krkn_ai/utils/weight_learning.py
+++ b/krkn_ai/utils/weight_learning.py
@@ -1,0 +1,60 @@
+"""Learn fitness-query weights from a run, favoring queries that vary across scenarios."""
+
+import json
+import os
+import statistics
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from krkn_ai.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _discrimination(values: List[float]) -> float:
+    """Relative spread of a query's values across scenarios; 0 when flat.
+    Normalized by max magnitude (not mean)
+    """
+    if len(values) < 2:
+        return 0.0
+    scale = max(abs(v) for v in values)
+    if scale == 0:
+        return 0.0
+    return statistics.pstdev(values) / scale
+
+
+def learn_weights(scenario_results, fitness_items) -> Dict[str, float]:
+    """Normalized weight per query from per-scenario values; {} if there's no signal."""
+    id_to_query = {item.id: item.query for item in fitness_items}
+    by_query: Dict[str, List[float]] = defaultdict(list)
+    for result in scenario_results:
+        fitness = getattr(result, "fitness_result", None)
+        if fitness is None:
+            continue
+        for score in fitness.scores:
+            query = id_to_query.get(score.id)
+            if query is not None:
+                by_query[query].append(score.fitness_score)
+
+    scores = {q: _discrimination(v) for q, v in by_query.items()}
+    total = sum(scores.values())
+    if total <= 0:
+        return {}
+    return {q: round(s / total, 4) for q, s in scores.items()}
+
+
+def save_learned_weights(weights: Dict[str, float], path: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(weights, f, indent=2)
+
+
+def load_learned_weights(path: Optional[str]) -> Dict[str, float]:
+    """Load learned weights written by a previous run; {} if the file is missing."""
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f) or {}
+    except (OSError, ValueError) as error:
+        logger.warning("Could not read learned weights %s: %s", path, error)
+        return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,4 @@ fallback_version = "0.0.0"
 include = ["krkn_ai*"]
 
 [tool.setuptools.package-data]
-"krkn_ai" = ["templates/*", "templates/**/*"]
+"krkn_ai" = ["templates/*", "templates/**/*", "utils/*.yaml"]

--- a/tests/unit/utils/test_catalog.py
+++ b/tests/unit/utils/test_catalog.py
@@ -141,8 +141,10 @@ class TestRecommendFitnessQueries:
     def test_all_present_single_series_all_enabled(self):
         prom = _FakeProm(_all_required_metrics())
         results = recommend_fitness_queries(_components(["demo"]), prom)
-        # 4 namespace-scoped x 1 ns + 2 cluster-scoped = 6 items, all enabled
-        assert len(results) == 6
+        # namespace-scoped x 1 ns + cluster-scoped, so the count tracks the catalog
+        ns_scoped = sum(1 for e in BASE_CATALOG if e.scope is Scope.namespace)
+        cluster_scoped = sum(1 for e in BASE_CATALOG if e.scope is Scope.cluster)
+        assert len(results) == ns_scoped + cluster_scoped
         assert all(r["enabled"] for r in results)
         # equal-split weights sum to ~1
         assert abs(sum(r["weight"] for r in results) - 1.0) < 0.01

--- a/tests/unit/utils/test_catalog.py
+++ b/tests/unit/utils/test_catalog.py
@@ -1,0 +1,253 @@
+"""Unit tests for the fitness catalog and its recommender."""
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from krkn_ai.models.config import FitnessFunctionItem, FitnessFunctionType
+from krkn_ai.templates.generator import create_krkn_ai_template
+from krkn_ai.utils.catalog import (
+    BASE_CATALOG,
+    CatalogEntry,
+    FitnessCategory,
+    Scope,
+    get_base_catalog,
+    recommend_fitness_queries,
+)
+
+
+def _all_required_metrics():
+    metrics = set()
+    for entry in BASE_CATALOG:
+        metrics.update(entry.requires)
+    return metrics
+
+
+def _components(namespace_names):
+    """Minimal stand-in for ClusterComponents.get_active_components()."""
+    active = SimpleNamespace(
+        namespaces=[SimpleNamespace(name=n) for n in namespace_names]
+    )
+    return SimpleNamespace(get_active_components=lambda: active)
+
+
+class _FakeProm:
+    """Fake KrknPrometheus: canned metric list + query-result rule."""
+
+    def __init__(self, metrics, query_rule=None, metrics_raises=False):
+        self._metrics = list(metrics)
+        self._rule = query_rule or (lambda q: [{"value": [0, "1"]}])  # 1 series
+        self._metrics_raises = metrics_raises
+        self.prom_cli = SimpleNamespace(all_metrics=self._all_metrics)
+
+    def _all_metrics(self):
+        if self._metrics_raises:
+            raise RuntimeError("prometheus down")
+        return self._metrics
+
+    def process_query(self, query):
+        return self._rule(query)
+
+
+class TestBaseCatalog:
+    """Structural checks over the shipped base catalog."""
+
+    def test_catalog_non_empty(self):
+        assert len(get_base_catalog()) > 0
+
+    def test_get_base_catalog_returns_base_catalog(self):
+        assert get_base_catalog() is BASE_CATALOG
+
+    def test_keys_are_unique(self):
+        keys = [entry.key for entry in BASE_CATALOG]
+        assert len(keys) == len(set(keys))
+
+    @pytest.mark.parametrize("entry", BASE_CATALOG, ids=lambda e: e.key)
+    def test_entry_is_well_formed(self, entry: CatalogEntry):
+        assert 0.0 <= entry.default_weight <= 1.0
+        assert isinstance(entry.type, FitnessFunctionType)
+        assert isinstance(entry.category, FitnessCategory)
+        assert isinstance(entry.scope, Scope)
+        assert entry.requires, "requires must list at least one metric name"
+        assert entry.key and entry.name and entry.query_template
+
+    @pytest.mark.parametrize("entry", BASE_CATALOG, ids=lambda e: e.key)
+    def test_scope_matches_placeholder(self, entry: CatalogEntry):
+        # namespace-scoped queries carry $ns; cluster-scoped ones do not.
+        if entry.scope is Scope.namespace:
+            assert "$ns" in entry.query_template
+        else:
+            assert "$ns" not in entry.query_template
+
+
+class TestCatalogEntryBehavior:
+    """Placeholder resolution and config-type emission."""
+
+    def _namespace_entry(self) -> CatalogEntry:
+        return next(e for e in BASE_CATALOG if e.scope is Scope.namespace)
+
+    def test_resolved_query_substitutes_namespace(self):
+        entry = self._namespace_entry()
+        resolved = entry.resolved_query("robot-shop")
+        assert "$ns" not in resolved
+        assert 'namespace="robot-shop"' in resolved
+
+    def test_resolved_query_leaves_range_placeholder(self):
+        # $range$ must survive for the runtime FitnessCalculator to substitute.
+        entry = next(e for e in BASE_CATALOG if "$range$" in e.query_template)
+        assert "$range$" in entry.resolved_query("robot-shop")
+
+    def test_resolved_query_without_namespace_is_unchanged(self):
+        entry = self._namespace_entry()
+        assert entry.resolved_query() == entry.query_template
+
+    @pytest.mark.parametrize("entry", BASE_CATALOG, ids=lambda e: e.key)
+    def test_to_fitness_item_emits_valid_config_type(self, entry: CatalogEntry):
+        item = entry.to_fitness_item("robot-shop")
+        assert isinstance(item, FitnessFunctionItem)
+        assert item.type == entry.type
+        assert item.weight == entry.default_weight
+        assert item.query == entry.resolved_query("robot-shop")
+
+
+class TestCatalogEntryValidation:
+    """The [0,1] weight constraint mirrors FitnessFunctionItem."""
+
+    def _kwargs(self, **overrides):
+        base = dict(
+            key="test",
+            category=FitnessCategory.availability,
+            name="Test",
+            query_template='sum(up{namespace="$ns"})',
+            requires=["up"],
+        )
+        base.update(overrides)
+        return base
+
+    @pytest.mark.parametrize("weight", [-0.1, 1.1])
+    def test_weight_out_of_range_rejected(self, weight):
+        with pytest.raises(ValidationError):
+            CatalogEntry(**self._kwargs(default_weight=weight))
+
+    def test_weight_in_range_accepted(self):
+        entry = CatalogEntry(**self._kwargs(default_weight=0.5))
+        assert entry.default_weight == 0.5
+
+
+class TestRecommendFitnessQueries:
+    """The dynamic layer: existence gate, scoping, shape validation."""
+
+    def test_all_present_single_series_all_enabled(self):
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["demo"]), prom)
+        # 4 namespace-scoped x 1 ns + 2 cluster-scoped = 6 items, all enabled
+        assert len(results) == 6
+        assert all(r["enabled"] for r in results)
+        # equal-split weights sum to ~1
+        assert abs(sum(r["weight"] for r in results) - 1.0) < 0.01
+
+    def test_missing_metric_is_gated_out(self):
+
+        metrics = _all_required_metrics() - {
+            "container_cpu_cfs_throttled_periods_total",
+            "container_cpu_cfs_periods_total",
+        }
+        results = recommend_fitness_queries(_components(["demo"]), _FakeProm(metrics))
+        cpu = [r for r in results if r["name"].startswith("cpu-throttle")]
+        assert cpu and all(not r["enabled"] for r in cpu)
+        assert "not scraped" in cpu[0]["reason"]
+        # everything else stays enabled
+        others = [r for r in results if not r["name"].startswith("cpu-throttle")]
+        assert all(r["enabled"] for r in others)
+
+    def test_zero_series_but_present_is_kept(self):
+
+        def rule(q):
+            return [] if "OOMKilled" in q else [{"value": [0, "1"]}]
+
+        results = recommend_fitness_queries(
+            _components(["demo"]), _FakeProm(_all_required_metrics(), rule)
+        )
+        oom = next(r for r in results if r["name"].startswith("oom-kills"))
+        assert oom["enabled"] is True
+
+    def test_multi_series_is_rejected(self):
+
+        def rule(q):
+            return [{"value": [0, "1"]}, {"value": [0, "2"]}] if "apiserver" in q else [
+                {"value": [0, "1"]}
+            ]
+
+        results = recommend_fitness_queries(
+            _components(["demo"]), _FakeProm(_all_required_metrics(), rule)
+        )
+        api = next(r for r in results if r["name"] == "apiserver-errors")
+        assert api["enabled"] is False
+        assert "needs aggregation" in api["reason"]
+
+    def test_namespace_scoping_expands_per_namespace(self):
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["a", "b"]), prom)
+        restarts = [r for r in results if r["name"].startswith("pod-restarts")]
+        assert {r["name"] for r in restarts} == {"pod-restarts:a", "pod-restarts:b"}
+        assert 'namespace="a"' in restarts[0]["query"] or 'namespace="b"' in restarts[0]["query"]
+        node = [r for r in results if r["name"] == "node-pressure"]
+        assert len(node) == 1  # cluster-scoped, no namespace suffix
+
+    def test_query_keeps_range_placeholder_for_runtime(self):
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["demo"]), prom)
+        restarts = next(r for r in results if r["name"] == "pod-restarts:demo")
+        assert "$range$" in restarts["query"]  # FitnessCalculator substitutes at runtime
+
+    def test_emitted_query_is_wrapped_against_empty_result(self):
+        # a label filter matching 0 series must not crash the runtime
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["demo"]), prom)
+        for r in results:
+            assert r["query"].endswith(") or vector(0)"), r["query"]
+
+    def test_prometheus_unreachable_returns_empty(self):
+        prom = _FakeProm(_all_required_metrics(), metrics_raises=True)
+        assert recommend_fitness_queries(_components(["demo"]), prom) == []
+
+
+class TestTemplateWiring:
+    """discover template renders dynamic items, else the static default."""
+
+    def _data(self):
+        return {"namespaces": []}
+
+    def test_enabled_items_rendered(self):
+        fitness_queries = [
+            {
+                "name": "pod-restarts:demo",
+                "query": 'sum(increase(kube_pod_container_status_restarts_total{namespace="demo"}[$range$]))',
+                "type": "range",
+                "weight": 0.5,
+                "enabled": True,
+                "reason": "",
+            },
+            {
+                "name": "cpu-throttle:demo",
+                "query": "max(...)",
+                "type": "range",
+                "weight": 1.0,
+                "enabled": False,
+                "reason": "metric(s) not scraped: container_cpu_cfs_periods_total",
+            },
+        ]
+        out = create_krkn_ai_template(
+            "/tmp/kubeconfig", self._data(), fitness_queries=fitness_queries
+        )
+        assert "items:" in out
+        assert "pod-restarts:demo" in out
+        assert "kube_pod_container_status_restarts_total" in out
+        # disabled entry appears commented with its reason
+        assert "# cpu-throttle:demo (metric(s) not scraped" in out
+
+    def test_static_default_when_no_fitness_queries(self):
+        out = create_krkn_ai_template("/tmp/kubeconfig", self._data())
+        assert "sum(kube_pod_container_status_restarts_total)" in out
+        assert "items:" not in out

--- a/tests/unit/utils/test_catalog.py
+++ b/tests/unit/utils/test_catalog.py
@@ -3,15 +3,16 @@
 from types import SimpleNamespace
 
 import pytest
-from pydantic import ValidationError
 
 from krkn_ai.models.config import FitnessFunctionItem, FitnessFunctionType
 from krkn_ai.templates.generator import create_krkn_ai_template
+from krkn_ai.utils.fs import _merge_fitness_items
 from krkn_ai.utils.catalog import (
     BASE_CATALOG,
     CatalogEntry,
     FitnessCategory,
     Scope,
+    _assign_weights,
     get_base_catalog,
     recommend_fitness_queries,
 )
@@ -56,21 +57,17 @@ class TestBaseCatalog:
     def test_catalog_non_empty(self):
         assert len(get_base_catalog()) > 0
 
-    def test_get_base_catalog_returns_base_catalog(self):
-        assert get_base_catalog() is BASE_CATALOG
-
     def test_keys_are_unique(self):
         keys = [entry.key for entry in BASE_CATALOG]
         assert len(keys) == len(set(keys))
 
     @pytest.mark.parametrize("entry", BASE_CATALOG, ids=lambda e: e.key)
     def test_entry_is_well_formed(self, entry: CatalogEntry):
-        assert 0.0 <= entry.default_weight <= 1.0
+        assert entry.key and entry.query_template
         assert isinstance(entry.type, FitnessFunctionType)
-        assert isinstance(entry.category, FitnessCategory)
         assert isinstance(entry.scope, Scope)
-        assert entry.requires, "requires must list at least one metric name"
-        assert entry.key and entry.name and entry.query_template
+        if entry.category is not None:
+            assert isinstance(entry.category, FitnessCategory)
 
     @pytest.mark.parametrize("entry", BASE_CATALOG, ids=lambda e: e.key)
     def test_scope_matches_placeholder(self, entry: CatalogEntry):
@@ -112,31 +109,19 @@ class TestCatalogEntryBehavior:
 
 
 class TestCatalogEntryValidation:
-    """The [0,1] weight constraint mirrors FitnessFunctionItem."""
+    """Fields are optional per key and weights are not capped."""
 
-    def _kwargs(self, **overrides):
-        base = dict(
-            key="test",
-            category=FitnessCategory.availability,
-            name="Test",
-            query_template='sum(up{namespace="$ns"})',
-            requires=["up"],
-        )
-        base.update(overrides)
-        return base
+    def test_minimal_entry_valid(self):
+        entry = CatalogEntry(key="x", query_template="sum(up)")
+        assert entry.category is None and entry.name is None and entry.requires == []
 
-    @pytest.mark.parametrize("weight", [-0.1, 1.1])
-    def test_weight_out_of_range_rejected(self, weight):
-        with pytest.raises(ValidationError):
-            CatalogEntry(**self._kwargs(default_weight=weight))
-
-    def test_weight_in_range_accepted(self):
-        entry = CatalogEntry(**self._kwargs(default_weight=0.5))
-        assert entry.default_weight == 0.5
+    def test_weight_any_value_accepted(self):
+        entry = CatalogEntry(key="x", query_template="sum(up)", default_weight=5.0)
+        assert entry.default_weight == 5.0
 
 
 class TestRecommendFitnessQueries:
-    """The dynamic layer: existence gate, scoping, shape validation."""
+    """The dynamic layer: existence gate, scoping, shape validation, weights."""
 
     def test_all_present_single_series_all_enabled(self):
         prom = _FakeProm(_all_required_metrics())
@@ -146,11 +131,10 @@ class TestRecommendFitnessQueries:
         cluster_scoped = sum(1 for e in BASE_CATALOG if e.scope is Scope.cluster)
         assert len(results) == ns_scoped + cluster_scoped
         assert all(r["enabled"] for r in results)
-        # equal-split weights sum to ~1
+        # no history -> equal split, weights sum to ~1
         assert abs(sum(r["weight"] for r in results) - 1.0) < 0.01
 
     def test_missing_metric_is_gated_out(self):
-
         metrics = _all_required_metrics() - {
             "container_cpu_cfs_throttled_periods_total",
             "container_cpu_cfs_periods_total",
@@ -164,7 +148,6 @@ class TestRecommendFitnessQueries:
         assert all(r["enabled"] for r in others)
 
     def test_zero_series_but_present_is_kept(self):
-
         def rule(q):
             return [] if "OOMKilled" in q else [{"value": [0, "1"]}]
 
@@ -175,11 +158,12 @@ class TestRecommendFitnessQueries:
         assert oom["enabled"] is True
 
     def test_multi_series_is_rejected(self):
-
         def rule(q):
-            return [{"value": [0, "1"]}, {"value": [0, "2"]}] if "apiserver" in q else [
-                {"value": [0, "1"]}
-            ]
+            return (
+                [{"value": [0, "1"]}, {"value": [0, "2"]}]
+                if "apiserver" in q
+                else [{"value": [0, "1"]}]
+            )
 
         results = recommend_fitness_queries(
             _components(["demo"]), _FakeProm(_all_required_metrics(), rule)
@@ -193,7 +177,10 @@ class TestRecommendFitnessQueries:
         results = recommend_fitness_queries(_components(["a", "b"]), prom)
         restarts = [r for r in results if r["name"].startswith("pod-restarts")]
         assert {r["name"] for r in restarts} == {"pod-restarts:a", "pod-restarts:b"}
-        assert 'namespace="a"' in restarts[0]["query"] or 'namespace="b"' in restarts[0]["query"]
+        assert (
+            'namespace="a"' in restarts[0]["query"]
+            or 'namespace="b"' in restarts[0]["query"]
+        )
         node = [r for r in results if r["name"] == "node-pressure"]
         assert len(node) == 1  # cluster-scoped, no namespace suffix
 
@@ -201,7 +188,7 @@ class TestRecommendFitnessQueries:
         prom = _FakeProm(_all_required_metrics())
         results = recommend_fitness_queries(_components(["demo"]), prom)
         restarts = next(r for r in results if r["name"] == "pod-restarts:demo")
-        assert "$range$" in restarts["query"]  # FitnessCalculator substitutes at runtime
+        assert "$range$" in restarts["query"]  # substituted at runtime
 
     def test_emitted_query_is_wrapped_against_empty_result(self):
         # a label filter matching 0 series must not crash the runtime
@@ -213,6 +200,57 @@ class TestRecommendFitnessQueries:
     def test_prometheus_unreachable_returns_empty(self):
         prom = _FakeProm(_all_required_metrics(), metrics_raises=True)
         assert recommend_fitness_queries(_components(["demo"]), prom) == []
+
+    def test_equal_weights_when_seeds_default(self):
+        # catalog seeds all default (1.0) -> equal split
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["demo"]), prom)
+        weights = [r["weight"] for r in results if r["enabled"]]
+        assert max(weights) - min(weights) < 0.001
+
+    def test_weights_normalize_catalog_seeds(self):
+        # user-set seed weights are respected (normalized), not overridden
+        enabled = [{"weight": 3.0}, {"weight": 1.0}]
+        _assign_weights(enabled)
+        assert enabled[0]["weight"] == 0.75
+        assert enabled[1]["weight"] == 0.25
+
+    def test_learned_weights_seed_priority(self):
+        # a learned weight for one query dominates the normalized result
+        prom = _FakeProm(_all_required_metrics())
+        results = recommend_fitness_queries(_components(["demo"]), prom)
+        target = next(r for r in results if r["enabled"])["query"]
+        learned = {target: 100.0}  # everything else keeps default seed 1.0
+        weighted = recommend_fitness_queries(
+            _components(["demo"]), prom, learned_weights=learned
+        )
+        picked = next(r for r in weighted if r["query"] == target)
+        others = [r for r in weighted if r["enabled"] and r["query"] != target]
+        assert all(picked["weight"] > o["weight"] for o in others)
+
+
+class TestMergeFitnessItems:
+    """merge unions new fitness items and keeps the user's existing ones."""
+
+    def test_adds_enabled_items_and_keeps_existing(self):
+        raw = {
+            "fitness_function": {
+                "items": [{"query": "existing", "type": "range", "weight": 0.5}]
+            }
+        }
+        fitness_queries = [
+            {"query": "new-one", "type": "range", "weight": 0.3, "enabled": True},
+            {"query": "disabled", "type": "range", "weight": 0.0, "enabled": False},
+            {"query": "existing", "type": "range", "weight": 0.9, "enabled": True},
+        ]
+        _merge_fitness_items(raw, fitness_queries)
+        queries = [i["query"] for i in raw["fitness_function"]["items"]]
+        assert queries == ["existing", "new-one"]  # existing kept, disabled skipped
+
+    def test_no_fitness_queries_is_noop(self):
+        raw = {"cluster_components": {}}
+        _merge_fitness_items(raw, None)
+        assert "fitness_function" not in raw
 
 
 class TestTemplateWiring:

--- a/tests/unit/utils/test_weight_learning.py
+++ b/tests/unit/utils/test_weight_learning.py
@@ -1,0 +1,82 @@
+"""Unit tests for learning fitness-query weights from a run."""
+
+from types import SimpleNamespace
+
+from krkn_ai.utils.weight_learning import (
+    learn_weights,
+    load_learned_weights,
+    save_learned_weights,
+)
+
+
+def _item(id, query):
+    return SimpleNamespace(id=id, query=query)
+
+
+def _scenario(scores):
+    # scores: list of (id, raw_value)
+    return SimpleNamespace(
+        fitness_result=SimpleNamespace(
+            scores=[SimpleNamespace(id=i, fitness_score=v) for i, v in scores]
+        )
+    )
+
+
+class TestLearnWeights:
+    def test_discriminating_query_gets_more_weight(self):
+        items = [_item(0, "restarts"), _item(1, "always-flat")]
+        # restarts spikes in one scenario; always-flat never moves
+        results = [
+            _scenario([(0, 0.0), (1, 5.0)]),
+            _scenario([(0, 0.0), (1, 5.0)]),
+            _scenario([(0, 50.0), (1, 5.0)]),
+        ]
+        weights = learn_weights(results, items)
+        assert weights["restarts"] > weights["always-flat"]
+        assert abs(sum(weights.values()) - 1.0) < 0.001
+
+    def test_no_signal_returns_empty(self):
+        items = [_item(0, "flat")]
+        results = [_scenario([(0, 5.0)]), _scenario([(0, 5.0)])]
+        assert learn_weights(results, items) == {}
+
+    def test_signed_values_keep_signal(self):
+        # negative values must still count as signal
+        items = [_item(0, "delta")]
+        results = [_scenario([(0, -10.0)]), _scenario([(0, 10.0)])]
+        assert learn_weights(results, items) == {"delta": 1.0}
+
+    def test_near_zero_mean_does_not_explode(self):
+        # a near-zero mean must not blow up the weight
+        items = [_item(0, "swingy"), _item(1, "steady")]
+        results = [
+            _scenario([(0, -5.0), (1, 100.0)]),
+            _scenario([(0, 5.0), (1, 300.0)]),
+        ]
+        weights = learn_weights(results, items)
+        assert all(0.0 <= w <= 1.0 for w in weights.values())
+
+    def test_keys_by_query_not_id(self):
+        items = [_item(7, "q-a"), _item(9, "q-b")]
+        results = [_scenario([(7, 1.0), (9, 0.0)]), _scenario([(7, 0.0), (9, 9.0)])]
+        weights = learn_weights(results, items)
+        assert set(weights) == {"q-a", "q-b"}
+
+    def test_ignores_unknown_ids(self):
+        items = [_item(0, "known")]
+        results = [_scenario([(0, 1.0), (99, 5.0)]), _scenario([(0, 9.0), (99, 5.0)])]
+        weights = learn_weights(results, items)
+        assert set(weights) == {"known"}
+
+
+class TestSaveLoad:
+    def test_roundtrip(self, tmp_path):
+        path = str(tmp_path / "learned_weights.json")
+        save_learned_weights({"q1": 0.7, "q2": 0.3}, path)
+        assert load_learned_weights(path) == {"q1": 0.7, "q2": 0.3}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert load_learned_weights(str(tmp_path / "nope.json")) == {}
+
+    def test_none_path_returns_empty(self):
+        assert load_learned_weights(None) == {}


### PR DESCRIPTION
## Description
Makes `discover` recommend `fitness_function` queries when it generates a fresh template.

For each query in a small catalog of reliability metrics, it checks the metric exists in the cluster's Prometheus, scopes namespace queries to each discovered namespace, and runs the query to confirm it returns a single series. Valid ones are written as fitness items; the rest are commented out with the reason. If Prometheus isn't reachable, the static default query stays as is.

This is the initial version with 6 base queries.

Week 6 #364

## Follow-up 
- Best-query selection — rank/weight queries by relevance instead of keeping all valid ones with equal weight.
- More catalog entries 
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- Unit tests for the catalog, the recommendation logic, template rendering.
- Ran it on Minikube and confirmed the template came out with the right fitness queries.

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
