### PR TITLE
fix(core): prevent dangling pointers in nested CompositeScenarios

### DIFF
--- a/krkn_ai/chaos_engines/composite.py
+++ b/krkn_ai/chaos_engines/composite.py
@@ -85,7 +85,7 @@ def _expand_composite_json(
         if scenario.dependency == CompositeDependency.A_ON_B:
             key = depends_on
         elif scenario.dependency == CompositeDependency.B_ON_A:
-            key = key_b
+            key = key_a
         elif scenario.dependency == CompositeDependency.NONE:
             key = key_root
 

--- a/tests/unit/chaos_engines/test_composite.py
+++ b/tests/unit/chaos_engines/test_composite.py
@@ -1,0 +1,51 @@
+from krkn_ai.models.scenario.base import Scenario, CompositeScenario, CompositeDependency
+from krkn_ai.chaos_engines.composite import _expand_composite_json
+
+class MockScenario(Scenario):
+    name: str = "mock"
+    krknctl_name: str = "mock-scenario"
+    krknhub_image: str = "mock-image"
+    
+    @property
+    def parameters(self):
+        return []
+
+def test_expand_composite_json_b_on_a_nested_composite():
+    """Test that B_ON_A with a nested CompositeScenario correctly assigns key_a as the dependency. (#411)"""
+    s1 = MockScenario(cluster_components=None)
+    s2 = MockScenario(cluster_components=None)
+    s3 = MockScenario(cluster_components=None)
+    
+    nested = CompositeScenario(
+        scenario_a=s2,
+        scenario_b=s3,
+        dependency=CompositeDependency.NONE,
+        cluster_components=None
+    )
+    
+    parent = CompositeScenario(
+        scenario_a=s1,
+        scenario_b=nested,
+        dependency=CompositeDependency.B_ON_A,
+        cluster_components=None
+    )
+    
+    result = _expand_composite_json(parent, root="$")
+    
+    # Expected keys:
+    # parent key_a -> "$l"
+    # parent key_b -> "$r"
+    # nested key_a -> "$rl"
+    # nested key_b -> "$rr"
+    
+    assert "$l" in result
+    assert "$rl" in result
+    assert "$rr" in result
+    
+    # Since dependency is B_ON_A, scenario_b (nested) gets passed depends_on="$l".
+    # Because nested has NONE dependency between its children, it injects a dummy root "$r".
+    # The dummy root "$r" should depend on "$l".
+    # Both nested children "$rl" and "$rr" should depend on the dummy root "$r".
+    assert result["$r"].get("depends_on") == "$l"
+    assert result["$rl"].get("depends_on") == "$r"
+    assert result["$rr"].get("depends_on") == "$r"


### PR DESCRIPTION
## Description
Fixes #411.

Resolves a critical bug in `_expand_composite_json` where nested `CompositeScenario` execution graphs failed to compile. When a parent composite scenario specified a `B_ON_A` dependency and `scenario_b` was itself a composite, the compiler mistakenly assigned `key_b` as the dependency target instead of `key_a`. This caused the nested graph's children to point to a non-existent parent node, generating invalid `krknctl` JSON graphs with dangling pointers.

**Changes:**
- Corrected the `CompositeScenario` `B_ON_A` dependency assignment in `_expand_composite_json` to correctly use `key_a`.
- Added unit tests in `tests/unit/chaos_engines/test_composite.py` to assert the correctness of generated DAG topologies (including dummy node injection for `CompositeDependency.NONE`).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- **Local Unit Testing**: Executed `pytest tests/unit/chaos_engines/test_composite.py` confirming the new `test_expand_composite_json_b_on_a_nested_composite` passes cleanly.
- Full `pytest` suite passes locally without regressions.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
