### PR TITLE
feat: expand network interface discovery for diverse cluster environm…

### DIFF
--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -25,6 +25,37 @@ from krkn_ai.models.cluster_components import VMI
 
 logger = get_logger(__name__)
 
+# Network interface name prefixes that are valid targets for network chaos.
+# Covers classic and predictable NIC names, bonds, bridges, InfiniBand and
+# wireless across bare-metal, cloud and OpenShift nodes. (#294)
+_TARGETABLE_INTERFACE_PREFIXES = (
+    "eth",  # classic: eth0
+    "en",  # predictable names: ens5, eno1, enp0s3, enx001122334455
+    "em",  # onboard (older biosdevname): em1
+    "p",  # PCI (older biosdevname): p2p1, p1p1
+    "bond",  # link aggregation: bond0
+    "br",  # bridges: br-ex, br0, bridge0
+    "ib",  # InfiniBand: ib0
+    "wlan",  # wireless: wlan0
+)
+
+# Virtual / internal interfaces that must never be disrupted, even when they
+# share a prefix with a targetable one (e.g. "podman0" starts with "p").
+# Exclusion takes precedence over the whitelist above. (#294)
+_EXCLUDED_INTERFACE_PREFIXES = (
+    "lo",  # loopback
+    "veth",  # container virtual ethernet pairs
+    "ovs",  # Open vSwitch: ovs-system
+    "docker",  # docker bridge: docker0
+    "podman",  # podman bridge: podman0
+    "cni",  # CNI plugin interfaces: cni0
+    "flannel",  # flannel.1
+    "cali",  # Calico: cali<hash>
+    "tunl",  # IPIP tunnels: tunl0
+    "vxlan",  # VXLAN overlays: vxlan.calico
+    "dummy",  # dummy interfaces
+)
+
 
 class ClusterManager:
     def __init__(self, kubeconfig: str):
@@ -558,20 +589,28 @@ class ClusterManager:
             logger.warning("Unable to find interfaces for node %s", node)
             return []
 
-        interfaces = []
         interfaces_list = [x.strip() for x in log.splitlines()]
 
-        # TODO: Check which interfaces to consider for network chaos
-        # For now, consider specific interfaces like ens5, eth0, etc.
-
-        for intf in interfaces_list:
-            # TODO: Check which interfaces to consider for network chaos
-            # ens5, eth0, br-ex, br-int, etc. as well as other interfaces like lo, ovs-system, etc.
-            # Krkn validation doesn't work with interfaces with name like ABC-XYZ
-            if intf.startswith("ens") or intf.startswith("eth"):
-                interfaces.append(intf)
+        # Keep only physical/targetable interfaces; drop virtual and internal
+        # ones (loopback, veth pairs, overlay/bridge interfaces created by
+        # container runtimes and CNIs) so chaos never disrupts core networking.
+        interfaces = [
+            intf for intf in interfaces_list if self._is_targetable_interface(intf)
+        ]
 
         return interfaces
+
+    @staticmethod
+    def _is_targetable_interface(name: str) -> bool:
+        """Return True if ``name`` is a physical/targetable network interface.
+
+        Excluded virtual/internal interfaces take precedence over the targetable
+        whitelist, so names that share a prefix with a real NIC (e.g. "podman0"
+        vs the "p" prefix) are still filtered out. (#294)
+        """
+        if not name or name.startswith(_EXCLUDED_INTERFACE_PREFIXES):
+            return False
+        return name.startswith(_TARGETABLE_INTERFACE_PREFIXES)
 
     @staticmethod
     def parse_cpu(cpu_str: str):

--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -32,20 +32,26 @@ _TARGETABLE_INTERFACE_PREFIXES = (
     "eth",  # classic: eth0
     "en",  # predictable names: ens5, eno1, enp0s3, enx001122334455
     "em",  # onboard (older biosdevname): em1
-    "p",  # PCI (older biosdevname): p2p1, p1p1
     "bond",  # link aggregation: bond0
     "br",  # bridges: br-ex, br0, bridge0
     "ib",  # InfiniBand: ib0
     "wlan",  # wireless: wlan0
 )
 
+# biosdevname-style PCI NICs (e.g. p2p1, p1p1). Matched separately from the
+# prefix tuple so a bare "p" doesn't admit non-physical names like "ppp0". (#294)
+_PCI_INTERFACE_RE = re.compile(r"^p\d")
+
 # Virtual / internal interfaces that must never be disrupted, even when they
-# share a prefix with a targetable one (e.g. "podman0" starts with "p").
-# Exclusion takes precedence over the whitelist above. (#294)
+# share a prefix with a targetable one (e.g. "podman0" starts with "p", and the
+# OVS/OVN internal bridges "br-int"/"br-tun" start with "br"). Exclusion takes
+# precedence over the whitelist above. (#294)
 _EXCLUDED_INTERFACE_PREFIXES = (
     "lo",  # loopback
     "veth",  # container virtual ethernet pairs
     "ovs",  # Open vSwitch: ovs-system
+    "br-int",  # OVN/OVS integration bridge (pod-to-pod traffic)
+    "br-tun",  # OVS tunnel bridge (overlay traffic)
     "docker",  # docker bridge: docker0
     "podman",  # podman bridge: podman0
     "cni",  # CNI plugin interfaces: cni0
@@ -610,7 +616,10 @@ class ClusterManager:
         """
         if not name or name.startswith(_EXCLUDED_INTERFACE_PREFIXES):
             return False
-        return name.startswith(_TARGETABLE_INTERFACE_PREFIXES)
+        if name.startswith(_TARGETABLE_INTERFACE_PREFIXES):
+            return True
+        # biosdevname PCI NICs (p2p1, p1p1) but not names like "ppp0".
+        return bool(_PCI_INTERFACE_RE.match(name))
 
     @staticmethod
     def parse_cpu(cpu_str: str):

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -472,16 +472,18 @@ class TestClusterManager:
         with patch(
             "krkn_ai.cluster.cluster_manager.run_shell",
             return_value=(
-                "eth0\nens5\neno1\nbond0\nbr-ex\nlo\novs-system\nveth1a2b\npodman0\n",
+                "eth0\nens5\neno1\nbond0\nbr-ex\n"
+                "br-int\nlo\novs-system\nveth1a2b\npodman0\nppp0\n",
                 0,
             ),
         ):
             interfaces = cluster_manager.list_node_interfaces("test-node")
 
-        # Physical / bond / bridge interfaces are targetable.
+        # Physical / bond / external-bridge interfaces are targetable.
         assert interfaces == ["eth0", "ens5", "eno1", "bond0", "br-ex"]
-        # Virtual / internal interfaces are excluded.
-        for excluded in ("lo", "ovs-system", "veth1a2b", "podman0"):
+        # Virtual / internal interfaces are excluded, including the OVS/OVN
+        # integration bridge and PPP links.
+        for excluded in ("br-int", "lo", "ovs-system", "veth1a2b", "podman0", "ppp0"):
             assert excluded not in interfaces
 
     @pytest.mark.parametrize(
@@ -512,8 +514,11 @@ class TestClusterManager:
             "lo",
             "veth1a2b",
             "ovs-system",
+            "br-int",  # OVN integration bridge (shares the "br" prefix)
+            "br-tun",  # OVS tunnel bridge (shares the "br" prefix)
             "docker0",
-            "podman0",  # shares the "p" prefix but must still be excluded
+            "podman0",  # would match a bare "p" prefix but must be excluded
+            "ppp0",  # PPP link: not a biosdevname PCI NIC
             "cni0",
             "flannel.1",
             "cali1234abcd",

--- a/tests/unit/cluster/test_cluster_manager.py
+++ b/tests/unit/cluster/test_cluster_manager.py
@@ -468,18 +468,64 @@ class TestClusterManager:
         assert nodes[0].interfaces == []  # Empty on failure
 
     def test_list_node_interfaces_filters_network_interfaces(self, cluster_manager):
-        """Test list_node_interfaces filters and returns only ens/eth interfaces"""
+        """list_node_interfaces keeps physical/bridge NICs and drops virtual ones (#294)."""
         with patch(
             "krkn_ai.cluster.cluster_manager.run_shell",
-            return_value=("eth0\nens5\nlo\novs-system\nbr-ex\n", 0),
+            return_value=(
+                "eth0\nens5\neno1\nbond0\nbr-ex\nlo\novs-system\nveth1a2b\npodman0\n",
+                0,
+            ),
         ):
             interfaces = cluster_manager.list_node_interfaces("test-node")
 
-        assert len(interfaces) == 2
-        assert "eth0" in interfaces
-        assert "ens5" in interfaces
-        assert "lo" not in interfaces
-        assert "ovs-system" not in interfaces
+        # Physical / bond / bridge interfaces are targetable.
+        assert interfaces == ["eth0", "ens5", "eno1", "bond0", "br-ex"]
+        # Virtual / internal interfaces are excluded.
+        for excluded in ("lo", "ovs-system", "veth1a2b", "podman0"):
+            assert excluded not in interfaces
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "eth0",
+            "ens5",
+            "eno1",
+            "enp0s3",
+            "enx001122334455",
+            "em1",
+            "p2p1",
+            "bond0",
+            "br-ex",
+            "br0",
+            "bridge0",
+            "ib0",
+            "wlan0",
+        ],
+    )
+    def test_is_targetable_interface_accepts_physical_nics(self, name):
+        """Physical, bond, bridge, InfiniBand and wireless NICs are targetable (#294)."""
+        assert ClusterManager._is_targetable_interface(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "lo",
+            "veth1a2b",
+            "ovs-system",
+            "docker0",
+            "podman0",  # shares the "p" prefix but must still be excluded
+            "cni0",
+            "flannel.1",
+            "cali1234abcd",
+            "tunl0",
+            "vxlan.calico",
+            "dummy0",
+            "",
+        ],
+    )
+    def test_is_targetable_interface_rejects_virtual_interfaces(self, name):
+        """Virtual/internal interfaces are excluded even when they share a prefix (#294)."""
+        assert ClusterManager._is_targetable_interface(name) is False
 
     def test_list_node_interfaces_returns_empty_list_on_shell_error(
         self, cluster_manager


### PR DESCRIPTION
## Description
Fixes #294. `ClusterManager.list_node_interfaces` only matched `ens`/`eth`
prefixes, so network chaos found no targetable interfaces on bare-metal,
OpenShift and cloud nodes that use `bond`, `br-ex`, `eno`, `em`, `ib`, etc.,
and it had no explicit guard against disrupting virtual interfaces.

This change:
- Adds a documented whitelist of targetable prefixes (eth, en, em, p, bond, br,
  ib, wlan) covering classic + predictable NIC names, bonds, bridges,
  InfiniBand and wireless.
- Adds an explicit exclusion list (lo, veth, ovs, docker, podman, cni, flannel,
  cali, tunl, vxlan, dummy). Exclusion takes precedence, so names that share a
  prefix with a real NIC (e.g. `podman0` vs the `p` prefix) are still filtered.
- Extracts the decision into a testable `_is_targetable_interface()` helper and
  removes the stale TODOs.

## Type of Change
- [x] New feature / enhancement

## Testing
- Updated the interface-filter test to the new behavior (keeps physical/bond/
  bridge NICs, drops virtual/internal ones).
- Added parametrized tests over 13 targetable and 12 excluded interface names,
  including the `podman0` prefix-collision case.
- Full suite green; `pre-commit` (ruff, ruff-format, mypy) green.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
