### PR TITLE
fix: correct ContainerScenario disruption_count bound and container s…

### DIFF
--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -70,10 +70,14 @@ class ContainerScenario(Scenario):
         self.label_selector.value = "{}={}".format(label, labels[label])
 
         # DISRUPTION_COUNT is the number of *pods* to disrupt, so bound it by how
-        # many pods in the namespace match the selected label rather than by the
-        # container count of a single pod. (#277)
+        # many pods in the namespace are eligible targets for the selected label
+        # rather than by the container count of a single pod. Pods without
+        # containers are excluded here just as they are from the candidate list
+        # above, so the count never exceeds the number of disruptable pods. (#277)
         matching_pod_count = sum(
-            1 for p in namespace.pods if p.labels.get(label) == labels[label]
+            1
+            for p in namespace.pods
+            if p.labels.get(label) == labels[label] and len(p.containers) > 0
         )
         self.disruption_count.value = rng.randint(1, matching_pod_count)
 

--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -69,13 +69,20 @@ class ContainerScenario(Scenario):
         # pod_label is a string of the form "key=value"
         self.label_selector.value = "{}={}".format(label, labels[label])
 
-        self.disruption_count.value = rng.randint(1, len(pod.containers))
+        # DISRUPTION_COUNT is the number of *pods* to disrupt, so bound it by how
+        # many pods in the namespace match the selected label rather than by the
+        # container count of a single pod. (#277)
+        matching_pod_count = sum(
+            1 for p in namespace.pods if p.labels.get(label) == labels[label]
+        )
+        self.disruption_count.value = rng.randint(1, matching_pod_count)
 
-        if self.disruption_count.value == 1:
-            # TODO: Verify whether we need to keep it empty or use regex pattern to match all container
-            self.container_name.value = ".*"
-        else:
-            # Select specific container to kill in the pod
+        # CONTAINER_NAME selects which container(s) to kill inside each disrupted
+        # pod, independently of how many pods are disrupted: either one specific
+        # container, or ".*" to target every container in the pod. (#277)
+        if rng.random() < 0.5:
             self.container_name.value = rng.choice([x.name for x in pod.containers])
+        else:
+            self.container_name.value = ".*"
 
         self.action.value = rng.choice(["1", "9"])

--- a/krkn_ai/models/scenario/scenario_container.py
+++ b/krkn_ai/models/scenario/scenario_container.py
@@ -69,24 +69,31 @@ class ContainerScenario(Scenario):
         # pod_label is a string of the form "key=value"
         self.label_selector.value = "{}={}".format(label, labels[label])
 
-        # DISRUPTION_COUNT is the number of *pods* to disrupt, so bound it by how
-        # many pods in the namespace are eligible targets for the selected label
-        # rather than by the container count of a single pod. Pods without
-        # containers are excluded here just as they are from the candidate list
-        # above, so the count never exceeds the number of disruptable pods. (#277)
-        matching_pod_count = sum(
-            1
-            for p in namespace.pods
-            if p.labels.get(label) == labels[label] and len(p.containers) > 0
-        )
-        self.disruption_count.value = rng.randint(1, matching_pod_count)
-
         # CONTAINER_NAME selects which container(s) to kill inside each disrupted
-        # pod, independently of how many pods are disrupted: either one specific
-        # container, or ".*" to target every container in the pod. (#277)
+        # pod: either one specific container, or ".*" to target every container.
+        # It is chosen before the disruption count because it constrains which
+        # pods can actually be targeted. (#277)
         if rng.random() < 0.5:
             self.container_name.value = rng.choice([x.name for x in pod.containers])
         else:
             self.container_name.value = ".*"
+
+        target_container = self.container_name.value
+
+        def is_targetable(candidate: Pod) -> bool:
+            """Whether the label selector and container name both apply to a pod."""
+            if candidate.labels.get(label) != labels[label]:
+                return False
+            if target_container == ".*":
+                return len(candidate.containers) > 0
+            return any(c.name == target_container for c in candidate.containers)
+
+        # DISRUPTION_COUNT is the number of *pods* to disrupt, not the container
+        # count of a single pod. Only pods that also contain the targeted
+        # container are counted: pods sharing a generic label (e.g. env=prod) can
+        # be completely different workloads, so counting them would let krkn pick
+        # a pod that has no such container and fail the lookup. (#277)
+        matching_pod_count = sum(1 for p in namespace.pods if is_targetable(p))
+        self.disruption_count.value = rng.randint(1, matching_pod_count)
 
         self.action.value = rng.choice(["1", "9"])

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -92,8 +92,58 @@ class TestContainerScenario:
         scenario = ContainerScenario(cluster_components=cluster)
         assert scenario.name == "container-scenarios"
         assert scenario.namespace.value == "test-ns"
-        assert scenario.disruption_count.value >= 1
-        assert scenario.disruption_count.value <= len(pod.containers)
+        # Only one pod matches the label, so disruption_count (number of pods
+        # to disrupt) is 1 regardless of how many containers the pod has (#277).
+        assert scenario.disruption_count.value == 1
+
+    def test_container_scenario_disruption_count_bounded_by_matching_pods(self):
+        """disruption_count counts matching pods, not one pod's containers (#277).
+
+        Each pod has a single container, so the old logic
+        (``rng.randint(1, len(pod.containers))``) could only ever produce 1.
+        With three pods sharing the label, the count must be able to exceed 1.
+        """
+        pods = [
+            Pod(
+                name=f"web-{i}",
+                labels={"app": "web"},
+                containers=[Container(name="c1")],
+            )
+            for i in range(3)
+        ]
+        namespace = Namespace(name="test-ns", pods=pods)
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        seen_counts = set()
+        for _ in range(100):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert 1 <= scenario.disruption_count.value <= 3
+            seen_counts.add(scenario.disruption_count.value)
+        assert max(seen_counts) > 1  # bounded by pods (3), not the single container
+
+    def test_container_scenario_container_name_is_specific_or_wildcard(self):
+        """container_name is a real container or '.*', decoupled from count (#277).
+
+        Even though only one pod matches (so disruption_count is always 1), the
+        container scope must still vary between a specific container and ".*"
+        rather than being forced to ".*" whenever the count is 1 (the old bug).
+        """
+        pod = Pod(
+            name="web",
+            labels={"app": "web"},
+            containers=[Container(name="c1"), Container(name="c2")],
+        )
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        valid = {"c1", "c2", ".*"}
+        seen = set()
+        for _ in range(100):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.container_name.value in valid
+            seen.add(scenario.container_name.value)
+        assert ".*" in seen  # wildcard still reachable
+        assert seen & {"c1", "c2"}  # specific-container choice reachable too
 
     def test_container_scenario_raises_error_when_no_pods_with_labels(self):
         """Test that ContainerScenario raises error when no pods have labels"""

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -139,6 +139,48 @@ class TestContainerScenario:
             scenario = ContainerScenario(cluster_components=cluster)
             assert scenario.disruption_count.value == 1
 
+    def test_container_scenario_count_excludes_pods_without_target_container(self):
+        """A specific container name limits the count to pods that have it (#277).
+
+        Pods can share a generic label (env=prod) while being different
+        workloads. If nginx is the targeted container, the redis pods must not
+        be counted, otherwise krkn would pick a pod with no nginx container and
+        fail the lookup. When the wildcard is chosen every labelled pod counts.
+        """
+        pods = [
+            Pod(
+                name="nginx-0",
+                labels={"env": "prod"},
+                containers=[Container(name="nginx")],
+            ),
+            Pod(
+                name="redis-0",
+                labels={"env": "prod"},
+                containers=[Container(name="redis")],
+            ),
+            Pod(
+                name="redis-1",
+                labels={"env": "prod"},
+                containers=[Container(name="redis")],
+            ),
+        ]
+        namespace = Namespace(name="test-ns", pods=pods)
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        for _ in range(200):
+            scenario = ContainerScenario(cluster_components=cluster)
+            target = scenario.container_name.value
+            count = scenario.disruption_count.value
+            if target == ".*":
+                # Wildcard applies to every labelled pod with containers.
+                assert 1 <= count <= 3
+            else:
+                # Only the pods actually running that container may be counted.
+                eligible = sum(
+                    1 for p in pods if any(c.name == target for c in p.containers)
+                )
+                assert 1 <= count <= eligible
+
     def test_container_scenario_container_name_is_specific_or_wildcard(self):
         """container_name is a real container or '.*', decoupled from count (#277).
 

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -121,6 +121,24 @@ class TestContainerScenario:
             seen_counts.add(scenario.disruption_count.value)
         assert max(seen_counts) > 1  # bounded by pods (3), not the single container
 
+    def test_container_scenario_disruption_count_excludes_containerless_pods(self):
+        """Label-matching pods without containers don't inflate the count (#277).
+
+        Three pods share the label but only one has a container, so only one pod
+        is a disruptable target and disruption_count must always be 1.
+        """
+        pods = [
+            Pod(name="web-0", labels={"app": "web"}, containers=[Container(name="c1")]),
+            Pod(name="web-1", labels={"app": "web"}, containers=[]),
+            Pod(name="web-2", labels={"app": "web"}, containers=[]),
+        ]
+        namespace = Namespace(name="test-ns", pods=pods)
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        for _ in range(50):
+            scenario = ContainerScenario(cluster_components=cluster)
+            assert scenario.disruption_count.value == 1
+
     def test_container_scenario_container_name_is_specific_or_wildcard(self):
         """container_name is a real container or '.*', decoupled from count (#277).
 


### PR DESCRIPTION

## Description
Fixes #277. `ContainerScenario.mutate()` had two coupled defects:

1. **Backwards container selection.** It set `container_name = ".*"` (match *all*
   containers) exactly when `disruption_count == 1`, and picked a single specific
   container when the count was > 1 — the inverse of the intended blast radius.
2. **Wrong `disruption_count` bound.** In krkn-hub's container scenario,
   `DISRUPTION_COUNT` is the number of *pods* to disrupt and `CONTAINER_NAME`
   selects which container(s) within each pod. The old code bounded the count by
   `len(pod.containers)` of a single pod, which is unrelated to the number of pods.

This change bounds `disruption_count` by the number of pods in the namespace that
match the selected label, and chooses `container_name` (a specific container or
`.*`) independently of the count.

## Type of Change
- [x] Bug fix

## Testing
- Added a test with three single-container pods sharing a label, asserting the
  count can exceed 1 (impossible under the old container-count bound).
- Added a test asserting `container_name` still varies between a specific
  container and `.*` even when only one pod matches (count == 1).
- Updated the existing init test to the corrected semantics. Full suite green;
  `pre-commit` (ruff, ruff-format, mypy) green.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
