### PR TITLE
fix: merge CLI parameter overrides with default config parameters

### DIFF
--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -56,12 +56,7 @@ def read_config_from_file(
         existing = config.get("parameters")
         if isinstance(existing, dict):
             for k, v in existing.items():
-                if isinstance(v, dict):
-                    params[str(k)] = ParameterValue.model_validate(v)
-                else:
-                    params[str(k)] = ParameterValue(
-                        value=str(v), is_private=str(k).startswith("__")
-                    )
+                params[str(k)] = ParameterValue.from_cli(str(k), str(v))
 
         for p in param:
             if "=" in p:

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -53,6 +53,16 @@ def read_config_from_file(
     # param refers to Key-value passed with -p flag during krkn-ai test run
     if param:
         params = {}
+        existing = config.get("parameters")
+        if isinstance(existing, dict):
+            for k, v in existing.items():
+                if isinstance(v, dict):
+                    params[str(k)] = ParameterValue.model_validate(v)
+                else:
+                    params[str(k)] = ParameterValue(
+                        value=str(v), is_private=str(k).startswith("__")
+                    )
+
         for p in param:
             if "=" in p:
                 key, value = p.split("=", 1)

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -143,6 +143,36 @@ class TestReadConfigFromFileHeaders:
         assert result.elastic.port == 9200
         assert result.elastic.verify_certs is True
 
+    def test_read_config_merges_cli_params_with_defaults(self, tmp_path):
+        """CLI parameter overrides should merge with default config file parameters, not erase them."""
+        config = {
+            "kubeconfig_file_path": "/tmp/kubeconfig",
+            "fitness_function": {"query": "up"},
+            "cluster_components": {"namespaces": [], "nodes": []},
+            "parameters": {
+                "DEFAULT_TIMEOUT": "30",
+                "TARGET_NAMESPACE": "benchmark",
+            },
+        }
+        config_file = str(tmp_path / "config.yaml")
+        with open(config_file, "w") as f:
+            yaml.dump(config, f)
+
+        # Override TARGET_NAMESPACE, add NEW_PARAM, keep DEFAULT_TIMEOUT
+        result = read_config_from_file(
+            config_file,
+            param=["TARGET_NAMESPACE=prod", "NEW_PARAM=value"],
+        )
+
+        assert "DEFAULT_TIMEOUT" in result.parameters
+        assert result.parameters["DEFAULT_TIMEOUT"].value == "30"
+
+        assert "TARGET_NAMESPACE" in result.parameters
+        assert result.parameters["TARGET_NAMESPACE"].value == "prod"  # Overridden
+
+        assert "NEW_PARAM" in result.parameters
+        assert result.parameters["NEW_PARAM"].value == "value"  # Added
+
     def test_elastic_null_values_are_not_stringified_with_params(self, tmp_path):
         """Explicit elastic nulls should remain null so validation catches them."""
         config = {


### PR DESCRIPTION

## Description
This pull request resolves a bug in `read_config_from_file()` where passing parameter overrides via the CLI `-p` / `--param` flags completely wiped out all other default parameters defined in the configuration file.

Instead of overriding the entire parameters dictionary, the code has been updated to retrieve and normalize the existing parameters defined in the YAML file and merge them with any overrides or additions supplied on the CLI (with CLI parameters taking precedence).

#413 

## Changes
- **`krkn_ai/utils/fs.py`**: Updated `read_config_from_file` to fetch, normalize, and merge config file parameters with CLI parameters.
- **`tests/unit/utils/test_fs.py`**: Added `test_read_config_merges_cli_params_with_defaults` to verify that default parameters are preserved, overrides take precedence, and new parameters are successfully added.

## Verification
- Added test coverage specifically for parameter merging and override precedence.
- Ran test suite to verify correct behavior:
  ```shell
  pytest tests/
  ```
  Result: `479 passed`.
