### PR TITLE
feat(dashboard): bring fitness score detailed breakdown into UI

### DIFF
--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -135,7 +135,7 @@ def main():
     # Load data — loaders return (file_found: bool, df | None)
     if running:
         results_file_found, df_results = load_results_csv.__wrapped__(output_dir)
-        best_scenarios_data = load_results_json.__wrapped__(output_dir)
+        best_scenarios_data = []
         config_data = load_config_yaml.__wrapped__(output_dir)
         health_file_found, df_health = load_health_check_csv.__wrapped__(output_dir)
         df_details = load_detailed_scenarios_data.__wrapped__(output_dir)

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -14,6 +14,7 @@ from krkn_ai.constants import (
 )
 from krkn_ai.dashboard.data_loader import (
     load_results_csv,
+    load_results_json,
     load_config_yaml,
     load_health_check_csv,
     load_detailed_scenarios_data,
@@ -134,6 +135,7 @@ def main():
     # Load data — loaders return (file_found: bool, df | None)
     if running:
         results_file_found, df_results = load_results_csv.__wrapped__(output_dir)
+        best_scenarios_data = load_results_json.__wrapped__(output_dir)
         config_data = load_config_yaml.__wrapped__(output_dir)
         health_file_found, df_health = load_health_check_csv.__wrapped__(output_dir)
         df_details = load_detailed_scenarios_data.__wrapped__(output_dir)
@@ -141,11 +143,13 @@ def main():
         df_lineage = load_population_lineage.__wrapped__(output_dir)
     else:
         results_file_found, df_results = load_results_csv(output_dir)
+        best_scenarios_data = load_results_json(output_dir)
         config_data = load_config_yaml(output_dir)
         health_file_found, df_health = load_health_check_csv(output_dir)
         df_details = load_detailed_scenarios_data(output_dir)
         df_logs = load_logs(output_dir)
         df_lineage = load_population_lineage(output_dir)
+
 
     # fully unfiltered copy (baseline row included) for anomaly detection
     df_results_all = df_results.copy() if df_results is not None else None
@@ -490,7 +494,7 @@ def main():
                 "No scenarios match the selected filters. Try adjusting the sidebar filters."
             )
         else:
-            render_summary(df_results)
+            render_summary(df_results, best_scenarios_data)
             st.divider()
 
             colA, colB = st.columns(2)

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -135,7 +135,7 @@ def main():
     # Load data — loaders return (file_found: bool, df | None)
     if running:
         results_file_found, df_results = load_results_csv.__wrapped__(output_dir)
-        best_scenarios_data = []
+        best_scenarios_data = load_results_json.__wrapped__(output_dir)
         config_data = load_config_yaml.__wrapped__(output_dir)
         health_file_found, df_health = load_health_check_csv.__wrapped__(output_dir)
         df_details = load_detailed_scenarios_data.__wrapped__(output_dir)

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -150,7 +150,6 @@ def main():
         df_logs = load_logs(output_dir)
         df_lineage = load_population_lineage(output_dir)
 
-
     # fully unfiltered copy (baseline row included) for anomaly detection
     df_results_all = df_results.copy() if df_results is not None else None
     df_anom_src = df_results.copy() if df_results is not None else None

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -54,7 +54,12 @@ def load_results_json(output_dir: str):
         try:
             with open(json_path, "r") as f:
                 data = json.load(f)
-                return data.get("best_scenarios", [])
+                scenarios = data.get("best_scenarios", [])
+                if isinstance(scenarios, list):
+                    return scenarios
+                return []
+        except (json.JSONDecodeError, OSError) as e:
+            logging.warning(f"Transient read error for {json_path}: {e}")
         except Exception as e:
             logging.error(f"Failed to read {json_path}: {e}")
     return []

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -47,6 +47,20 @@ def load_population_lineage(output_dir: str):
 
 
 @st.cache_data(ttl=300)
+def load_results_json(output_dir: str):
+    """Load the results.json file and return the best_scenarios data as a list of dicts."""
+    json_path = os.path.join(output_dir, "results.json")
+    if os.path.exists(json_path):
+        try:
+            with open(json_path, "r") as f:
+                data = json.load(f)
+                return data.get("best_scenarios", [])
+        except Exception as e:
+            logging.error(f"Failed to read {json_path}: {e}")
+    return []
+
+
+@st.cache_data(ttl=300)
 def load_config_yaml(output_dir: str):
     config_path = os.path.join(output_dir, "krkn-ai.yaml")
     if os.path.exists(config_path):

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -54,12 +54,7 @@ def load_results_json(output_dir: str):
         try:
             with open(json_path, "r") as f:
                 data = json.load(f)
-                scenarios = data.get("best_scenarios", [])
-                if isinstance(scenarios, list):
-                    return scenarios
-                return []
-        except (json.JSONDecodeError, OSError) as e:
-            logging.warning(f"Transient read error for {json_path}: {e}")
+                return data.get("best_scenarios", [])
         except Exception as e:
             logging.error(f"Failed to read {json_path}: {e}")
     return []

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -4,7 +4,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 
 
-def render_summary(df):
+def render_summary(df, best_scenarios_data=None):
     st.header("Experiment Summary")
     if df is None or df.empty:
         st.warning("Results data not yet available. Waiting for Krkn-AI engine...")
@@ -23,6 +23,37 @@ def render_summary(df):
     col2.metric("Scenarios Executed", scenarios_executed)
     col3.metric("Best Fitness Score", f"{best_fitness:.1f}%")
     col4.metric("Avg Fitness Score", f"{avg_fitness:.1f}%")
+
+    if best_scenarios_data:
+        st.subheader("Top Scenarios Breakdown")
+        
+        # Flatten the nested fitness_result data
+        rows = []
+        for bs in best_scenarios_data:
+            fr = bs.get("fitness_result", {})
+            rows.append({
+                "Rank": bs.get("rank"),
+                "Scenario ID": bs.get("scenario_id"),
+                "Generation": bs.get("generation", 0) + 1,
+                "Total Fitness": bs.get("fitness_score", 0.0),
+                "Krkn Failure Score": fr.get("krkn_failure_score", 0.0),
+                "Health Failure Score": fr.get("health_check_failure_score", 0.0),
+                "Health Latency Score": fr.get("health_check_response_time_score", 0.0),
+            })
+            
+        bs_df = pd.DataFrame(rows)
+        if not bs_df.empty:
+            column_cfg = {
+                "Rank": st.column_config.NumberColumn("Rank", format="%d"),
+                "Scenario ID": st.column_config.TextColumn("Scenario ID"),
+                "Generation": st.column_config.NumberColumn("Generation", format="%d"),
+                "Total Fitness": st.column_config.NumberColumn("Total Fitness", format="%.4f"),
+                "Krkn Failure Score": st.column_config.NumberColumn("Krkn Failure", format="%.4f"),
+                "Health Failure Score": st.column_config.NumberColumn("Health Failure", format="%.4f"),
+                "Health Latency Score": st.column_config.NumberColumn("Health Latency", format="%.4f"),
+            }
+            st.dataframe(bs_df, column_config=column_cfg, hide_index=True, width="stretch")
+
 
 
 def create_fitness_evolution_plot(df):

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -26,36 +26,49 @@ def render_summary(df, best_scenarios_data=None):
 
     if best_scenarios_data:
         st.subheader("Top Scenarios Breakdown")
-        
+
         # Flatten the nested fitness_result data
         rows = []
         for bs in best_scenarios_data:
             if "fitness_result" not in bs:
                 continue
             fr = bs["fitness_result"]
-            rows.append({
-                "Rank": bs.get("rank"),
-                "Scenario ID": bs.get("scenario_id"),
-                "Generation": bs.get("generation", 0) + 1,
-                "Total Fitness": bs.get("fitness_score", 0.0),
-                "Krkn Failure Score": fr.get("krkn_failure_score", 0.0),
-                "Health Failure Score": fr.get("health_check_failure_score", 0.0),
-                "Health Latency Score": fr.get("health_check_response_time_score", 0.0),
-            })
-            
+            rows.append(
+                {
+                    "Rank": bs.get("rank"),
+                    "Scenario ID": bs.get("scenario_id"),
+                    "Generation": bs.get("generation", 0) + 1,
+                    "Total Fitness": bs.get("fitness_score", 0.0),
+                    "Krkn Failure Score": fr.get("krkn_failure_score", 0.0),
+                    "Health Failure Score": fr.get("health_check_failure_score", 0.0),
+                    "Health Latency Score": fr.get(
+                        "health_check_response_time_score", 0.0
+                    ),
+                }
+            )
+
         bs_df = pd.DataFrame(rows)
         if not bs_df.empty:
             column_cfg = {
                 "Rank": st.column_config.NumberColumn("Rank", format="%d"),
                 "Scenario ID": st.column_config.TextColumn("Scenario ID"),
                 "Generation": st.column_config.NumberColumn("Generation", format="%d"),
-                "Total Fitness": st.column_config.NumberColumn("Total Fitness", format="%.4f"),
-                "Krkn Failure Score": st.column_config.NumberColumn("Krkn Failure", format="%.4f"),
-                "Health Failure Score": st.column_config.NumberColumn("Health Failure", format="%.4f"),
-                "Health Latency Score": st.column_config.NumberColumn("Health Latency", format="%.4f"),
+                "Total Fitness": st.column_config.NumberColumn(
+                    "Total Fitness", format="%.4f"
+                ),
+                "Krkn Failure Score": st.column_config.NumberColumn(
+                    "Krkn Failure", format="%.4f"
+                ),
+                "Health Failure Score": st.column_config.NumberColumn(
+                    "Health Failure", format="%.4f"
+                ),
+                "Health Latency Score": st.column_config.NumberColumn(
+                    "Health Latency", format="%.4f"
+                ),
             }
-            st.dataframe(bs_df, column_config=column_cfg, hide_index=True, width="stretch")
-
+            st.dataframe(
+                bs_df, column_config=column_cfg, hide_index=True, width="stretch"
+            )
 
 
 def create_fitness_evolution_plot(df):

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -30,7 +30,9 @@ def render_summary(df, best_scenarios_data=None):
         # Flatten the nested fitness_result data
         rows = []
         for bs in best_scenarios_data:
-            fr = bs.get("fitness_result", {})
+            if "fitness_result" not in bs:
+                continue
+            fr = bs["fitness_result"]
             rows.append({
                 "Rank": bs.get("rank"),
                 "Scenario ID": bs.get("scenario_id"),

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -176,6 +176,7 @@ class JSONSummaryReporter:
                     "scenario_id": result.scenario_id,
                     "generation": result.generation_id,
                     "fitness_score": result.fitness_result.fitness_score,
+                    "fitness_result": result.fitness_result.model_dump(),
                     "scenario_type": result.scenario.name,
                     "parameters": scenario_params,
                 }

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -111,7 +111,7 @@ class TestJSONSummaryReporter:
             assert "scenario_type" in item
             assert "parameters" in item
             assert "fitness_result" in item
-            
+
             fr = item["fitness_result"]
             assert "fitness_score" in fr
             assert "krkn_failure_score" in fr

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -110,6 +110,13 @@ class TestJSONSummaryReporter:
             assert "generation" in item
             assert "scenario_type" in item
             assert "parameters" in item
+            assert "fitness_result" in item
+            
+            fr = item["fitness_result"]
+            assert "fitness_score" in fr
+            assert "krkn_failure_score" in fr
+            assert "health_check_failure_score" in fr
+            assert "health_check_response_time_score" in fr
 
     def test_edge_cases(self, minimal_config):
         """Test single generation and zero fitness cases"""


### PR DESCRIPTION
## Description
Brings fitness score results into Dashboard 

This PR brings the detailed `FitnessResult` metrics into both the telemetry payload and the Streamlit Dashboard, solving the issue where only the raw scalar `fitness_score` was available in `results.json`.

### Changes Made
1. **`json_summary_reporter.py`**: Updated `_build_best_scenarios` to dump the fully nested `fitness_result` dictionary into `results.json` (via `.model_dump()`).
2. **`data_loader.py`**: Added a new cacheable `load_results_json` function to parse the `best_scenarios` object from `results.json` directly into the app.
3. **`app.py`**: Piped the extracted `best_scenarios_data` from the data loader into `render_summary`.
4. **`dashboard.py`**: Upgraded the `render_summary` component to parse the flattened nested `fitness_result` data and render a new **Top Scenarios Breakdown** leaderboard using `st.dataframe`.

### Why this matters
The Streamlit UI and downstream tools can now visualize the exact breakdown of how the Fitness Score was calculated (Krkn Failures vs Health Check Failures vs Health Check Latency).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- [x] Verified `make test` / `pytest` runs cleanly without breaking existing tests.
- [x] Generated a mock `results.json` locally and ran `streamlit run krkn_ai/dashboard/app.py` to confirm the new `Top Scenarios Breakdown` UI table renders the nested metrics correctly without runtime errors.
- [x] Verified backward compatibility: dashboard gracefully handles old `results.json` files missing the nested dictionary.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors