### PR TITLE
fix(reporter): prevent silent data loss in health check reports handling empty endpoints (#421)

### DIFF
--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -36,7 +36,7 @@ class HealthCheckReporter:
 
             for component_results in health_check_results:
                 if len(component_results) == 0:
-                    break
+                    continue
                 component_name = component_results[0].name
                 min_response_time = min(
                     [result.response_time for result in component_results]

--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -36,6 +36,10 @@ class HealthCheckReporter:
 
             for component_results in health_check_results:
                 if len(component_results) == 0:
+                    logger.warning(
+                        "Component in scenario_id=%s produced zero health-check samples, skipping.",
+                        scenario_id,
+                    )
                     continue
                 component_name = component_results[0].name
                 min_response_time = min(

--- a/tests/unit/reporter/test_health_check_reporter.py
+++ b/tests/unit/reporter/test_health_check_reporter.py
@@ -83,7 +83,9 @@ class TestHealthCheckReporter:
         assert app1_row["success_count"] == 2
         assert app1_row["failure_count"] == 0
 
-    def test_save_report_skips_empty_results_and_continues(self, temp_output_dir, caplog):
+    def test_save_report_skips_empty_results_and_continues(
+        self, temp_output_dir, caplog
+    ):
         """Test that an empty component results list does not break the loop, missing subsequent components."""
         import logging
 
@@ -124,7 +126,9 @@ class TestHealthCheckReporter:
             )
         ]
 
-        with caplog.at_level(logging.WARNING, logger="krkn_ai.reporter.health_check_reporter"):
+        with caplog.at_level(
+            logging.WARNING, logger="krkn_ai.reporter.health_check_reporter"
+        ):
             reporter.save_report(fitness_results)
 
         report_path = os.path.join(

--- a/tests/unit/reporter/test_health_check_reporter.py
+++ b/tests/unit/reporter/test_health_check_reporter.py
@@ -83,6 +83,57 @@ class TestHealthCheckReporter:
         assert app1_row["success_count"] == 2
         assert app1_row["failure_count"] == 0
 
+    def test_save_report_skips_empty_results_and_continues(self, temp_output_dir):
+        """Test that an empty component results list does not break the loop, missing subsequent components."""
+        reporter = HealthCheckReporter(output_dir=temp_output_dir)
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        now = datetime.datetime.now()
+
+        fitness_results = [
+            CommandRunResult(
+                generation_id=0,
+                scenario_id=1,
+                scenario=scenario,
+                cmd="test-cmd",
+                log="test-log",
+                returncode=0,
+                start_time=now,
+                end_time=now,
+                fitness_result=FitnessResult(fitness_score=10.0),
+                health_check_results={
+                    "app1": [
+                        HealthCheckResult(
+                            name="app1",
+                            response_time=0.1,
+                            status_code=200,
+                            success=True,
+                        )
+                    ],
+                    "broken_app_2": [],  # Empty result! This used to break the loop.
+                    "app3": [
+                        HealthCheckResult(
+                            name="app3",
+                            response_time=0.3,
+                            status_code=200,
+                            success=True,
+                        )
+                    ],
+                },
+            )
+        ]
+
+        reporter.save_report(fitness_results)
+
+        report_path = os.path.join(
+            temp_output_dir, "reports", "health_check_report.csv"
+        )
+        assert os.path.exists(report_path)
+
+        df = pd.read_csv(report_path)
+        # Should contain app1 and app3, skipping broken_app_2 but NOT terminating the loop
+        assert len(df) == 2
+        assert set(df["component_name"].values) == {"app1", "app3"}
+
     def test_save_report_with_empty_results(self, temp_output_dir):
         """Test saving report with empty fitness results"""
         reporter = HealthCheckReporter(output_dir=temp_output_dir)

--- a/tests/unit/reporter/test_health_check_reporter.py
+++ b/tests/unit/reporter/test_health_check_reporter.py
@@ -83,8 +83,10 @@ class TestHealthCheckReporter:
         assert app1_row["success_count"] == 2
         assert app1_row["failure_count"] == 0
 
-    def test_save_report_skips_empty_results_and_continues(self, temp_output_dir):
+    def test_save_report_skips_empty_results_and_continues(self, temp_output_dir, caplog):
         """Test that an empty component results list does not break the loop, missing subsequent components."""
+        import logging
+
         reporter = HealthCheckReporter(output_dir=temp_output_dir)
         scenario = DummyScenario(cluster_components=ClusterComponents())
         now = datetime.datetime.now()
@@ -122,7 +124,8 @@ class TestHealthCheckReporter:
             )
         ]
 
-        reporter.save_report(fitness_results)
+        with caplog.at_level(logging.WARNING, logger="krkn_ai.reporter.health_check_reporter"):
+            reporter.save_report(fitness_results)
 
         report_path = os.path.join(
             temp_output_dir, "reports", "health_check_report.csv"
@@ -133,6 +136,9 @@ class TestHealthCheckReporter:
         # Should contain app1 and app3, skipping broken_app_2 but NOT terminating the loop
         assert len(df) == 2
         assert set(df["component_name"].values) == {"app1", "app3"}
+
+        # Assert the skip was logged so operators can debug silent gaps
+        assert any("zero health-check samples" in msg for msg in caplog.messages)
 
     def test_save_report_with_empty_results(self, temp_output_dir):
         """Test saving report with empty fitness results"""


### PR DESCRIPTION
## Description
This PR fixes Issue Fixes #421  a critical data truncation bug in the `HealthCheckReporter`. 
Previously, if a scenario contained multiple health check applications and one of them failed to return any results (e.g. an unreachable endpoint causing an empty result list), the reporter would hit a `break` statement. This violently exited the inner loop, silently truncating the CSV report and causing all subsequent applications in the same scenario to be permanently lost from the `health_check_report.csv`.

**Changes made:**
- Changed `break` to `continue` in `health_check_reporter.py` to gracefully skip empty result lists and continue processing the remaining applications.
- Added `test_save_report_skips_empty_results_and_continues` to the pytest suite to explicitly prevent regressions on this exact edge case.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- **Local Unit Testing**: Added a new unit test `test_save_report_skips_empty_results_and_continues` which injects a `broken_app_2: []` right in the middle of a result dictionary. Verified that it correctly outputs `app1` and `app3`, while skipping the empty one without early termination.
- Executed `pytest tests/unit/reporter/test_health_check_reporter.py` ensuring all 9 tests pass cleanly.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
