### PR TITLE
fix(core): resolve dangling pointer in nested CompositeScenarios

### DIFF
--- a/krkn_ai/chaos_engines/composite.py
+++ b/krkn_ai/chaos_engines/composite.py
@@ -21,7 +21,7 @@ def build_graph_command(
     graph_json_directory = os.path.join(output_dir, "graphs")
     os.makedirs(graph_json_directory, exist_ok=True)
 
-    scenario_json = _expand_composite_json(scenario)
+    scenario_json, _ = _expand_composite_json(scenario)
     with tempfile.NamedTemporaryFile(
         suffix=".json",
         dir=graph_json_directory,
@@ -42,7 +42,7 @@ def build_graph_command(
 
 def _expand_composite_json(
     scenario: CompositeScenario, root: str = "$", depends_on: str = None
-):
+) -> tuple[dict, str]:
     result = {}
     scenario_a = scenario.scenario_a
     scenario_b = scenario.scenario_b
@@ -50,60 +50,77 @@ def _expand_composite_json(
     key_root = root
     key_a = root + "l"
     key_b = root + "r"
+    
+    terminal_key = None
 
     if scenario.dependency == CompositeDependency.NONE:
         result[key_root] = _generate_scenario_json(
             ScenarioFactory.create_dummy_scenario(), depends_on=depends_on
         )
+        terminal_key = key_root
 
-    if isinstance(scenario_a, CompositeScenario):
-        key = None
-        if scenario.dependency == CompositeDependency.A_ON_B:
-            key = key_b
-        elif scenario.dependency == CompositeDependency.B_ON_A:
-            key = depends_on
-        elif scenario.dependency == CompositeDependency.NONE:
-            key = key_root
+        if isinstance(scenario_a, CompositeScenario):
+            nodes_a, _ = _expand_composite_json(scenario_a, key_a, depends_on=key_root)
+            result.update(nodes_a)
+        elif isinstance(scenario_a, Scenario):
+            result[key_a] = _generate_scenario_json(scenario_a, depends_on=key_root)
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_a)}")
 
-        result.update(_expand_composite_json(scenario_a, key_a, depends_on=key))
-    elif isinstance(scenario_a, Scenario):
-        key = None
-        if scenario.dependency == CompositeDependency.A_ON_B:
-            key = key_b
-        elif scenario.dependency == CompositeDependency.B_ON_A:
-            key = depends_on
-        elif scenario.dependency == CompositeDependency.NONE:
-            key = key_root
+        if isinstance(scenario_b, CompositeScenario):
+            nodes_b, _ = _expand_composite_json(scenario_b, key_b, depends_on=key_root)
+            result.update(nodes_b)
+        elif isinstance(scenario_b, Scenario):
+            result[key_b] = _generate_scenario_json(scenario_b, depends_on=key_root)
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_b)}")
 
-        result[key_a] = _generate_scenario_json(
-            scenario_a,
-            depends_on=key,
-        )
+    elif scenario.dependency == CompositeDependency.A_ON_B:
+        if isinstance(scenario_b, CompositeScenario):
+            nodes_b, term_b = _expand_composite_json(scenario_b, key_b, depends_on=depends_on)
+            result.update(nodes_b)
+        elif isinstance(scenario_b, Scenario):
+            result[key_b] = _generate_scenario_json(scenario_b, depends_on=depends_on)
+            term_b = key_b
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_b)}")
+        
+        if isinstance(scenario_a, CompositeScenario):
+            nodes_a, term_a = _expand_composite_json(scenario_a, key_a, depends_on=term_b)
+            result.update(nodes_a)
+        elif isinstance(scenario_a, Scenario):
+            result[key_a] = _generate_scenario_json(scenario_a, depends_on=term_b)
+            term_a = key_a
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_a)}")
+            
+        terminal_key = term_a
 
-    if isinstance(scenario_b, CompositeScenario):
-        key = None
-        if scenario.dependency == CompositeDependency.A_ON_B:
-            key = depends_on
-        elif scenario.dependency == CompositeDependency.B_ON_A:
-            key = key_b
-        elif scenario.dependency == CompositeDependency.NONE:
-            key = key_root
+    elif scenario.dependency == CompositeDependency.B_ON_A:
+        if isinstance(scenario_a, CompositeScenario):
+            nodes_a, term_a = _expand_composite_json(scenario_a, key_a, depends_on=depends_on)
+            result.update(nodes_a)
+        elif isinstance(scenario_a, Scenario):
+            result[key_a] = _generate_scenario_json(scenario_a, depends_on=depends_on)
+            term_a = key_a
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_a)}")
+            
+        if isinstance(scenario_b, CompositeScenario):
+            nodes_b, term_b = _expand_composite_json(scenario_b, key_b, depends_on=term_a)
+            result.update(nodes_b)
+        elif isinstance(scenario_b, Scenario):
+            result[key_b] = _generate_scenario_json(scenario_b, depends_on=term_a)
+            term_b = key_b
+        else:
+            raise TypeError(f"Unsupported scenario type: {type(scenario_b)}")
+            
+        terminal_key = term_b
+    else:
+        raise ValueError(f"Unsupported dependency type: {scenario.dependency}")
 
-        result.update(_expand_composite_json(scenario_b, key_b, depends_on=key))
-    elif isinstance(scenario_b, Scenario):
-        key = None
-        if scenario.dependency == CompositeDependency.A_ON_B:
-            key = depends_on
-        elif scenario.dependency == CompositeDependency.B_ON_A:
-            key = key_a
-        elif scenario.dependency == CompositeDependency.NONE:
-            key = key_root
-        result[key_b] = _generate_scenario_json(
-            scenario_b,
-            depends_on=key,
-        )
-
-    return result
+    assert terminal_key is not None, "terminal_key must be resolved"
+    return result, terminal_key
 
 
 def _generate_scenario_json(scenario: Scenario, depends_on: str = None):

--- a/tests/unit/chaos_engines/test_composite.py
+++ b/tests/unit/chaos_engines/test_composite.py
@@ -1,0 +1,82 @@
+from krkn_ai.models.scenario.base import CompositeDependency, CompositeScenario
+from krkn_ai.models.scenario.factory import ScenarioFactory
+from krkn_ai.chaos_engines.composite import _expand_composite_json
+
+
+def test_expand_composite_json_b_on_a_nested():
+    """
+    Test that when a nested CompositeScenario is placed in scenario_b
+    with a B_ON_A dependency, the nested root properly depends on key_a
+    rather than causing a dangling pointer to itself (key_b).
+    Resolves Issue #411.
+    """
+    # Create the nested composite for scenario_b
+    nested_b = CompositeScenario(
+        scenario_a=ScenarioFactory.create_dummy_scenario(),
+        scenario_b=ScenarioFactory.create_dummy_scenario(),
+        dependency=CompositeDependency.A_ON_B,
+    )
+
+    # Create the parent composite with B_ON_A dependency
+    parent = CompositeScenario(
+        scenario_a=ScenarioFactory.create_dummy_scenario(),
+        scenario_b=nested_b,
+        dependency=CompositeDependency.B_ON_A,
+    )
+
+    # Expand the JSON graph
+    # Root key is "$"
+    # key_a is "$l", key_b is "$r"
+    result, _ = _expand_composite_json(parent, root="$")
+
+    # In the result, we should see nodes for the nested B composite.
+    # Because B depends on A, the nested B components should depend on key_a ("$l").
+
+    # nested_b is "$r". Its A component is "$rl", its B component is "$rr".
+    # nested_b has A_ON_B dependency.
+    # So "$rl" should depend on "$rr".
+    # And "$rr" (the root of the nested_b subtree) should depend on the parent's depends_on.
+    # Since parent is B_ON_A, nested_b's depends_on is "$l" (key_a).
+
+    assert "$l" in result
+    assert "$rl" in result
+    assert "$rr" in result
+
+    # "$rl" (A of nested) depends on "$rr" (B of nested) because nested_b is A_ON_B
+    assert result["$rl"]["depends_on"] == "$rr"
+    assert result["$rr"]["depends_on"] == "$l"
+
+
+def test_expand_composite_json_b_on_a_with_composite_a():
+    """
+    Test the edge case requested by AI reviewer:
+    Parent has B_ON_A dependency, but scenario_a is a CompositeScenario
+    with A_ON_B dependency. Ensure B depends on the *actual* terminal node
+    of A (which is A's A component, i.e., "$ll"), and not the missing "$l".
+    """
+    nested_a = CompositeScenario(
+        scenario_a=ScenarioFactory.create_dummy_scenario(),
+        scenario_b=ScenarioFactory.create_dummy_scenario(),
+        dependency=CompositeDependency.A_ON_B,
+    )
+
+    parent = CompositeScenario(
+        scenario_a=nested_a,
+        scenario_b=ScenarioFactory.create_dummy_scenario(),
+        dependency=CompositeDependency.B_ON_A,
+    )
+
+    result, _ = _expand_composite_json(parent, root="$")
+
+    # Assert every depends_on value exists in the graph (no dangling pointers)
+    for key, node in result.items():
+        if "depends_on" in node:
+            assert node["depends_on"] in result, (
+                f"Dangling pointer found: {node['depends_on']}"
+            )
+
+    # nested_a is A_ON_B, so "$ll" depends on "$lr"
+    assert result["$ll"]["depends_on"] == "$lr"
+
+    # parent is B_ON_A, so B ("$r") should depend on the terminal key of A ("$ll")
+    assert result["$r"]["depends_on"] == "$ll"


### PR DESCRIPTION
## Description
Fixes a graph generation bug where nested `CompositeScenario`s under a `B_ON_A` dependency incorrectly bind their root dependency to their own sub-graph root (`key_b`) rather than the parent's target (`key_a`). This caused the execution DAG to reference non-existent dangling pointers, breaking nested composite chaos runs.

Resolves #411 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing
- Added `test_expand_composite_json_b_on_a_nested` in a new `test_composite.py` suite.
- Explicitly verified that the DAG compiler points the nested A and B components back to the parent `key_a` root without dangling self-references.

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
