### PR TITLE
feat: add validate subcommand for offline config validation (#442)

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -342,3 +342,87 @@ def discover(
         fitness_queries=fitness_queries,
         health_checks=health_checks,
     )
+
+
+@main.command(help="Validate a Krkn-AI config file without running any chaos")
+@click.option("--config", "-c", help="Path to krkn-ai config file.")
+@click.option(
+    "--kubeconfig",
+    "-k",
+    help="Path to cluster kubeconfig file. Overrides the value in the config file.",
+    envvar="KUBECONFIG",
+    default=None,
+)
+@click.option(
+    "--param",
+    "-p",
+    multiple=True,
+    help="Additional parameters for config file in key=value format.",
+)
+@click.option(
+    "--check-connectivity",
+    is_flag=True,
+    help="Also verify the cluster and Prometheus are reachable (requires a cluster).",
+)
+@click.option("-v", "--verbose", count=True, help="Increase verbosity of output.")
+@click.pass_context
+def validate(
+    ctx,
+    config: str,
+    kubeconfig: str = None,
+    param: tuple[str, ...] = (),
+    check_connectivity: bool = False,
+    verbose: int = 0,
+):
+    init_logger(None, verbose >= 2)
+    logger = get_logger(__name__)
+
+    if config == "" or config is None:
+        logger.error("Config file invalid.")
+        sys.exit(1)
+    if not os.path.exists(config):
+        logger.error("Config file not found.")
+        sys.exit(1)
+
+    # Offline validation: parse + Pydantic-validate without touching a cluster.
+    try:
+        parsed_config = read_config_from_file(config, param, kubeconfig)
+    except KeyError as err:
+        logger.error("Invalid config file, missing key: %s", err)
+        sys.exit(1)
+    except (ValueError, ValidationError) as err:
+        logger.error("Invalid config file: %s", err)
+        sys.exit(1)
+
+    logger.info("Config file '%s' is valid.", config)
+
+    if not check_connectivity:
+        return
+
+    resolved_kubeconfig = kubeconfig or parsed_config.kubeconfig_file_path
+    if not resolved_kubeconfig or not os.path.exists(resolved_kubeconfig):
+        logger.error(
+            "--check-connectivity requires a valid kubeconfig "
+            "(via -k or kubeconfig_file_path in the config file)."
+        )
+        sys.exit(1)
+
+    reachable = True
+
+    try:
+        cluster_manager = ClusterManager(resolved_kubeconfig)
+        cluster_manager.core_api.list_namespace(limit=1)
+        logger.info("Cluster is reachable.")
+    except Exception as err:
+        logger.error("Cluster is not reachable: %s", err)
+        reachable = False
+
+    try:
+        create_prometheus_client(resolved_kubeconfig)
+        logger.info("Prometheus is reachable.")
+    except PrometheusConnectionError as err:
+        logger.error("Prometheus is not reachable: %s", err)
+        reachable = False
+
+    if not reachable:
+        sys.exit(1)

--- a/tests/unit/cli/test_cmd.py
+++ b/tests/unit/cli/test_cmd.py
@@ -12,7 +12,10 @@ from click.testing import CliRunner
 from pydantic import ValidationError
 
 from krkn_ai.cli.cmd import main
-from krkn_ai.models.custom_errors import FitnessFunctionCalculationError
+from krkn_ai.models.custom_errors import (
+    FitnessFunctionCalculationError,
+    PrometheusConnectionError,
+)
 from krkn_ai.models.app import KrknRunnerType
 from krkn_ai.models.config import ConfigFile
 
@@ -637,3 +640,121 @@ class TestDiscoverCommand:
             assert result.exit_code != 0
         finally:
             os.unlink(kubeconfig_path)
+
+
+class TestValidateCommand:
+    """Test behavior of the validate command"""
+
+    def _write_config(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("apiVersion: v1\n")
+            return f.name
+
+    def test_validate_valid_config_succeeds_offline(self, minimal_config):
+        """A valid config validates without touching the cluster."""
+        runner = CliRunner()
+        config_path = self._write_config()
+        try:
+            with (
+                patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read,
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_cm,
+                patch("krkn_ai.cli.cmd.create_prometheus_client") as mock_prom,
+            ):
+                mock_read.return_value = minimal_config
+                result = runner.invoke(main, ["validate", "--config", config_path])
+
+                assert result.exit_code == 0, result.exception
+                mock_read.assert_called_once_with(config_path, (), None)
+                # offline by default: no cluster / prometheus contact
+                mock_cm.assert_not_called()
+                mock_prom.assert_not_called()
+        finally:
+            os.unlink(config_path)
+
+    def test_validate_missing_config_fails(self):
+        """Empty or non-existent config paths fail fast."""
+        runner = CliRunner()
+        with patch("krkn_ai.cli.cmd.get_logger") as mock_get_logger:
+            mock_logger = Mock()
+            mock_get_logger.return_value = mock_logger
+
+            result = runner.invoke(main, ["validate", "--config", ""])
+            assert result.exit_code == 1
+            assert "Config file invalid" in str(mock_logger.error.call_args)
+
+            mock_logger.reset_mock()
+            result = runner.invoke(
+                main, ["validate", "--config", "/nonexistent/file.yaml"]
+            )
+            assert result.exit_code == 1
+            assert "Config file not found" in str(mock_logger.error.call_args)
+
+    def test_validate_invalid_config_fails(self, minimal_config):
+        """A schema-invalid config exits non-zero."""
+        runner = CliRunner()
+        config_path = self._write_config()
+        try:
+            with patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read:
+                mock_read.side_effect = ValidationError.from_exception_data(
+                    "ConfigFile", []
+                )
+                result = runner.invoke(main, ["validate", "--config", config_path])
+                assert result.exit_code == 1
+        finally:
+            os.unlink(config_path)
+
+    def test_validate_check_connectivity_success(self, minimal_config):
+        """--check-connectivity passes when cluster and Prometheus are reachable."""
+        runner = CliRunner()
+        config_path = self._write_config()
+        try:
+            with (
+                patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read,
+                patch("krkn_ai.cli.cmd.ClusterManager") as mock_cm,
+                patch("krkn_ai.cli.cmd.create_prometheus_client") as mock_prom,
+            ):
+                mock_read.return_value = minimal_config
+                # config_path exists on disk, so it doubles as a valid kubeconfig path
+                result = runner.invoke(
+                    main,
+                    [
+                        "validate",
+                        "--config",
+                        config_path,
+                        "-k",
+                        config_path,
+                        "--check-connectivity",
+                    ],
+                )
+                assert result.exit_code == 0, result.exception
+                mock_cm.assert_called_once()
+                mock_prom.assert_called_once()
+        finally:
+            os.unlink(config_path)
+
+    def test_validate_check_connectivity_prometheus_failure(self, minimal_config):
+        """--check-connectivity exits non-zero when Prometheus is unreachable."""
+        runner = CliRunner()
+        config_path = self._write_config()
+        try:
+            with (
+                patch("krkn_ai.cli.cmd.read_config_from_file") as mock_read,
+                patch("krkn_ai.cli.cmd.ClusterManager"),
+                patch("krkn_ai.cli.cmd.create_prometheus_client") as mock_prom,
+            ):
+                mock_read.return_value = minimal_config
+                mock_prom.side_effect = PrometheusConnectionError("no prometheus")
+                result = runner.invoke(
+                    main,
+                    [
+                        "validate",
+                        "--config",
+                        config_path,
+                        "-k",
+                        config_path,
+                        "--check-connectivity",
+                    ],
+                )
+                assert result.exit_code == 1
+        finally:
+            os.unlink(config_path)


### PR DESCRIPTION
## Description

Fixes #442.

Adds a `validate` subcommand so a Krkn-AI config can be checked **without executing any
chaos against a live cluster**. Until now the only way to find out whether a config parses
and passes schema validation was to start a full `run`, which requires a reachable cluster
(and Prometheus) and actually injects faults.

```
krkn_ai validate -c config.yaml [-p key=value ...] [-k kubeconfig] [--check-connectivity]
```

Behavior:

1. Loads and Pydantic-validates the config via the existing `read_config_from_file()` (the
   same parsing path `run` uses), applying any `-p` overrides. Prints a clear valid/invalid
   result and exits non-zero on an invalid config, so it is CI-friendly.
2. `--check-connectivity` (opt-in, off by default): also verifies the cluster is reachable
   (`ClusterManager` + a light `list_namespace` call) and that Prometheus can be resolved
   (reusing `create_prometheus_client()`). Without the flag, validation is fully offline and
   needs no cluster.

The command reuses existing helpers only and adds no new dependencies.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Testing

- New `TestValidateCommand` in `tests/unit/cli/test_cmd.py`:
  - valid config validates offline and does **not** contact the cluster/Prometheus;
  - empty / non-existent config paths fail fast;
  - a schema-invalid config exits non-zero;
  - `--check-connectivity` passes when cluster + Prometheus are reachable, and exits
    non-zero when Prometheus is unreachable.
- Manually verified against real config files: a complete config reports valid (exit 0), a
  config with a bad `fitness_function.type` / missing required fields reports the exact
  Pydantic errors (exit 1), and `--check-connectivity` cleanly reports an unreachable
  cluster/Prometheus (exit 1).
- `pre-commit` (ruff, ruff-format, mypy) passes on the changed files. The only failing tests
  in the CLI suite are the pre-existing Windows temp-dir teardown errors, unrelated to this
  change.

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors
