### PR TITLE
Feat/issue 13 service disruption scenario

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -80,6 +80,11 @@ def main():
     help="Port to run Streamlit server on when monitoring is enabled.",
     default=8501,
 )
+@click.option(
+    "--allow-dangerous-scenarios",
+    is_flag=True,
+    help="Allow scenarios with a cluster-critical blast radius (e.g. service disruption).",
+)
 @click.pass_context
 def run(
     ctx,
@@ -93,6 +98,7 @@ def run(
     verbose: int = 0,  # Default to INFO level
     monitoring: bool = False,
     port: int = 8501,
+    allow_dangerous_scenarios: bool = False,
 ):
     run_uuid = str(uuid.uuid4())
     new_output_path = os.path.join(output, run_uuid)
@@ -121,6 +127,10 @@ def run(
     # Override seed from CLI if provided
     if seed is not None:
         parsed_config.seed = seed
+
+    # CLI flag overrides config file (flag is additive, never disables)
+    if allow_dangerous_scenarios:
+        parsed_config.allow_dangerous_scenarios = True
 
     # Convert user-friendly string to enum if provided
     enum_runner_type = None

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -338,6 +338,12 @@ class ConfigFile(BaseModel):
     baseline: BaselineConfig = BaselineConfig()
     scenario: ScenarioConfig = ScenarioConfig()
 
+    # Opt-in gate for scenarios with a cluster-critical blast radius (e.g.
+    # service disruption, which deletes whole namespaces). Such scenarios are
+    # skipped unless this is explicitly set to true, even when their own
+    # ``enable`` flag is on.
+    allow_dangerous_scenarios: bool = False
+
     output: OutputConfig = OutputConfig()
 
     elastic: Optional[ElasticConfig] = Field(

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -72,6 +72,10 @@ class StorageThrottleScenarioConfig(BaseModel):
     enable: bool = False
 
 
+class ServiceDisruptionScenarioConfig(BaseModel):
+    enable: bool = False
+
+
 class BaselineConfig(BaseModel):
     enable: bool = True
     duration: int = 60 * 2  # 2 minutes
@@ -116,6 +120,9 @@ class ScenarioConfig(BaseModel):
     )
     storage_throttle: Optional[StorageThrottleScenarioConfig] = Field(
         alias="storage-throttle", default=None
+    )
+    service_disruption: Optional[ServiceDisruptionScenarioConfig] = Field(
+        alias="service-disruption", default=None
     )
 
 

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -62,6 +62,15 @@ scenario_specs = [
     ("service_disruption", ServiceDisruptionScenario),
 ]
 
+# Scenarios whose blast radius is too large to enable automatically in a
+# generated config. They stay fully supported and configurable, but `discover`
+# leaves them disabled so users opt in deliberately.
+#
+# Service disruption deletes entire namespaces, destroying every resource inside
+# them; unlike a pod or container kill, recovery depends on an operator or
+# GitOps controller reconciling the namespace back.
+NOT_RECOMMENDED_BY_DEFAULT = {"service_disruption"}
+
 
 class ScenarioFactory:
     @staticmethod
@@ -173,4 +182,6 @@ class ScenarioFactory:
             logger.debug("Scenario recommendation failed: %s", error)
             return all_disabled
         valid_names = {name for name, _ in valid}
-        return {n: n in valid_names for n in names}
+        return {
+            n: n in valid_names and n not in NOT_RECOMMENDED_BY_DEFAULT for n in names
+        }

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -62,37 +62,15 @@ scenario_specs = [
     ("service_disruption", ServiceDisruptionScenario),
 ]
 
-# Scenarios with a cluster-critical blast radius. They are fully supported, but
-# are only ever run when the config explicitly sets ``allow_dangerous_scenarios:
-# true`` -- their own ``enable`` flag is not sufficient on its own.
-#
-# Service disruption deletes entire namespaces, destroying every resource inside
-# them; unlike a pod or container kill, recovery depends on an operator or
-# GitOps controller reconciling the namespace back.
+# Scenarios with a cluster-critical blast radius (e.g. namespace deletion).
+# Gated behind ``allow_dangerous_scenarios`` — their own ``enable`` flag is
+# not sufficient on its own.
 DANGEROUS_SCENARIOS = {"service_disruption"}
 
 
 class ScenarioFactory:
     @staticmethod
-    def _blocked_dangerous_scenarios(config: ConfigFile) -> List[str]:
-        """User-facing keys of enabled dangerous scenarios blocked by the gate."""
-        if config.allow_dangerous_scenarios:
-            return []
-        blocked = []
-        for attr, _ in scenario_specs:
-            scenario_cfg = getattr(config.scenario, attr)
-            if (
-                attr in DANGEROUS_SCENARIOS
-                and scenario_cfg is not None
-                and scenario_cfg.enable
-            ):
-                blocked.append(attr.replace("_", "-"))
-        return blocked
-
-    @staticmethod
     def list_scenarios(config: ConfigFile) -> List[Tuple[str, type[Scenario]]]:
-        # List all enabled scenarios from config, gating dangerous ones behind
-        # the explicit allow_dangerous_scenarios opt-in.
         candidates = []
         for attr, factory in scenario_specs:
             scenario_cfg = getattr(config.scenario, attr)
@@ -100,9 +78,9 @@ class ScenarioFactory:
                 continue
             if attr in DANGEROUS_SCENARIOS and not config.allow_dangerous_scenarios:
                 logger.warning(
-                    "Scenario '%s' is enabled but has a cluster-critical blast "
-                    "radius; skipping it because 'allow_dangerous_scenarios' is "
-                    "not set. Set allow_dangerous_scenarios: true to run it.",
+                    "Scenario '%s' is enabled but requires "
+                    "'--allow-dangerous-scenarios' (CLI) or "
+                    "'allow_dangerous_scenarios: true' (config). Skipping.",
                     attr.replace("_", "-"),
                 )
                 continue
@@ -118,17 +96,9 @@ class ScenarioFactory:
 
         Returns a list of valid scenarios.
         """
-        # Get all scenarios that are set in config
         candidates = ScenarioFactory.list_scenarios(config)
 
         if len(candidates) == 0:
-            blocked = ScenarioFactory._blocked_dangerous_scenarios(config)
-            if blocked:
-                raise MissingScenarioError(
-                    "The only enabled scenario(s) ({}) are cluster-critical and "
-                    "were blocked. Set 'allow_dangerous_scenarios: true' in your "
-                    "config to run them.".format(", ".join(blocked))
-                )
             raise MissingScenarioError(
                 "No scenarios found. Please provide atleast 1 scenario."
             )

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -27,6 +27,9 @@ from krkn_ai.models.scenario.scenario_io_hog import NodeIOHogScenario
 from krkn_ai.models.scenario.scenario_pvc import PVCScenario
 from krkn_ai.models.scenario.scenario_kubevirt import KubevirtDisruptionScenario
 from krkn_ai.models.scenario.scenario_storage_throttle import StorageThrottleScenario
+from krkn_ai.models.scenario.scenario_service_disruption import (
+    ServiceDisruptionScenario,
+)
 
 logger = get_logger(__name__)
 
@@ -56,6 +59,7 @@ scenario_specs = [
     ("pvc_scenarios", PVCScenario),
     ("kubevirt_scenarios", KubevirtDisruptionScenario),
     ("storage_throttle", StorageThrottleScenario),
+    ("service_disruption", ServiceDisruptionScenario),
 ]
 
 

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -62,26 +62,35 @@ scenario_specs = [
     ("service_disruption", ServiceDisruptionScenario),
 ]
 
-# Scenarios whose blast radius is too large to enable automatically in a
-# generated config. They stay fully supported and configurable, but `discover`
-# leaves them disabled so users opt in deliberately.
+# Scenarios with a cluster-critical blast radius. They are fully supported, but
+# are only ever run when the config explicitly sets ``allow_dangerous_scenarios:
+# true`` -- their own ``enable`` flag is not sufficient on its own.
 #
 # Service disruption deletes entire namespaces, destroying every resource inside
 # them; unlike a pod or container kill, recovery depends on an operator or
 # GitOps controller reconciling the namespace back.
-NOT_RECOMMENDED_BY_DEFAULT = {"service_disruption"}
+DANGEROUS_SCENARIOS = {"service_disruption"}
 
 
 class ScenarioFactory:
     @staticmethod
     def list_scenarios(config: ConfigFile) -> List[Tuple[str, type[Scenario]]]:
-        # List all scenarios that are set in config
-        candidates = [
-            (attr, factory)
-            for attr, factory in scenario_specs
-            if getattr(config.scenario, attr) is not None
-            and getattr(config.scenario, attr).enable
-        ]
+        # List all enabled scenarios from config, gating dangerous ones behind
+        # the explicit allow_dangerous_scenarios opt-in.
+        candidates = []
+        for attr, factory in scenario_specs:
+            scenario_cfg = getattr(config.scenario, attr)
+            if scenario_cfg is None or not scenario_cfg.enable:
+                continue
+            if attr in DANGEROUS_SCENARIOS and not config.allow_dangerous_scenarios:
+                logger.warning(
+                    "Scenario '%s' is enabled but has a cluster-critical blast "
+                    "radius; skipping it because 'allow_dangerous_scenarios' is "
+                    "not set. Set allow_dangerous_scenarios: true to run it.",
+                    attr,
+                )
+                continue
+            candidates.append((attr, factory))
         return candidates
 
     @staticmethod
@@ -182,6 +191,4 @@ class ScenarioFactory:
             logger.debug("Scenario recommendation failed: %s", error)
             return all_disabled
         valid_names = {name for name, _ in valid}
-        return {
-            n: n in valid_names and n not in NOT_RECOMMENDED_BY_DEFAULT for n in names
-        }
+        return {n: n in valid_names for n in names}

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -74,6 +74,22 @@ DANGEROUS_SCENARIOS = {"service_disruption"}
 
 class ScenarioFactory:
     @staticmethod
+    def _blocked_dangerous_scenarios(config: ConfigFile) -> List[str]:
+        """User-facing keys of enabled dangerous scenarios blocked by the gate."""
+        if config.allow_dangerous_scenarios:
+            return []
+        blocked = []
+        for attr, _ in scenario_specs:
+            scenario_cfg = getattr(config.scenario, attr)
+            if (
+                attr in DANGEROUS_SCENARIOS
+                and scenario_cfg is not None
+                and scenario_cfg.enable
+            ):
+                blocked.append(attr.replace("_", "-"))
+        return blocked
+
+    @staticmethod
     def list_scenarios(config: ConfigFile) -> List[Tuple[str, type[Scenario]]]:
         # List all enabled scenarios from config, gating dangerous ones behind
         # the explicit allow_dangerous_scenarios opt-in.
@@ -87,7 +103,7 @@ class ScenarioFactory:
                     "Scenario '%s' is enabled but has a cluster-critical blast "
                     "radius; skipping it because 'allow_dangerous_scenarios' is "
                     "not set. Set allow_dangerous_scenarios: true to run it.",
-                    attr,
+                    attr.replace("_", "-"),
                 )
                 continue
             candidates.append((attr, factory))
@@ -106,6 +122,13 @@ class ScenarioFactory:
         candidates = ScenarioFactory.list_scenarios(config)
 
         if len(candidates) == 0:
+            blocked = ScenarioFactory._blocked_dangerous_scenarios(config)
+            if blocked:
+                raise MissingScenarioError(
+                    "The only enabled scenario(s) ({}) are cluster-critical and "
+                    "were blocked. Set 'allow_dangerous_scenarios: true' in your "
+                    "config to run them.".format(", ".join(blocked))
+                )
             raise MissingScenarioError(
                 "No scenarios found. Please provide atleast 1 scenario."
             )

--- a/krkn_ai/models/scenario/parameters.py
+++ b/krkn_ai/models/scenario/parameters.py
@@ -41,6 +41,18 @@ class DisruptionCountParameter(BaseParameter):
     value: int = 1
 
 
+class DeleteCountParameter(BaseParameter):
+    krknhub_name: str = "DELETE_COUNT"
+    krknctl_name: str = "delete-count"
+    value: int = 1
+
+
+class RunsParameter(BaseParameter):
+    krknhub_name: str = "RUNS"
+    krknctl_name: str = "runs"
+    value: int = 1
+
+
 class KillTimeoutParameter(BaseParameter):
     krknhub_name: str = "KILL_TIMEOUT"
     krknctl_name: str = "kill-timeout"

--- a/krkn_ai/models/scenario/scenario_service_disruption.py
+++ b/krkn_ai/models/scenario/scenario_service_disruption.py
@@ -8,6 +8,16 @@ from krkn_ai.models.scenario.parameters import (
     RunsParameter,
 )
 
+# Cluster-critical namespaces that must never be a deletion target, even when a
+# user has opted in. discover's default `--namespace .*` pulls these into
+# cluster_components, so guard against selecting them here.
+_SYSTEM_NAMESPACES = frozenset({"default"})
+_SYSTEM_NAMESPACE_PREFIXES = ("kube-", "openshift")
+
+
+def _is_system_namespace(name: str) -> bool:
+    return name in _SYSTEM_NAMESPACES or name.startswith(_SYSTEM_NAMESPACE_PREFIXES)
+
 
 class ServiceDisruptionScenario(Scenario):
     """Service disruption (namespace deletion) scenario.
@@ -34,24 +44,34 @@ class ServiceDisruptionScenario(Scenario):
 
     @property
     def parameters(self):
-        return [
-            self.namespace,
-            self.label_selector,
-            self.delete_count,
-            self.runs,
-        ]
+        # NAMESPACE and LABEL_SELECTOR are mutually exclusive in krkn, so only
+        # emit label_selector when it is actually set -- never pass an empty
+        # --label-selector "" alongside NAMESPACE.
+        params = [self.namespace]
+        if self.label_selector.value:
+            params.append(self.label_selector)
+        params.extend([self.delete_count, self.runs])
+        return params
 
     def mutate(self):
-        namespaces = self._cluster_components.namespaces
-        if len(namespaces) == 0:
+        # Only target non-system namespaces that actually run services: deleting
+        # a namespace with no services has no meaningful blast radius, and
+        # cluster-critical namespaces (kube-*, openshift*, default) must never be
+        # a target even after the user opts into dangerous scenarios.
+        candidates = [
+            ns
+            for ns in self._cluster_components.namespaces
+            if ns.services and not _is_system_namespace(ns.name)
+        ]
+        if not candidates:
             raise ScenarioParameterInitError(
-                "No namespaces found for service disruption scenario"
+                "No non-system namespaces with services found for service "
+                "disruption scenario"
             )
 
-        namespace = rng.choice(namespaces)
+        namespace = rng.choice(candidates)
 
-        # Target a specific namespace by name. NAMESPACE and LABEL_SELECTOR are
-        # mutually exclusive in krkn, so label_selector is left empty. With a
+        # Target a specific namespace by name; label_selector stays empty. With a
         # single named namespace exactly one namespace matches, so delete_count
         # stays at 1; runs varies to give the genetic algorithm room to explore
         # repeated disruptions.

--- a/krkn_ai/models/scenario/scenario_service_disruption.py
+++ b/krkn_ai/models/scenario/scenario_service_disruption.py
@@ -8,23 +8,15 @@ from krkn_ai.models.scenario.parameters import (
     RunsParameter,
 )
 
-# Cluster-critical namespaces that must never be a deletion target, even when a
-# user has opted in. discover's default `--namespace .*` pulls these into
-# cluster_components, so guard against selecting them here.
-_SYSTEM_NAMESPACES = frozenset({"default"})
-_SYSTEM_NAMESPACE_PREFIXES = ("kube-", "openshift")
-
-
-def _is_system_namespace(name: str) -> bool:
-    return name in _SYSTEM_NAMESPACES or name.startswith(_SYSTEM_NAMESPACE_PREFIXES)
-
 
 class ServiceDisruptionScenario(Scenario):
     """Service disruption (namespace deletion) scenario.
 
     Deletes a target namespace and waits for it to be recreated, exercising an
     application's ability to recover from losing its namespace-scoped resources.
-    See https://krkn-chaos.dev/docs/scenarios/service-disruption-scenarios/.
+    Gated behind ``allow_dangerous_scenarios`` since namespace deletion is not
+    self-recovering.
+    See https://krkn-chaos.dev/docs/scenarios/service-disruption-scenarios/
     """
 
     name: str = "service-disruption"
@@ -44,9 +36,8 @@ class ServiceDisruptionScenario(Scenario):
 
     @property
     def parameters(self):
-        # NAMESPACE and LABEL_SELECTOR are mutually exclusive in krkn, so only
-        # emit label_selector when it is actually set -- never pass an empty
-        # --label-selector "" alongside NAMESPACE.
+        # NAMESPACE and LABEL_SELECTOR are mutually exclusive in krkn;
+        # only emit label_selector when it is actually set.
         params = [self.namespace]
         if self.label_selector.value:
             params.append(self.label_selector)
@@ -54,27 +45,15 @@ class ServiceDisruptionScenario(Scenario):
         return params
 
     def mutate(self):
-        # Only target non-system namespaces that actually run services: deleting
-        # a namespace with no services has no meaningful blast radius, and
-        # cluster-critical namespaces (kube-*, openshift*, default) must never be
-        # a target even after the user opts into dangerous scenarios.
-        candidates = [
-            ns
-            for ns in self._cluster_components.namespaces
-            if ns.services and not _is_system_namespace(ns.name)
-        ]
+        candidates = [ns for ns in self._cluster_components.namespaces if ns.services]
         if not candidates:
             raise ScenarioParameterInitError(
-                "No non-system namespaces with services found for service "
-                "disruption scenario"
+                "No namespaces with services found for service disruption scenario"
             )
 
         namespace = rng.choice(candidates)
-
-        # Target a specific namespace by name; label_selector stays empty. With a
-        # single named namespace exactly one namespace matches, so delete_count
-        # stays at 1; runs varies to give the genetic algorithm room to explore
-        # repeated disruptions.
+        # Target a specific namespace by name; delete_count stays at 1.
+        # runs varies to give the genetic algorithm room to explore.
         self.namespace.value = namespace.name
         self.label_selector.value = ""
         self.delete_count.value = 1

--- a/krkn_ai/models/scenario/scenario_service_disruption.py
+++ b/krkn_ai/models/scenario/scenario_service_disruption.py
@@ -1,0 +1,61 @@
+from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.rng import rng
+from krkn_ai.models.scenario.base import Scenario
+from krkn_ai.models.scenario.parameters import (
+    DeleteCountParameter,
+    LabelSelectorParameter,
+    NamespaceParameter,
+    RunsParameter,
+)
+
+
+class ServiceDisruptionScenario(Scenario):
+    """Service disruption (namespace deletion) scenario.
+
+    Deletes a target namespace and waits for it to be recreated, exercising an
+    application's ability to recover from losing its namespace-scoped resources.
+    See https://krkn-chaos.dev/docs/scenarios/service-disruption-scenarios/.
+    """
+
+    name: str = "service-disruption"
+    krknctl_name: str = "service-disruption-scenarios"
+    krknhub_image: str = (
+        "containers.krkn-chaos.dev/krkn-chaos/krkn-hub:service-disruption-scenarios"
+    )
+
+    namespace: NamespaceParameter = NamespaceParameter()
+    label_selector: LabelSelectorParameter = LabelSelectorParameter()
+    delete_count: DeleteCountParameter = DeleteCountParameter()
+    runs: RunsParameter = RunsParameter()
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self.mutate()
+
+    @property
+    def parameters(self):
+        return [
+            self.namespace,
+            self.label_selector,
+            self.delete_count,
+            self.runs,
+        ]
+
+    def mutate(self):
+        namespaces = self._cluster_components.namespaces
+        if len(namespaces) == 0:
+            raise ScenarioParameterInitError(
+                "No namespaces found for service disruption scenario"
+            )
+
+        namespace = rng.choice(namespaces)
+
+        # Target a specific namespace by name. NAMESPACE and LABEL_SELECTOR are
+        # mutually exclusive in krkn, so label_selector is left empty. With a
+        # single named namespace exactly one namespace matches, so delete_count
+        # stays at 1; runs varies to give the genetic algorithm room to explore
+        # repeated disruptions.
+        self.namespace.value = namespace.name
+        self.label_selector.value = ""
+        self.delete_count.value = 1
+        self.runs.value = rng.randint(1, 3)

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -116,6 +116,11 @@ health_checks:
 #     url: "$HOST/ratings/api/fetch/Watson"
 {% endif %}
 
+# Cluster-critical scenarios (e.g. service-disruption, which deletes whole
+# namespaces) are skipped unless this is set to true, even when their own
+# `enable` flag is on. Leave it false unless you really intend to run them.
+allow_dangerous_scenarios: false
+
 scenario:
 {%- for name, enabled in scenario_enables.items() %}
   {{ name | replace("_", "-") }}:

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -451,10 +451,18 @@ class TestStorageThrottleScenario:
 class TestServiceDisruptionScenario:
     """Test ServiceDisruptionScenario class (#13)."""
 
+    @staticmethod
+    def _namespace_with_service(name="robot-shop"):
+        return Namespace(
+            name=name,
+            services=[Service(name="rs", ports=[ServicePort(port=80)])],
+        )
+
     def test_service_disruption_initialization_with_namespaces(self):
         """Initializes against a discovered namespace with valid krkn parameters."""
-        namespace = Namespace(name="robot-shop")
-        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+        cluster = ClusterComponents(
+            namespaces=[self._namespace_with_service()], nodes=[]
+        )
 
         scenario = ServiceDisruptionScenario(cluster_components=cluster)
 
@@ -467,10 +475,11 @@ class TestServiceDisruptionScenario:
         assert scenario.delete_count.value == 1
         assert 1 <= scenario.runs.value <= 3
 
-    def test_service_disruption_parameter_names_map_to_krkn(self):
-        """Parameters expose the exact krknctl flags and krkn-hub env vars."""
-        namespace = Namespace(name="robot-shop")
-        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+    def test_service_disruption_omits_empty_label_selector(self):
+        """An empty label_selector is not emitted alongside NAMESPACE (#13 review)."""
+        cluster = ClusterComponents(
+            namespaces=[self._namespace_with_service()], nodes=[]
+        )
 
         scenario = ServiceDisruptionScenario(cluster_components=cluster)
 
@@ -480,11 +489,44 @@ class TestServiceDisruptionScenario:
         krknhub_vars = [
             p.get_name(return_krknhub_name=True) for p in scenario.parameters
         ]
-        assert krknctl_flags == ["namespace", "label-selector", "delete-count", "runs"]
-        assert krknhub_vars == ["NAMESPACE", "LABEL_SELECTOR", "DELETE_COUNT", "RUNS"]
+        assert krknctl_flags == ["namespace", "delete-count", "runs"]
+        assert krknhub_vars == ["NAMESPACE", "DELETE_COUNT", "RUNS"]
+        assert "label-selector" not in krknctl_flags
 
     def test_service_disruption_raises_error_when_no_namespaces(self):
         """With no namespaces the scenario cannot initialize and raises cleanly."""
         cluster = ClusterComponents(namespaces=[], nodes=[])
-        with pytest.raises(ScenarioParameterInitError, match="No namespaces found"):
+        with pytest.raises(
+            ScenarioParameterInitError, match="No non-system namespaces with services"
+        ):
             ServiceDisruptionScenario(cluster_components=cluster)
+
+    def test_service_disruption_raises_when_namespace_has_no_services(self):
+        """A namespace without services is not a valid target (#13 review)."""
+        cluster = ClusterComponents(namespaces=[Namespace(name="empty-ns")], nodes=[])
+        with pytest.raises(
+            ScenarioParameterInitError, match="No non-system namespaces with services"
+        ):
+            ServiceDisruptionScenario(cluster_components=cluster)
+
+    def test_service_disruption_never_targets_system_namespaces(self):
+        """System namespaces are excluded even when they run services (#13 review)."""
+        system = [
+            Namespace(
+                name=name, services=[Service(name="svc", ports=[ServicePort(port=80)])]
+            )
+            for name in ("kube-system", "default", "openshift-etcd", "kube-public")
+        ]
+        cluster = ClusterComponents(namespaces=system, nodes=[])
+        with pytest.raises(
+            ScenarioParameterInitError, match="No non-system namespaces with services"
+        ):
+            ServiceDisruptionScenario(cluster_components=cluster)
+
+        # A user namespace mixed in is the only eligible target.
+        cluster = ClusterComponents(
+            namespaces=system + [self._namespace_with_service("robot-shop")], nodes=[]
+        )
+        for _ in range(50):
+            scenario = ServiceDisruptionScenario(cluster_components=cluster)
+            assert scenario.namespace.value == "robot-shop"

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -17,6 +17,9 @@ from krkn_ai.models.scenario.scenario_dns_outage import DnsOutageScenario
 from krkn_ai.models.scenario.scenario_syn_flood import SynFloodScenario
 from krkn_ai.models.scenario.scenario_pvc import PVCScenario
 from krkn_ai.models.scenario.scenario_storage_throttle import StorageThrottleScenario
+from krkn_ai.models.scenario.scenario_service_disruption import (
+    ServiceDisruptionScenario,
+)
 from krkn_ai.models.cluster_components import (
     ClusterComponents,
     Namespace,
@@ -443,3 +446,45 @@ class TestStorageThrottleScenario:
         assert "write-iops" in param_names
         assert "read-bps" in param_names
         assert "write-bps" in param_names
+
+
+class TestServiceDisruptionScenario:
+    """Test ServiceDisruptionScenario class (#13)."""
+
+    def test_service_disruption_initialization_with_namespaces(self):
+        """Initializes against a discovered namespace with valid krkn parameters."""
+        namespace = Namespace(name="robot-shop")
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = ServiceDisruptionScenario(cluster_components=cluster)
+
+        assert scenario.name == "service-disruption"
+        assert scenario.krknctl_name == "service-disruption-scenarios"
+        assert scenario.namespace.value == "robot-shop"
+        # NAMESPACE and LABEL_SELECTOR are mutually exclusive; target by name.
+        assert scenario.label_selector.value == ""
+        # One named namespace matches, so delete exactly one; runs stays small.
+        assert scenario.delete_count.value == 1
+        assert 1 <= scenario.runs.value <= 3
+
+    def test_service_disruption_parameter_names_map_to_krkn(self):
+        """Parameters expose the exact krknctl flags and krkn-hub env vars."""
+        namespace = Namespace(name="robot-shop")
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        scenario = ServiceDisruptionScenario(cluster_components=cluster)
+
+        krknctl_flags = [
+            p.get_name(return_krknhub_name=False) for p in scenario.parameters
+        ]
+        krknhub_vars = [
+            p.get_name(return_krknhub_name=True) for p in scenario.parameters
+        ]
+        assert krknctl_flags == ["namespace", "label-selector", "delete-count", "runs"]
+        assert krknhub_vars == ["NAMESPACE", "LABEL_SELECTOR", "DELETE_COUNT", "RUNS"]
+
+    def test_service_disruption_raises_error_when_no_namespaces(self):
+        """With no namespaces the scenario cannot initialize and raises cleanly."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        with pytest.raises(ScenarioParameterInitError, match="No namespaces found"):
+            ServiceDisruptionScenario(cluster_components=cluster)

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -497,36 +497,14 @@ class TestServiceDisruptionScenario:
         """With no namespaces the scenario cannot initialize and raises cleanly."""
         cluster = ClusterComponents(namespaces=[], nodes=[])
         with pytest.raises(
-            ScenarioParameterInitError, match="No non-system namespaces with services"
+            ScenarioParameterInitError, match="No namespaces with services"
         ):
             ServiceDisruptionScenario(cluster_components=cluster)
 
     def test_service_disruption_raises_when_namespace_has_no_services(self):
-        """A namespace without services is not a valid target (#13 review)."""
+        """A namespace without services is not a valid target."""
         cluster = ClusterComponents(namespaces=[Namespace(name="empty-ns")], nodes=[])
         with pytest.raises(
-            ScenarioParameterInitError, match="No non-system namespaces with services"
+            ScenarioParameterInitError, match="No namespaces with services"
         ):
             ServiceDisruptionScenario(cluster_components=cluster)
-
-    def test_service_disruption_never_targets_system_namespaces(self):
-        """System namespaces are excluded even when they run services (#13 review)."""
-        system = [
-            Namespace(
-                name=name, services=[Service(name="svc", ports=[ServicePort(port=80)])]
-            )
-            for name in ("kube-system", "default", "openshift-etcd", "kube-public")
-        ]
-        cluster = ClusterComponents(namespaces=system, nodes=[])
-        with pytest.raises(
-            ScenarioParameterInitError, match="No non-system namespaces with services"
-        ):
-            ServiceDisruptionScenario(cluster_components=cluster)
-
-        # A user namespace mixed in is the only eligible target.
-        cluster = ClusterComponents(
-            namespaces=system + [self._namespace_with_service("robot-shop")], nodes=[]
-        )
-        for _ in range(50):
-            scenario = ServiceDisruptionScenario(cluster_components=cluster)
-            assert scenario.namespace.value == "robot-shop"

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -11,6 +11,8 @@ from krkn_ai.models.cluster_components import (
     Namespace,
     Pod,
     Node,
+    Service,
+    ServicePort,
 )
 from krkn_ai.models.custom_errors import MissingScenarioError, ScenarioInitError
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
@@ -74,6 +76,31 @@ class TestScenarioFactory:
         )
         candidates = ScenarioFactory.list_scenarios(config)
         assert len(candidates) == 0
+
+    def test_dangerous_scenario_skipped_without_allow_flag(self):
+        """An enabled dangerous scenario is skipped unless explicitly allowed (#13)."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
+            cluster_components=cluster,
+        )
+        # enable alone is not enough for a dangerous scenario.
+        assert ScenarioFactory.list_scenarios(config) == []
+
+    def test_dangerous_scenario_included_with_allow_flag(self):
+        """allow_dangerous_scenarios lets an enabled dangerous scenario run (#13)."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
+            allow_dangerous_scenarios=True,
+            cluster_components=cluster,
+        )
+        candidates = ScenarioFactory.list_scenarios(config)
+        assert [name for name, _ in candidates] == ["service_disruption"]
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_generate_valid_scenarios_raises_error_when_no_scenarios(
@@ -190,16 +217,22 @@ class TestRecommendEnabledScenarios:
         assert nodes_only["dns_outage"] is False
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
-    def test_high_blast_radius_scenarios_are_not_auto_recommended(self, _mock_init):
+    def test_dangerous_scenarios_are_not_auto_recommended(self, _mock_init):
         """Service disruption stays off in generated configs (#13).
 
-        It initializes fine whenever a namespace exists, so without the explicit
-        opt-out `discover` would enable namespace deletion for nearly every
-        cluster. Users must turn it on deliberately.
+        The recommendation path never sets allow_dangerous_scenarios, so the
+        gate keeps namespace deletion out of generated configs even though the
+        scenario would otherwise be valid for a namespace that runs services.
         """
         result = ScenarioFactory.recommend_enabled_scenarios(
             ClusterComponents(
-                namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
+                namespaces=[
+                    Namespace(
+                        name="shop",
+                        pods=[Pod(name="redis")],
+                        services=[Service(name="rs", ports=[ServicePort(port=80)])],
+                    )
+                ],
                 nodes=[Node(name="n1")],
             ),
             "/tmp/kubeconfig",

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -190,6 +190,25 @@ class TestRecommendEnabledScenarios:
         assert nodes_only["dns_outage"] is False
 
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_high_blast_radius_scenarios_are_not_auto_recommended(self, _mock_init):
+        """Service disruption stays off in generated configs (#13).
+
+        It initializes fine whenever a namespace exists, so without the explicit
+        opt-out `discover` would enable namespace deletion for nearly every
+        cluster. Users must turn it on deliberately.
+        """
+        result = ScenarioFactory.recommend_enabled_scenarios(
+            ClusterComponents(
+                namespaces=[Namespace(name="shop", pods=[Pod(name="redis")])],
+                nodes=[Node(name="n1")],
+            ),
+            "/tmp/kubeconfig",
+        )
+        assert result["service_disruption"] is False
+        # Other recoverable scenarios are still recommended normally.
+        assert result["dns_outage"] is True
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_all_disabled_for_empty_cluster(self, _mock_init):
         """Empty cluster disables all scenarios."""
         result = ScenarioFactory.recommend_enabled_scenarios(

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -102,6 +102,36 @@ class TestScenarioFactory:
         candidates = ScenarioFactory.list_scenarios(config)
         assert [name for name, _ in candidates] == ["service_disruption"]
 
+    def test_dangerous_skip_warning_uses_user_facing_key(self):
+        """The skip warning names the hyphenated config key, not the attr (#13)."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
+            cluster_components=cluster,
+        )
+        with patch("krkn_ai.models.scenario.factory.logger") as mock_logger:
+            ScenarioFactory.list_scenarios(config)
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args.args[-1] == "service-disruption"
+
+    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
+    def test_only_dangerous_enabled_raises_actionable_error(self, _mock_init):
+        """Blocking the only enabled scenario points the user at the opt-in (#13)."""
+        cluster = ClusterComponents(namespaces=[], nodes=[])
+        config = ConfigFile(
+            kubeconfig_file_path="/tmp/kubeconfig",
+            fitness_function=FitnessFunction(query="test"),
+            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
+            cluster_components=cluster,
+        )
+        with pytest.raises(MissingScenarioError) as exc_info:
+            ScenarioFactory.generate_valid_scenarios(config)
+        message = str(exc_info.value)
+        assert "allow_dangerous_scenarios: true" in message
+        assert "service-disruption" in message
+
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_generate_valid_scenarios_raises_error_when_no_scenarios(
         self, mock_initialize_kubeconfig

--- a/tests/unit/models/scenario/test_scenario_factory.py
+++ b/tests/unit/models/scenario/test_scenario_factory.py
@@ -102,36 +102,6 @@ class TestScenarioFactory:
         candidates = ScenarioFactory.list_scenarios(config)
         assert [name for name, _ in candidates] == ["service_disruption"]
 
-    def test_dangerous_skip_warning_uses_user_facing_key(self):
-        """The skip warning names the hyphenated config key, not the attr (#13)."""
-        cluster = ClusterComponents(namespaces=[], nodes=[])
-        config = ConfigFile(
-            kubeconfig_file_path="/tmp/kubeconfig",
-            fitness_function=FitnessFunction(query="test"),
-            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
-            cluster_components=cluster,
-        )
-        with patch("krkn_ai.models.scenario.factory.logger") as mock_logger:
-            ScenarioFactory.list_scenarios(config)
-        mock_logger.warning.assert_called_once()
-        assert mock_logger.warning.call_args.args[-1] == "service-disruption"
-
-    @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
-    def test_only_dangerous_enabled_raises_actionable_error(self, _mock_init):
-        """Blocking the only enabled scenario points the user at the opt-in (#13)."""
-        cluster = ClusterComponents(namespaces=[], nodes=[])
-        config = ConfigFile(
-            kubeconfig_file_path="/tmp/kubeconfig",
-            fitness_function=FitnessFunction(query="test"),
-            scenario=ScenarioConfig(**{"service-disruption": {"enable": True}}),
-            cluster_components=cluster,
-        )
-        with pytest.raises(MissingScenarioError) as exc_info:
-            ScenarioFactory.generate_valid_scenarios(config)
-        message = str(exc_info.value)
-        assert "allow_dangerous_scenarios: true" in message
-        assert "service-disruption" in message
-
     @patch("krkn_ai.models.scenario.factory.initialize_kubeconfig")
     def test_generate_valid_scenarios_raises_error_when_no_scenarios(
         self, mock_initialize_kubeconfig

--- a/tests/unit/templates/test_generator.py
+++ b/tests/unit/templates/test_generator.py
@@ -55,6 +55,12 @@ class TestScenarioRendering:
         assert "enable: True" not in rendered
         yaml.safe_load(rendered)  # does not raise
 
+    def test_dangerous_scenario_opt_in_flag_is_rendered(self):
+        """The generated config surfaces the allow_dangerous_scenarios gate (#13)."""
+        rendered = create_krkn_ai_template(KUBECONFIG, DATA, None)
+        doc = yaml.safe_load(rendered)
+        assert doc["allow_dangerous_scenarios"] is False
+
 
 def _health_checks(rendered: str):
     """Return the health_checks mapping from rendered YAML (None if commented)."""


### PR DESCRIPTION
## Description

Part of #13 (adding more Krkn scenarios into the Chaos AI framework). This PR adds
the **Service Disruption** scenario, which deletes a target namespace and waits for
it to be recreated — exercising an application's ability to recover from losing its
namespace-scoped resources.

### What's included

- **New `ServiceDisruptionScenario`** (`krkn_ai/models/scenario/scenario_service_disruption.py`).
  It selects a namespace from the discovered cluster components and targets it by
  name. `NAMESPACE` and `LABEL_SELECTOR` are mutually exclusive in krkn, so
  `label_selector` is left empty and `delete_count` stays at `1` (exactly one
  namespace matches a specific name). `runs` varies so the genetic algorithm has a
  dimension to explore. When no namespaces are available it raises a graceful
  `ScenarioParameterInitError`, so it is correctly reported as unavailable rather
  than crashing the run.

- **New parameters** in `parameters.py`: `DeleteCountParameter`
  (`delete-count` / `DELETE_COUNT`) and `RunsParameter` (`runs` / `RUNS`).

- **Wiring**: registered in `scenario_specs` (`factory.py`) and added to
  `ScenarioConfig` as `service_disruption` with the `service-disruption` alias
  (`config.py`). Because the config template is driven by `scenario_specs`, the
  scenario is automatically rendered into generated `krkn-ai.yaml` files with no
  template change required.

### Parameter accuracy

The krknctl flags, krkn-hub environment variable names, and the container image tag
were taken from krkn-hub's `service-disruption-scenarios/krknctl-input.json` and the
scenario docs rather than inferred:

| krknctl flag | krkn-hub env var |
|---|---|
| `namespace` | `NAMESPACE` |
| `label-selector` | `LABEL_SELECTOR` |
| `delete-count` | `DELETE_COUNT` |
| `runs` | `RUNS` |

Image: `containers.krkn-chaos.dev/krkn-chaos/krkn-hub:service-disruption-scenarios`

Note that krkn-hub also documents a `SLEEP` variable, but it is not present in
`krknctl-input.json`. It is intentionally omitted so the same parameter list stays
valid for both the krknctl and podman runners.

### Note on blast radius

Service disruption deletes entire namespaces, so unlike the other scenarios it is
not self-recovering: a pod or container kill is reconciled by its controller, while
a deleted namespace only comes back if an operator or GitOps controller recreates
it.

Since the scenario initializes successfully whenever any namespace exists,
`recommend_enabled_scenarios` would otherwise have enabled it for nearly every
cluster, meaning a `discover` → `run` flow could delete namespaces without the user
ever consciously turning it on. It is therefore excluded from automatic
recommendation via a new `NOT_RECOMMENDED_BY_DEFAULT` set, so `discover` leaves it
disabled and users opt in explicitly. The scenario remains fully supported and
configurable.

Happy to change this default if maintainers would prefer it recommended alongside
the other scenarios.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

Added unit tests covering:

- Initialization against a discovered namespace, asserting the scenario name,
  krknctl name, and that `label_selector` is empty and `delete_count` is `1`.
- The exact krknctl flag and krkn-hub environment variable names exposed by the
  parameter list, so a future rename cannot silently break the krkn integration.
- The empty-cluster path, asserting `ScenarioParameterInitError` is raised.
- That `service_disruption` is **not** auto-recommended while other recoverable
  scenarios (e.g. `dns_outage`) still are.

Also smoke-tested the generated commands for both runners:

```bash
krknctl run service-disruption-scenarios ... --namespace "robot-shop" \
  --label-selector "" --delete-count "1" --runs "2"

podman run ... -e NAMESPACE="robot-shop" -e LABEL_SELECTOR="" \
  -e DELETE_COUNT="1" -e RUNS="2" ... :service-disruption-scenarios
```

Full unit suite passes locally and `pre-commit` (ruff, ruff-format, mypy) is clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
