### PR TITLE
fix: prevent mutation stagnation for small percentage parameters (#292)

### DIFF
--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -5,6 +5,22 @@ from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import BaseParameter
 
 
+def _mutate_percentage(value: int, floor: int) -> int:
+    """Mutate an integer percentage by at least +/-1, clamped to ``[floor, 100]``.
+
+    The ``max(1, ...)`` guard guarantees a real change even for small values.
+    Without it, ``int(rng.randint(1, 35) * value / 100)`` truncates to ``0`` for
+    low ``value`` (e.g. ``value <= 3`` with ``floor == 1``), so ``mutate`` would
+    be a no-op and the genetic algorithm would stagnate on those parameters
+    instead of exploring the search space. (#292)
+    """
+    if rng.random() < 0.5:
+        value += max(1, int(rng.randint(1, 35) * value / 100))
+    else:
+        value -= max(1, int(rng.randint(1, 25) * value / 100))
+    return min(max(value, floor), 100)
+
+
 class DummyEndParameter(BaseParameter):
     krknhub_name: str = "END"
     krknctl_name: str = "duration"
@@ -112,13 +128,7 @@ class NodeCPUPercentageParameter(BaseParameter):
     value: int = 50
 
     def mutate(self):
-        if rng.random() < 0.5:
-            self.value += rng.randint(1, 35) * self.value / 100
-        else:
-            self.value -= rng.randint(1, 25) * self.value / 100
-        self.value = int(self.value)
-        self.value = max(self.value, 20)
-        self.value = min(self.value, 100)
+        self.value = _mutate_percentage(self.value, floor=20)
 
 
 class NodeMemoryPercentageParameter(BaseParameter):
@@ -134,13 +144,7 @@ class NodeMemoryPercentageParameter(BaseParameter):
         return f"{self.value}%"
 
     def mutate(self):
-        if rng.random() < 0.5:
-            self.value += rng.randint(1, 35) * self.value / 100
-        else:
-            self.value -= rng.randint(1, 25) * self.value / 100
-        self.value = int(self.value)
-        self.value = max(self.value, 20)
-        self.value = min(self.value, 100)
+        self.value = _mutate_percentage(self.value, floor=20)
 
 
 class NumberOfWorkersParameter(BaseParameter):
@@ -503,13 +507,7 @@ class IOWriteBytesParameter(BaseParameter):
         """
         Mutate the percentage value between 1 and 100.
         """
-        if rng.random() < 0.5:
-            self.value += rng.randint(1, 35) * self.value / 100
-        else:
-            self.value -= rng.randint(1, 25) * self.value / 100
-        self.value = int(self.value)
-        self.value = max(self.value, 1)
-        self.value = min(self.value, 100)
+        self.value = _mutate_percentage(self.value, floor=1)
 
 
 class NodeMountPathParameter(BaseParameter):

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -6,19 +6,27 @@ from krkn_ai.models.scenario.base import BaseParameter
 
 
 def _mutate_percentage(value: int, floor: int) -> int:
-    """Mutate an integer percentage by at least +/-1, clamped to ``[floor, 100]``.
+    """Mutate an integer percentage, clamped to ``[floor, 100]``.
 
-    The ``max(1, ...)`` guard guarantees a real change even for small values.
-    Without it, ``int(rng.randint(1, 35) * value / 100)`` truncates to ``0`` for
-    low ``value`` (e.g. ``value <= 3`` with ``floor == 1``), so ``mutate`` would
-    be a no-op and the genetic algorithm would stagnate on those parameters
-    instead of exploring the search space. (#292)
+    Preserves the original ``int(value +/- randint(...) * value / 100)`` rounding
+    of the previous per-parameter implementations, but guarantees the mutation is
+    not a silent no-op: when truncation would leave ``value`` unchanged it is
+    nudged by +/-1, so the genetic algorithm keeps exploring instead of
+    stagnating on small values (e.g. ``value <= 3`` with ``floor == 1``, where
+    ``int(randint(1, 35) * value / 100)`` truncated to ``0``). (#292)
+
+    Note: at the bounds the final clamp to ``[floor, 100]`` may still return the
+    original value (e.g. an increment from ``100`` or a decrement at ``floor``).
     """
     if rng.random() < 0.5:
-        value += max(1, int(rng.randint(1, 35) * value / 100))
+        mutated = int(value + rng.randint(1, 35) * value / 100)
+        if mutated == value:
+            mutated = value + 1
     else:
-        value -= max(1, int(rng.randint(1, 25) * value / 100))
-    return min(max(value, floor), 100)
+        mutated = int(value - rng.randint(1, 25) * value / 100)
+        if mutated == value:
+            mutated = value - 1
+    return min(max(mutated, floor), 100)
 
 
 class DummyEndParameter(BaseParameter):

--- a/tests/unit/models/scenario/test_parameters.py
+++ b/tests/unit/models/scenario/test_parameters.py
@@ -52,6 +52,35 @@ class TestPercentageMutationDoesNotStagnate:
             param.mutate()
         assert param.value == 1
 
+    def test_decrement_preserves_original_int_rounding(self):
+        """A real decrement keeps the pre-refactor int(value - delta) rounding.
+
+        value=50, multiplier=3 -> delta=1.5; int(50 - 1.5) == 48. The no-op guard
+        must not alter this, since the value genuinely changed (50 -> 48).
+        """
+        param = NodeCPUPercentageParameter()
+        param.value = 50
+        with (
+            patch(f"{_RNG}.random", return_value=0.9),
+            patch(f"{_RNG}.randint", return_value=3),
+        ):
+            param.mutate()
+        assert param.value == 48
+
+    def test_increment_preserves_original_int_rounding(self):
+        """A real increment keeps the pre-refactor int(value + delta) rounding.
+
+        value=50, multiplier=3 -> delta=1.5; int(50 + 1.5) == 51.
+        """
+        param = NodeCPUPercentageParameter()
+        param.value = 50
+        with (
+            patch(f"{_RNG}.random", return_value=0.0),
+            patch(f"{_RNG}.randint", return_value=3),
+        ):
+            param.mutate()
+        assert param.value == 51
+
     def test_result_always_within_bounds_and_integer(self):
         for cls, floor in (
             (NodeCPUPercentageParameter, 20),

--- a/tests/unit/models/scenario/test_parameters.py
+++ b/tests/unit/models/scenario/test_parameters.py
@@ -1,0 +1,67 @@
+"""Unit tests for scenario parameter mutation behaviour."""
+
+from unittest.mock import patch
+
+from krkn_ai.models.scenario.parameters import (
+    IOWriteBytesParameter,
+    NodeCPUPercentageParameter,
+    NodeMemoryPercentageParameter,
+)
+
+_RNG = "krkn_ai.models.scenario.parameters.rng"
+
+
+class TestPercentageMutationDoesNotStagnate:
+    """Regression tests for #292: mutate must change small values by >= 1.
+
+    The old logic did ``self.value += int(rng.randint(1, 35) * self.value / 100)``.
+    For small values the product is < 1, ``int()`` truncates it to ``0`` and the
+    mutation is a no-op, so the genetic algorithm stops exploring those params.
+    """
+
+    def test_io_write_bytes_low_value_increments_by_at_least_one(self):
+        param = IOWriteBytesParameter()
+        param.value = 1
+        # random < 0.5 -> increment branch; smallest possible multiplier (1).
+        # Old code: int(1 * 1 / 100) == 0 -> value stays 1 (the bug).
+        with (
+            patch(f"{_RNG}.random", return_value=0.0),
+            patch(f"{_RNG}.randint", return_value=1),
+        ):
+            param.mutate()
+        assert param.value == 2
+
+    def test_cpu_percentage_at_floor_can_increase(self):
+        param = NodeCPUPercentageParameter()
+        param.value = 20  # the floor
+        with (
+            patch(f"{_RNG}.random", return_value=0.0),
+            patch(f"{_RNG}.randint", return_value=1),
+        ):
+            param.mutate()
+        assert param.value == 21
+
+    def test_decrement_at_floor_stays_at_floor(self):
+        param = IOWriteBytesParameter()
+        param.value = 1  # floor for this parameter
+        # random >= 0.5 -> decrement branch; would go to 0 but is clamped up.
+        with (
+            patch(f"{_RNG}.random", return_value=0.9),
+            patch(f"{_RNG}.randint", return_value=1),
+        ):
+            param.mutate()
+        assert param.value == 1
+
+    def test_result_always_within_bounds_and_integer(self):
+        for cls, floor in (
+            (NodeCPUPercentageParameter, 20),
+            (NodeMemoryPercentageParameter, 20),
+            (IOWriteBytesParameter, 1),
+        ):
+            param = cls()
+            for start in (floor, 50, 100):
+                param.value = start
+                for _ in range(200):
+                    param.mutate()
+                    assert floor <= param.value <= 100
+                    assert isinstance(param.value, int)


### PR DESCRIPTION
## Description
Fixes #292. `mutate()` on percentage parameters did
`self.value += int(rng.randint(1, 35) * self.value / 100)`. For small values the
product is < 1, so `int()` truncates it to 0 and the mutation is a no-op — the
genetic algorithm then stops exploring those parameters (e.g. `IOWriteBytesParameter`
at values 1–3, and the CPU/Memory percentage params near their floor of 20).

Introduces a shared `_mutate_percentage(value, floor)` helper that guarantees a
minimum change of ±1 via `max(1, int(...))`, clamps to `[floor, 100]`, and
replaces the three duplicated (and identically buggy) implementations.

## Type of Change
- [x] Bug fix

## Testing
- New `tests/unit/models/scenario/test_parameters.py`: verifies a low value
  increments by at least 1, decrement at the floor stays clamped, and results
  always stay within `[floor, 100]` as integers.
- Full suite green; `pre-commit` (ruff, ruff-format, mypy) green.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
