### PR TITLE
fix(config): add URL scheme validation for health check endpoints (#415)

### DIFF
--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -176,6 +176,15 @@ class HealthCheckApplicationConfig(BaseModel):
     interval: int = 2  # in seconds
     headers: Optional[Dict[str, str]] = None
 
+    @field_validator("url", mode="after")
+    @classmethod
+    def validate_url_scheme(cls, value: str) -> str:
+        if not value.startswith(("http://", "https://")):
+            raise ValueError(
+                f"URL must start with 'http://' or 'https://', got: '{value}'"
+            )
+        return value
+
 
 class HealthCheckConfig(BaseModel):
     stop_watcher_on_failure: bool = False

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -179,7 +179,7 @@ class HealthCheckApplicationConfig(BaseModel):
     @field_validator("url", mode="after")
     @classmethod
     def validate_url_scheme(cls, value: str) -> str:
-        if not value.startswith(("http://", "https://")):
+        if not value.lower().startswith(("http://", "https://")):
             raise ValueError(
                 f"URL must start with 'http://' or 'https://', got: '{value}'"
             )

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -192,7 +192,7 @@ class TestHealthCheckConfig:
             name="test-app", url="http://localhost:8080/health"
         )
         assert app.name == "test-app"
-        assert app.url == "http://localhost:8080/health"
+        assert str(app.url) == "http://localhost:8080/health"
         assert app.status_code == 200
         assert app.timeout == 4
         assert app.interval == 2
@@ -217,6 +217,27 @@ class TestHealthCheckConfig:
             name="api", url="http://localhost:8080/health"
         )
         assert app_no_headers.headers is None
+
+    def test_health_check_rejects_url_without_scheme(self):
+        """URLs missing http:// or https:// must be rejected at config load time."""
+        with pytest.raises(ValidationError):
+            HealthCheckApplicationConfig(
+                name="bad-app", url="localhost:8080/health"
+            )
+
+    def test_health_check_rejects_non_http_scheme(self):
+        """URLs with non-http schemes (e.g. ftp://) must be rejected."""
+        with pytest.raises(ValidationError):
+            HealthCheckApplicationConfig(
+                name="bad-app", url="ftp://localhost:8080/health"
+            )
+
+    def test_health_check_accepts_valid_https_url(self):
+        """Valid https:// URLs must be accepted."""
+        app = HealthCheckApplicationConfig(
+            name="secure-app", url="https://api.example.com/health"
+        )
+        assert app.url == "https://api.example.com/health"
 
 
 class TestOutputConfig:

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -239,6 +239,13 @@ class TestHealthCheckConfig:
         )
         assert app.url == "https://api.example.com/health"
 
+    def test_health_check_accepts_uppercase_http_scheme(self):
+        """Valid HTTP/HTTPS URLs with uppercase schemes must be accepted."""
+        app = HealthCheckApplicationConfig(
+            name="uppercase-app", url="HTTP://localhost:8080/health"
+        )
+        assert app.url == "HTTP://localhost:8080/health"
+
 
 class TestOutputConfig:
     """Test OutputConfig model"""


### PR DESCRIPTION
## Description
Resolves #415

Health check application URLs in `HealthCheckApplicationConfig` were typed as plain `str `with no format validation. If a user manually uncommented the `health_checks` block in `krkn-ai.yaml` and entered a URL without the `http://` or `https://` scheme (e.g., `localhost:8080/health`), Pydantic silently accepted the invalid value. The misconfiguration was only caught at runtime when the HTTP client attempted to make a request, resulting in a confusing `MissingSchema` error mid-chaos-run.

This PR adds a `@field_validator` on `HealthCheckApplicationConfig.url` that rejects URLs missing a valid `http://` or `https:// `scheme at config load time, providing an immediate and actionable `ValidationError `on startup.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
`python -m pytest tests/unit/models/test_config.py::TestHealthCheckConfig -v

test_health_check_config_creation           PASSED
test_health_check_config_headers            PASSED
test_health_check_rejects_url_without_scheme PASSED
test_health_check_rejects_non_http_scheme    PASSED
test_health_check_accepts_valid_https_url    PASSED
`
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
