### PR TITLE
fix: interpolate format-string args in list_vmis log and ScenarioInit…

### DIFF
--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -393,7 +393,7 @@ class ClusterManager:
                 logger.debug(
                     "Found %d vmis in namespace %s",
                     len(vmis),
-                    vmis[0]["metadata"]["name"],
+                    namespace.name,
                 )
             else:
                 logger.debug("No VMIs found in namespace %s", namespace.name)

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -137,7 +137,9 @@ class ScenarioFactory:
             _, cls = rng.choice(candidates)
             return cls(cluster_components=active_components)
         except Exception as error:
-            raise ScenarioInitError("Unable to initialize scenario: %s", error)
+            raise ScenarioInitError(
+                f"Unable to initialize scenario: {error}"
+            ) from error
 
     @staticmethod
     def create_dummy_scenario():

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -566,6 +566,28 @@ class TestClusterManager:
         assert by_name["good-node"].interfaces == ["eth0"]
         assert by_name["bad-node"].interfaces == []
 
+    def test_list_vmis_logs_namespace_name_not_vmi_name(self, cluster_manager):
+        """list_vmis should log the namespace name, not the first VMI's name (#258)."""
+        namespace = Namespace(name="production")
+        cluster_manager.custom_obj_api.list_namespaced_custom_object.return_value = {
+            "items": [{"metadata": {"name": "vmi-abc-123"}}]
+        }
+
+        with patch("krkn_ai.cluster.cluster_manager.logger") as mock_logger:
+            vmis = cluster_manager.list_vmis(namespace)
+
+        # The discovered VMI is still returned correctly.
+        assert [v.name for v in vmis] == ["vmi-abc-123"]
+
+        # The "Found N vmis" debug log must reference the namespace, not the VMI.
+        found_calls = [
+            call.args
+            for call in mock_logger.debug.call_args_list
+            if call.args and call.args[0] == "Found %d vmis in namespace %s"
+        ]
+        assert found_calls, "expected a 'Found ... vmis' debug log"
+        assert found_calls[0][2] == "production"
+
 
 def _http_get(path, port, scheme="HTTP"):
     hg = Mock()

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -141,8 +141,15 @@ class TestScenarioFactory:
                 raise Exception("Initialization failed")
 
         candidates = [("failing", FailingScenario)]
-        with pytest.raises(ScenarioInitError):
+        with pytest.raises(ScenarioInitError) as exc_info:
             ScenarioFactory.generate_random_scenario(config, candidates)
+
+        # The underlying error must be interpolated into the message (#258),
+        # not left as a raw tuple argument, and the cause must be chained.
+        assert str(exc_info.value) == (
+            "Unable to initialize scenario: Initialization failed"
+        )
+        assert isinstance(exc_info.value.__cause__, Exception)
 
     def test_create_dummy_scenario_returns_dummy_scenario(self):
         """Test that create_dummy_scenario returns a DummyScenario instance"""


### PR DESCRIPTION
## Description
Fixes #258. Two format-string bugs where variables were passed to a format
placeholder but never interpolated:

1. `ClusterManager.list_vmis` logged `vmis[0]["metadata"]["name"]` (the first
   VMI's name) in the "Found %d vmis in namespace %s" message instead of
   `namespace.name`, so the log named a VMI where it should name the namespace.
2. `ScenarioFactory.generate_random_scenario` raised
   `ScenarioInitError("Unable to initialize scenario: %s", error)` — Python's
   `Exception` does not printf-interpolate, so `str(e)` was a raw tuple. Now uses
   an f-string and chains the cause with `raise ... from error`.

## Type of Change
- [x] Bug fix

## Testing
- Added a regression test for `list_vmis` asserting the namespace name is logged.
- Strengthened the factory test to assert the interpolated message and chained cause.
- `pytest` green; `pre-commit` (ruff, ruff-format, mypy) green.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
