### PR TITLE
fix: handle '*' wildcard in PatternMatcher list input (#441)

### DIFF
--- a/krkn_ai/cluster/pattern_matcher.py
+++ b/krkn_ai/cluster/pattern_matcher.py
@@ -70,14 +70,22 @@ class PatternMatcher:
         if isinstance(pattern_string, list):
             list_include: List[re.Pattern] = []
             list_exclude: List[re.Pattern] = []
+            list_has_wildcard = False
             for pat in pattern_string:
-                if pat.startswith("!"):
-                    actual = pat[1:]
+                stripped_pat = pat.strip()
+                if stripped_pat == "*":
+                    # '*' means match all (before exclusions), same as the string form
+                    list_has_wildcard = True
+                elif stripped_pat.startswith("!"):
+                    actual = stripped_pat[1:]
                     if actual:
                         list_exclude.append(cls._compile_pattern(actual))
-                else:
-                    list_include.append(cls._compile_pattern(pat))
-            list_match_all = len(list_include) == 0 and len(list_exclude) > 0
+                elif stripped_pat:
+                    list_include.append(cls._compile_pattern(stripped_pat))
+            # Match all when '*' is present, or when only exclusions were given
+            list_match_all = list_has_wildcard or (
+                len(list_include) == 0 and len(list_exclude) > 0
+            )
             return cls(list_include, list_exclude, match_all=list_match_all)
 
         # Handle None or empty string
@@ -222,21 +230,30 @@ class PatternMatcher:
         return not self.match_all and len(self.include_patterns) == 0
 
     @classmethod
-    def validate(cls, pattern_string: str) -> List[str]:
+    def validate(cls, pattern_string: Optional[Union[str, List[str]]]) -> List[str]:
         """
-        Validate a pattern string without creating a matcher.
+        Validate a pattern string (or list of patterns) without creating a matcher.
+
+        Accepts the same inputs as ``from_string`` so list-form patterns can be
+        pre-validated too.
 
         Args:
-            pattern_string: The pattern string to validate
+            pattern_string: The pattern string or list of patterns to validate
 
         Returns:
             List of error messages (empty if valid)
         """
         errors: List[str] = []
-        if not pattern_string or pattern_string.strip() in ("", "*"):
+        if pattern_string is None:
             return errors
 
-        parts = [p.strip() for p in pattern_string.split(",") if p.strip()]
+        if isinstance(pattern_string, list):
+            parts = [p.strip() for p in pattern_string if p.strip()]
+        else:
+            if pattern_string.strip() in ("", "*"):
+                return errors
+            parts = [p.strip() for p in pattern_string.split(",") if p.strip()]
+
         for part in parts:
             if part == "*":
                 continue

--- a/tests/unit/cluster/test_pattern_matcher.py
+++ b/tests/unit/cluster/test_pattern_matcher.py
@@ -73,6 +73,13 @@ class TestPatternMatcherCreation:
         assert matcher.matches("kube-system")
         assert not matcher.matches("test-ns")
 
+    def test_list_input_wildcard_creates_match_all_matcher(self):
+        """Test ['*'] matches everything, like the string form '*'"""
+        matcher = PatternMatcher.from_string(["*"])
+        assert matcher.match_all
+        assert matcher.matches("anything")
+        assert matcher.matches("kube-system")
+
 
 class TestPatternMatcherExclusion:
     """Test PatternMatcher exclusion patterns"""
@@ -129,6 +136,14 @@ class TestPatternMatcherExclusion:
         assert matcher.matches("default")
         assert not matcher.matches("kube-system")
         assert not matcher.matches("other")
+
+    def test_list_input_wildcard_with_exclusion(self):
+        """Test ['*', '!pattern'] matches everything except the excluded one"""
+        matcher = PatternMatcher.from_string(["*", "!kube-system"])
+        assert matcher.match_all
+        assert matcher.matches("default")
+        assert matcher.matches("prod-ns")
+        assert not matcher.matches("kube-system")
 
 
 class TestPatternMatcherFilter:
@@ -199,6 +214,17 @@ class TestPatternMatcherValidation:
         """Test from_string raises PatternValidationError for invalid regex"""
         with pytest.raises(PatternValidationError, match="Invalid regex"):
             PatternMatcher.from_string("[invalid")
+
+    def test_validate_accepts_list_input(self):
+        """Test validate accepts a list of patterns, like from_string"""
+        assert PatternMatcher.validate(["default", "kube-.*"]) == []
+        assert PatternMatcher.validate(["*", "!kube-system"]) == []
+
+    def test_validate_returns_errors_for_invalid_regex_in_list(self):
+        """Test validate reports invalid regex inside a list"""
+        errors = PatternMatcher.validate(["default", "[invalid"])
+        assert len(errors) == 1
+        assert "Invalid regex" in errors[0]
 
 
 class TestPatternMatcherEdgeCases:


### PR DESCRIPTION
## Description

Fixes #441.

`PatternMatcher.from_string()` accepts `Optional[Union[str, List[str]]]`, and list input
is a supported, unit-tested part of the contract. But the list branch never handled the
`*` wildcard: every element was passed straight to `_compile_pattern()`, which anchored
`*` to `^*$` and raised `PatternValidationError: nothing to repeat`. So the string `"*"`
matched everything while the equivalent list `["*"]` crashed — an asymmetry between two
documented forms of the same API.

This PR makes the list branch mirror the string branch:

- `["*"]` -> `match_all=True` (matches everything)
- `["*", "!kube-system"]` -> `match_all=True` with `kube-system` excluded

A `*` element now sets `match_all` and is skipped as an include pattern, exactly as the
comma-separated string form already does. Empty/whitespace-only list items are ignored for
consistency with the string path.

I also extended `PatternMatcher.validate()` to accept `List[str]` (the same
`Union[str, List[str]]` as `from_string`), since it previously only accepted `str` and
list-form patterns couldn't be pre-validated.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

- New unit tests in `tests/unit/cluster/test_pattern_matcher.py`:
  - `["*"]` matches everything;
  - `["*", "!kube-system"]` matches everything except the exclusion;
  - `validate()` accepts a list and reports invalid regex inside a list.
- Verified the original crash no longer reproduces (`from_string(["*"])` now returns a
  match-all matcher instead of raising).
- Full `tests/unit/cluster` suite passes (109 tests); `pre-commit` (ruff, ruff-format,
  mypy) passes on the changed files.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
