### PR TITLE
fix(reporter): handle empty health check records in plot_report

### DIFF
--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -106,6 +106,13 @@ class HealthCheckReporter:
                         "success": 1 if health_check_result.success else 0,
                     }
                 )
+        if not records:
+            logger.debug(
+                "No health check records found to plot for scenario_id=%s",
+                result.scenario_id,
+            )
+            return
+
         df = pd.DataFrame(records)
         df = df.sort_values("timestamp")
 

--- a/tests/unit/reporter/test_health_check_reporter.py
+++ b/tests/unit/reporter/test_health_check_reporter.py
@@ -238,6 +238,35 @@ class TestHealthCheckReporter:
             # Should not call savefig for empty results
             mock_plt.savefig.assert_not_called()
 
+    def test_plot_report_with_empty_sample_lists_in_health_check_results(
+        self, temp_output_dir
+    ):
+        """Test that health_check_results with empty sample lists does not cause KeyError."""
+        reporter = HealthCheckReporter(output_dir=temp_output_dir)
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        now = datetime.datetime.now()
+
+        result = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="test-cmd",
+            log="test-log",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=10.0),
+            health_check_results={
+                "http://broken-app/api": [],
+                "http://unreachable/ping": [],
+            },
+        )
+
+        with patch("krkn_ai.reporter.health_check_reporter.plt") as mock_plt:
+            # Should not raise KeyError: 'timestamp'
+            reporter.plot_report(result)
+            mock_plt.savefig.assert_not_called()
+
     def test_write_fitness_result_creates_and_appends_csv(self, temp_output_dir):
         """Test writing fitness result creates CSV and appends subsequent results"""
         reporter = HealthCheckReporter(output_dir=temp_output_dir)


### PR DESCRIPTION
## Description

This PR Fixes #444  by preventing an unhandled `KeyError` in `HealthCheckReporter.plot_report()` when all configured application health check result lists are empty.

Previously, `plot_report()` only checked whether the `health_check_results` dictionary contained any keys. If the dictionary contained application URLs whose corresponding result lists were all empty (for example, due to unreachable endpoints, connection failures, or timeouts), the method proceeded to build an empty DataFrame and attempted to sort it by the `timestamp` column. Since the DataFrame contained no columns, this resulted in an uncaught `KeyError: 'timestamp'`, causing report generation to fail.

**Changes made:**
- Added an early guard in `health_check_reporter.py` to detect when no health check records exist after flattening the application results and return gracefully without attempting DataFrame operations or plot generation.
- Added `test_plot_report_with_empty_sample_lists_in_health_check_results` to the pytest suite to prevent regressions for this edge case.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

- **Local Unit Testing:** Added a new unit test `test_plot_report_with_empty_sample_lists_in_health_check_results` which creates a `CommandRunResult` containing application URLs whose health check result lists are all empty. Verified that `plot_report()` exits gracefully without raising `KeyError` and does not attempt to generate a graph.

- Executed `pytest tests/unit/reporter/test_health_check_reporter.py` ensuring all tests pass successfully.

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors