### PR TITLE
fix: require a PVC for PVC and storage-throttle scenarios (#384)

### DIFF
--- a/krkn_ai/models/scenario/base.py
+++ b/krkn_ai/models/scenario/base.py
@@ -1,7 +1,9 @@
 from enum import Enum
 from pydantic import BaseModel, PrivateAttr
-from krkn_ai.models.cluster_components import ClusterComponents
-from typing import Any
+from krkn_ai.models.cluster_components import ClusterComponents, Namespace, PVC
+from krkn_ai.models.custom_errors import ScenarioParameterInitError
+from krkn_ai.utils.rng import rng
+from typing import Any, List, Tuple
 
 
 class BaseParameter(BaseModel):
@@ -36,6 +38,33 @@ class Scenario(BaseScenario):
 
     def scenario_wait_duration(self, config_wait_duration: int) -> int:
         return config_wait_duration
+
+    def _select_namespace_pvc(self, scenario_name: str) -> Tuple[Namespace, PVC]:
+        """Pick a random (namespace, PVC) pair from the discovered components.
+
+        PVC-based scenarios always target a PersistentVolumeClaim. krkn's pod-name
+        mode still requires the pod to have a PVC mounted, and discovery does not
+        track pod->PVC mounts, so a namespace with pods but no PVCs is not a valid
+        target -- we do not fall back to an arbitrary pod (which would trigger the
+        scenario and then fail at runtime). Raises ScenarioParameterInitError when
+        no namespaces or no PVCs are available. (#384)
+        """
+        if len(self._cluster_components.namespaces) == 0:
+            raise ScenarioParameterInitError(
+                "No namespaces found in cluster components"
+            )
+
+        namespace_pvc_pairs: List[Tuple[Namespace, PVC]] = [
+            (namespace, pvc)
+            for namespace in self._cluster_components.namespaces
+            for pvc in namespace.pvcs
+        ]
+        if not namespace_pvc_pairs:
+            raise ScenarioParameterInitError(
+                f"No PVCs found in cluster components for {scenario_name} scenario"
+            )
+
+        return rng.choice(namespace_pvc_pairs)
 
     def __str__(self):
         param_value = ", ".join([str(x.value) for x in self.parameters])

--- a/krkn_ai/models/scenario/scenario_pvc.py
+++ b/krkn_ai/models/scenario/scenario_pvc.py
@@ -9,7 +9,7 @@ from krkn_ai.models.scenario.parameters import (
     PVCNameParameter,
     StandardDurationParameter,
 )
-from krkn_ai.models.cluster_components import Namespace, Pod, PVC
+from krkn_ai.models.cluster_components import Namespace, PVC
 from krkn_ai.cluster import get_pvc_usage_percentage
 from krkn_ai.utils.logger import get_logger
 
@@ -51,51 +51,39 @@ class PVCScenario(Scenario):
                 "No namespaces found in cluster components"
             )
 
-        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = []  # (namespace, pvc)
-        namespace_pod_tuple: List[Tuple[Namespace, Pod]] = []  # (namespace, pod)
+        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = [
+            (namespace, pvc)
+            for namespace in self._cluster_components.namespaces
+            for pvc in namespace.pvcs
+        ]
 
-        for namespace in self._cluster_components.namespaces:
-            if namespace.pvcs:
-                namespace_pvc_tuple.extend((namespace, pvc) for pvc in namespace.pvcs)
-            if namespace.pods:
-                namespace_pod_tuple.extend((namespace, pod) for pod in namespace.pods)
-
-        # Check availability before mutation - skip test if no PVCs or pods found
-        if not namespace_pvc_tuple and not namespace_pod_tuple:
+        # The PVC scenario always targets a PersistentVolumeClaim. krkn's
+        # pod-name mode still requires the pod to have a PVC mounted, and
+        # discovery does not track pod->PVC mounts, so a namespace with pods but
+        # no PVCs is not a valid target -- do not fall back to an arbitrary pod
+        # (which would trigger the scenario and then fail at runtime). (#384)
+        if not namespace_pvc_tuple:
             raise ScenarioParameterInitError(
-                "No PVCs or pods found in cluster components for PVC scenario"
+                "No PVCs found in cluster components for PVC scenario"
             )
 
-        # Prefer PVCs
-        selected_pvc_name = None
-        selected_namespace = None
-        if namespace_pvc_tuple:
-            namespace, pvc = rng.choice(namespace_pvc_tuple)
-            self.namespace.value = namespace.name
-            self.pvc_name.value = pvc.name
-            self.pod_name.value = ""  # Leave empty when using pvc-name
-            selected_pvc_name = pvc.name
-            selected_namespace = namespace.name
-        else:
-            namespace, pod = rng.choice(namespace_pod_tuple)
-            self.namespace.value = namespace.name
-            self.pod_name.set_pod(namespace.name, pod)
-            self.pvc_name.value = ""  # Leave empty when using pod-name
-            selected_pvc_name = None
+        namespace, pvc = rng.choice(namespace_pvc_tuple)
+        self.namespace.value = namespace.name
+        self.pvc_name.value = pvc.name
+        self.pod_name.value = ""  # Leave empty when using pvc-name
 
         min_usage = None
-        if selected_pvc_name:
-            try:
-                current_usage = get_pvc_usage_percentage(
-                    pvc_name=selected_pvc_name, namespace=selected_namespace
-                )
-                if current_usage is not None:
-                    min_usage = current_usage
-            except Exception as e:
-                logger.debug(
-                    "Failed to get real-time PVC usage for %s: %s",
-                    selected_pvc_name,
-                    str(e),
-                )
+        try:
+            current_usage = get_pvc_usage_percentage(
+                pvc_name=pvc.name, namespace=namespace.name
+            )
+            if current_usage is not None:
+                min_usage = current_usage
+        except Exception as e:
+            logger.debug(
+                "Failed to get real-time PVC usage for %s: %s",
+                pvc.name,
+                str(e),
+            )
 
         self.fill_percentage.mutate(min_value=min_usage)

--- a/krkn_ai/models/scenario/scenario_pvc.py
+++ b/krkn_ai/models/scenario/scenario_pvc.py
@@ -1,6 +1,3 @@
-from typing import List, Tuple
-from krkn_ai.models.custom_errors import ScenarioParameterInitError
-from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
 from krkn_ai.models.scenario.parameters import (
     FillPercentageParameter,
@@ -9,7 +6,6 @@ from krkn_ai.models.scenario.parameters import (
     PVCNameParameter,
     StandardDurationParameter,
 )
-from krkn_ai.models.cluster_components import Namespace, PVC
 from krkn_ai.cluster import get_pvc_usage_percentage
 from krkn_ai.utils.logger import get_logger
 
@@ -46,28 +42,7 @@ class PVCScenario(Scenario):
         return params
 
     def mutate(self):
-        if len(self._cluster_components.namespaces) == 0:
-            raise ScenarioParameterInitError(
-                "No namespaces found in cluster components"
-            )
-
-        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = [
-            (namespace, pvc)
-            for namespace in self._cluster_components.namespaces
-            for pvc in namespace.pvcs
-        ]
-
-        # The PVC scenario always targets a PersistentVolumeClaim. krkn's
-        # pod-name mode still requires the pod to have a PVC mounted, and
-        # discovery does not track pod->PVC mounts, so a namespace with pods but
-        # no PVCs is not a valid target -- do not fall back to an arbitrary pod
-        # (which would trigger the scenario and then fail at runtime). (#384)
-        if not namespace_pvc_tuple:
-            raise ScenarioParameterInitError(
-                "No PVCs found in cluster components for PVC scenario"
-            )
-
-        namespace, pvc = rng.choice(namespace_pvc_tuple)
+        namespace, pvc = self._select_namespace_pvc("PVC")
         self.namespace.value = namespace.name
         self.pvc_name.value = pvc.name
         self.pod_name.value = ""  # Leave empty when using pvc-name

--- a/krkn_ai/models/scenario/scenario_storage_throttle.py
+++ b/krkn_ai/models/scenario/scenario_storage_throttle.py
@@ -15,7 +15,7 @@ from krkn_ai.models.scenario.parameters import (
     WriteBPSParameter,
     WriteIOPSParameter,
 )
-from krkn_ai.models.cluster_components import Namespace, Pod, PVC
+from krkn_ai.models.cluster_components import Namespace, PVC
 from krkn_ai.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -71,30 +71,26 @@ class StorageThrottleScenario(Scenario):
                 "No namespaces found in cluster components"
             )
 
-        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = []
-        namespace_pod_tuple: List[Tuple[Namespace, Pod]] = []
+        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = [
+            (namespace, pvc)
+            for namespace in self._cluster_components.namespaces
+            for pvc in namespace.pvcs
+        ]
 
-        for namespace in self._cluster_components.namespaces:
-            if namespace.pvcs:
-                namespace_pvc_tuple.extend((namespace, pvc) for pvc in namespace.pvcs)
-            if namespace.pods:
-                namespace_pod_tuple.extend((namespace, pod) for pod in namespace.pods)
-
-        if not namespace_pvc_tuple and not namespace_pod_tuple:
+        # Storage throttling always targets a PersistentVolumeClaim. krkn's
+        # pod-name mode still requires the pod to have a PVC mounted, and
+        # discovery does not track pod->PVC mounts, so a namespace with pods but
+        # no PVCs is not a valid target -- do not fall back to an arbitrary pod
+        # (which would trigger the scenario and then fail at runtime). (#384)
+        if not namespace_pvc_tuple:
             raise ScenarioParameterInitError(
-                "No PVCs or pods found in cluster components for storage-throttle scenario"
+                "No PVCs found in cluster components for storage-throttle scenario"
             )
 
-        if namespace_pvc_tuple:
-            namespace, pvc = rng.choice(namespace_pvc_tuple)
-            self.namespace.value = namespace.name
-            self.pvc_name.value = pvc.name
-            self.pod_name.value = ""
-        else:
-            namespace, pod = rng.choice(namespace_pod_tuple)
-            self.namespace.value = namespace.name
-            self.pod_name.set_pod(namespace.name, pod)
-            self.pvc_name.value = ""
+        namespace, pvc = rng.choice(namespace_pvc_tuple)
+        self.namespace.value = namespace.name
+        self.pvc_name.value = pvc.name
+        self.pod_name.value = ""
 
         self.throttle_type.mutate()
         self.read_iops.mutate()

--- a/krkn_ai/models/scenario/scenario_storage_throttle.py
+++ b/krkn_ai/models/scenario/scenario_storage_throttle.py
@@ -1,6 +1,3 @@
-from typing import List, Tuple
-from krkn_ai.models.custom_errors import ScenarioParameterInitError
-from krkn_ai.utils.rng import rng
 from krkn_ai.models.scenario.base import Scenario
 from krkn_ai.models.scenario.parameters import (
     MountPathParameter,
@@ -15,10 +12,6 @@ from krkn_ai.models.scenario.parameters import (
     WriteBPSParameter,
     WriteIOPSParameter,
 )
-from krkn_ai.models.cluster_components import Namespace, PVC
-from krkn_ai.utils.logger import get_logger
-
-logger = get_logger(__name__)
 
 
 class StorageThrottleScenario(Scenario):
@@ -66,28 +59,7 @@ class StorageThrottleScenario(Scenario):
         return params
 
     def mutate(self):
-        if len(self._cluster_components.namespaces) == 0:
-            raise ScenarioParameterInitError(
-                "No namespaces found in cluster components"
-            )
-
-        namespace_pvc_tuple: List[Tuple[Namespace, PVC]] = [
-            (namespace, pvc)
-            for namespace in self._cluster_components.namespaces
-            for pvc in namespace.pvcs
-        ]
-
-        # Storage throttling always targets a PersistentVolumeClaim. krkn's
-        # pod-name mode still requires the pod to have a PVC mounted, and
-        # discovery does not track pod->PVC mounts, so a namespace with pods but
-        # no PVCs is not a valid target -- do not fall back to an arbitrary pod
-        # (which would trigger the scenario and then fail at runtime). (#384)
-        if not namespace_pvc_tuple:
-            raise ScenarioParameterInitError(
-                "No PVCs found in cluster components for storage-throttle scenario"
-            )
-
-        namespace, pvc = rng.choice(namespace_pvc_tuple)
+        namespace, pvc = self._select_namespace_pvc("storage-throttle")
         self.namespace.value = namespace.name
         self.pvc_name.value = pvc.name
         self.pod_name.value = ""

--- a/tests/unit/models/scenario/test_scenario_classes.py
+++ b/tests/unit/models/scenario/test_scenario_classes.py
@@ -354,6 +354,19 @@ class TestPVCScenario:
         with pytest.raises(ScenarioParameterInitError, match="No namespaces found"):
             PVCScenario(cluster_components=cluster)
 
+    def test_pvc_scenario_raises_when_pods_but_no_pvcs(self):
+        """PVCScenario requires a PVC and does not fall back to a pod (#384)."""
+        pod = Pod(
+            name="test-pod", labels={"app": "web"}, containers=[Container(name="c1")]
+        )
+        namespace = Namespace(name="test-ns", pods=[pod])
+        cluster = ClusterComponents(namespaces=[namespace], nodes=[])
+
+        with pytest.raises(
+            ScenarioParameterInitError, match="No PVCs found in cluster components"
+        ):
+            PVCScenario(cluster_components=cluster)
+
 
 class TestStorageThrottleScenario:
     """Test StorageThrottleScenario class"""
@@ -371,8 +384,8 @@ class TestStorageThrottleScenario:
         assert scenario.pod_name.value == ""
         assert scenario.throttle_type.value in ["iops", "bandwidth", "both"]
 
-    def test_storage_throttle_scenario_initialization_with_pods_only(self):
-        """Test that StorageThrottleScenario falls back to pods when no PVCs exist"""
+    def test_storage_throttle_scenario_raises_when_pods_but_no_pvcs(self):
+        """StorageThrottleScenario requires a PVC, not just a pod (#384)."""
         pod = Pod(
             name="test-pod",
             labels={"app": "web"},
@@ -381,11 +394,10 @@ class TestStorageThrottleScenario:
         namespace = Namespace(name="test-ns", pods=[pod])
         cluster = ClusterComponents(namespaces=[namespace], nodes=[])
 
-        scenario = StorageThrottleScenario(cluster_components=cluster)
-        assert scenario.name == "storage-throttle"
-        assert scenario.namespace.value == "test-ns"
-        assert scenario.pod_name.value == "test-pod"
-        assert scenario.pvc_name.value == ""
+        with pytest.raises(
+            ScenarioParameterInitError, match="No PVCs found in cluster components"
+        ):
+            StorageThrottleScenario(cluster_components=cluster)
 
     def test_storage_throttle_scenario_raises_error_when_no_pvcs_or_pods(self):
         """Test that StorageThrottleScenario raises error when no PVCs or pods exist"""
@@ -395,11 +407,11 @@ class TestStorageThrottleScenario:
             StorageThrottleScenario(cluster_components=cluster)
 
     def test_storage_throttle_scenario_raises_error_empty_namespace(self):
-        """Test that StorageThrottleScenario raises error when namespace has no PVCs or pods"""
+        """Test that StorageThrottleScenario raises error when namespace has no PVCs"""
         namespace = Namespace(name="test-ns")
         cluster = ClusterComponents(namespaces=[namespace], nodes=[])
 
-        with pytest.raises(ScenarioParameterInitError, match="No PVCs or pods found"):
+        with pytest.raises(ScenarioParameterInitError, match="No PVCs found"):
             StorageThrottleScenario(cluster_components=cluster)
 
     def test_storage_throttle_scenario_conditional_parameters_iops(self):


### PR DESCRIPTION
## Description
Fixes #384. `PVCScenario` and `StorageThrottleScenario` collected both PVCs and
pods, raised only when *both* were empty, and otherwise fell back to targeting an
arbitrary pod when no PVCs existed. But krkn's pod-name mode still requires the
pod to have a PVC **mounted**, and discovery does not track pod→PVC mounts — so on
a namespace with pods but no PVCs, both scenarios were recommended and triggered,
then failed at runtime (the behaviour reported in the issue).

Both scenarios now require a discovered PVC and raise `ScenarioParameterInitError`
when none is available, so they are correctly reported as unavailable and left out
of generated configs for pods-only namespaces.

The `pod_name` parameter is kept in the models, since krkn genuinely supports
pod-name mode when the pod has a PVC. Re-enabling it via discovery would require
capturing pod→PVC mounts during cluster discovery — noted as a possible follow-up.

## Type of Change
- [x] Bug fix

## Testing
- New tests assert both scenarios raise on a pods-only (no-PVC) namespace.
- Verified via `recommend_enabled_scenarios`: a pods-only cluster no longer
  recommends `pvc_scenarios`/`storage_throttle`; a cluster with a PVC still does.
- Full unit suite green; `pre-commit` (ruff, ruff-format, mypy) green.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
