### PR TITLE
feat: auto-discover Prometheus on vanilla Kubernetes (#443)

### DIFF
--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 from kubernetes import client, config
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
 from krkn_ai.utils.fs import env_is_truthy
@@ -6,6 +7,11 @@ from krkn_ai.utils.logger import get_logger
 from krkn_ai.models.custom_errors import PrometheusConnectionError
 
 logger = get_logger(__name__)
+
+# Namespaces searched when auto-discovering Prometheus on vanilla Kubernetes.
+_K8S_MONITORING_NAMESPACES = ("monitoring", "prometheus", "kube-prometheus-stack")
+# Substrings that identify a Prometheus/Thanos Ingress or Service by name.
+_PROMETHEUS_NAME_HINTS = ("prometheus", "thanos")
 
 
 def is_openshift(kubeconfig: str) -> bool:
@@ -61,15 +67,19 @@ def create_prometheus_client(kubeconfig: str) -> KrknPrometheus:
 
     is_ocp = is_openshift(kubeconfig)
 
-    # Case 2: For non-OpenShift clusters, both variables are required.
+    # Case 2: Vanilla Kubernetes. Try to auto-discover an externally reachable
+    # Prometheus endpoint (Ingress or LoadBalancer Service) before giving up.
     if not is_ocp and not url:
-        raise PrometheusConnectionError(
-            "Prometheus configuration missing for Kubernetes cluster.\n"
-            "Please set the following environment variables:\n"
-            "  export PROMETHEUS_URL=https://<prometheus-host>\n"
-            "  export PROMETHEUS_TOKEN=<bearer-token>\n\n"
-            "For generic Kubernetes clusters, explicit configuration is required."
-        )
+        url = _discover_k8s_prometheus_url(kubeconfig)
+        if not url:
+            raise PrometheusConnectionError(
+                "Prometheus configuration missing for Kubernetes cluster.\n"
+                "Automatic discovery found no externally reachable Prometheus "
+                "(Ingress or LoadBalancer Service) in the monitoring namespaces.\n"
+                "Please set the following environment variables:\n"
+                "  export PROMETHEUS_URL=https://<prometheus-host>\n"
+                "  export PROMETHEUS_TOKEN=<bearer-token>"
+            )
 
     # Case 3: OpenShift Auto-discovery
     if is_ocp and not url:
@@ -150,6 +160,158 @@ def _discover_openshift_prometheus_token(kubeconfig: str) -> str:
     except Exception as e:
         logger.debug(f"Unexpected error during token discovery: {e}")
         return ""
+
+
+def _monitoring_namespaces() -> list:
+    """Namespaces to search for a Prometheus endpoint.
+
+    A ``PROMETHEUS_NAMESPACE`` override is searched first when set.
+    """
+    override = os.getenv("PROMETHEUS_NAMESPACE", "").strip()
+    namespaces = list(_K8S_MONITORING_NAMESPACES)
+    if override and override not in namespaces:
+        namespaces.insert(0, override)
+    return namespaces
+
+
+def _looks_like_prometheus(name: Optional[str]) -> bool:
+    """True if a resource name looks like a Prometheus/Thanos endpoint."""
+    if not name:
+        return False
+    lowered = name.lower()
+    return any(hint in lowered for hint in _PROMETHEUS_NAME_HINTS)
+
+
+def _discover_k8s_prometheus_url(kubeconfig: str) -> str:
+    """
+    Discover an externally reachable Prometheus URL on a vanilla Kubernetes
+    cluster, via an Ingress or a LoadBalancer Service in a monitoring namespace.
+
+    A ClusterIP Service is intentionally ignored: it is not reachable from
+    outside the cluster (this is exactly why OpenShift discovery targets a Route).
+
+    Args:
+        kubeconfig: Path to the Kubernetes configuration file.
+
+    Returns:
+        The discovered URL, or an empty string if none is found.
+    """
+    try:
+        config.load_kube_config(config_file=kubeconfig)
+    except Exception as error:
+        logger.debug("Could not load kubeconfig for Prometheus discovery: %s", error)
+        return ""
+
+    url = _discover_prometheus_from_ingress()
+    if url:
+        logger.debug("Discovered Prometheus via Ingress: %s", url)
+        return url
+
+    url = _discover_prometheus_from_loadbalancer()
+    if url:
+        logger.debug("Discovered Prometheus via LoadBalancer Service: %s", url)
+        return url
+
+    return ""
+
+
+def _ingress_targets_prometheus(ingress) -> bool:
+    """True if an Ingress is named like Prometheus or routes to a Prometheus service."""
+    name = getattr(getattr(ingress, "metadata", None), "name", None)
+    if _looks_like_prometheus(name):
+        return True
+    spec = getattr(ingress, "spec", None)
+    for rule in getattr(spec, "rules", None) or []:
+        http = getattr(rule, "http", None)
+        for path in getattr(http, "paths", None) or []:
+            service = getattr(getattr(path, "backend", None), "service", None)
+            if _looks_like_prometheus(getattr(service, "name", None)):
+                return True
+    return False
+
+
+def _first_ingress_host(ingress) -> str:
+    """First host declared on an Ingress, or an empty string."""
+    spec = getattr(ingress, "spec", None)
+    for rule in getattr(spec, "rules", None) or []:
+        host = getattr(rule, "host", None)
+        if host:
+            return host.strip()
+    return ""
+
+
+def _discover_prometheus_from_ingress() -> str:
+    """Look for a Prometheus Ingress across the monitoring namespaces."""
+    try:
+        networking = client.NetworkingV1Api()
+    except Exception as error:
+        logger.debug("Could not create NetworkingV1Api: %s", error)
+        return ""
+
+    for namespace in _monitoring_namespaces():
+        try:
+            ingresses = networking.list_namespaced_ingress(namespace=namespace).items
+        except Exception as error:
+            logger.debug("Could not list ingresses in %s: %s", namespace, error)
+            continue
+        for ingress in ingresses:
+            if not _ingress_targets_prometheus(ingress):
+                continue
+            host = _first_ingress_host(ingress)
+            if host:
+                scheme = "https" if getattr(ingress.spec, "tls", None) else "http"
+                return f"{scheme}://{host}"
+    return ""
+
+
+def _loadbalancer_host(service) -> str:
+    """External hostname or IP of a LoadBalancer Service, or an empty string."""
+    status = getattr(service, "status", None)
+    load_balancer = getattr(status, "load_balancer", None)
+    for ingress in getattr(load_balancer, "ingress", None) or []:
+        host = getattr(ingress, "hostname", None) or getattr(ingress, "ip", None)
+        if host:
+            return host.strip()
+    return ""
+
+
+def _first_service_port(service) -> Optional[int]:
+    """First declared port of a Service, or None."""
+    spec = getattr(service, "spec", None)
+    for port in getattr(spec, "ports", None) or []:
+        value = getattr(port, "port", None)
+        if value:
+            return value
+    return None
+
+
+def _discover_prometheus_from_loadbalancer() -> str:
+    """Look for a Prometheus LoadBalancer Service across the monitoring namespaces."""
+    try:
+        core = client.CoreV1Api()
+    except Exception as error:
+        logger.debug("Could not create CoreV1Api: %s", error)
+        return ""
+
+    for namespace in _monitoring_namespaces():
+        try:
+            services = core.list_namespaced_service(namespace=namespace).items
+        except Exception as error:
+            logger.debug("Could not list services in %s: %s", namespace, error)
+            continue
+        for service in services:
+            spec = getattr(service, "spec", None)
+            if getattr(spec, "type", None) != "LoadBalancer":
+                continue
+            name = getattr(getattr(service, "metadata", None), "name", None)
+            if not _looks_like_prometheus(name):
+                continue
+            host = _loadbalancer_host(service)
+            if not host:
+                continue
+            port = _first_service_port(service)
+            return f"http://{host}:{port}" if port else f"http://{host}"
+    return ""
 
 
 def _validate_and_create_client(url: str, token: str) -> KrknPrometheus:

--- a/tests/unit/utils/test_prometheus.py
+++ b/tests/unit/utils/test_prometheus.py
@@ -4,9 +4,45 @@ Unit tests for Prometheus utility functions and client creation logic using Kube
 
 import os
 import pytest
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from krkn_ai.utils.prometheus import is_openshift, create_prometheus_client
 from krkn_ai.models.custom_errors import PrometheusConnectionError
+
+
+def _ingress(name, host, tls=False, backend_service=None):
+    """Build a minimal V1Ingress-like object for discovery tests."""
+    http = None
+    if backend_service:
+        http = SimpleNamespace(
+            paths=[
+                SimpleNamespace(
+                    backend=SimpleNamespace(
+                        service=SimpleNamespace(name=backend_service)
+                    )
+                )
+            ]
+        )
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name),
+        spec=SimpleNamespace(
+            tls=[SimpleNamespace()] if tls else None,
+            rules=[SimpleNamespace(host=host, http=http)],
+        ),
+    )
+
+
+def _service(name, hostname=None, ip=None, port=9090, svc_type="LoadBalancer"):
+    """Build a minimal V1Service-like object for discovery tests."""
+    lb_ingress = [SimpleNamespace(hostname=hostname, ip=ip)] if (hostname or ip) else []
+    return SimpleNamespace(
+        metadata=SimpleNamespace(name=name),
+        spec=SimpleNamespace(
+            type=svc_type,
+            ports=[SimpleNamespace(port=port)] if port else [],
+        ),
+        status=SimpleNamespace(load_balancer=SimpleNamespace(ingress=lb_ingress)),
+    )
 
 
 class TestPrometheusUtils:
@@ -141,3 +177,91 @@ class TestPrometheusUtils:
             create_prometheus_client("/tmp/test-kubeconfig")
             args, _ = mock_prom_class.call_args
             assert args[0] == "https://my-prom"
+
+
+class TestVanillaPrometheusDiscovery:
+    """Auto-discovery of Prometheus on vanilla (non-OpenShift) Kubernetes."""
+
+    @patch("krkn_ai.utils.prometheus.KrknPrometheus")
+    @patch("krkn_ai.utils.prometheus.client.CoreV1Api")
+    @patch("krkn_ai.utils.prometheus.client.NetworkingV1Api")
+    @patch("krkn_ai.utils.prometheus.config.load_kube_config")
+    @patch("krkn_ai.utils.prometheus.is_openshift", return_value=False)
+    def test_discovers_prometheus_via_ingress(
+        self, _ocp, _load, mock_net_cls, mock_core_cls, mock_prom_cls
+    ):
+        """A Prometheus Ingress with TLS is discovered as an https:// URL."""
+        mock_net_cls.return_value.list_namespaced_ingress.return_value = (
+            SimpleNamespace(
+                items=[_ingress("prometheus-ingress", "prom.example.com", tls=True)]
+            )
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            mock_prom_cls.return_value = Mock(process_query=Mock(return_value=None))
+            create_prometheus_client("/tmp/test-kubeconfig")
+            args, _ = mock_prom_cls.call_args
+            assert args[0] == "https://prom.example.com"
+
+    @patch("krkn_ai.utils.prometheus.KrknPrometheus")
+    @patch("krkn_ai.utils.prometheus.client.CoreV1Api")
+    @patch("krkn_ai.utils.prometheus.client.NetworkingV1Api")
+    @patch("krkn_ai.utils.prometheus.config.load_kube_config")
+    @patch("krkn_ai.utils.prometheus.is_openshift", return_value=False)
+    def test_discovers_prometheus_via_loadbalancer(
+        self, _ocp, _load, mock_net_cls, mock_core_cls, mock_prom_cls
+    ):
+        """A LoadBalancer Service is discovered as http://host:port when no Ingress exists."""
+        mock_net_cls.return_value.list_namespaced_ingress.return_value = (
+            SimpleNamespace(items=[])
+        )
+        mock_core_cls.return_value.list_namespaced_service.return_value = (
+            SimpleNamespace(
+                items=[_service("prometheus-k8s", hostname="lb.example.com", port=9090)]
+            )
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            mock_prom_cls.return_value = Mock(process_query=Mock(return_value=None))
+            create_prometheus_client("/tmp/test-kubeconfig")
+            args, _ = mock_prom_cls.call_args
+            assert args[0] == "http://lb.example.com:9090"
+
+    @patch("krkn_ai.utils.prometheus.client.CoreV1Api")
+    @patch("krkn_ai.utils.prometheus.client.NetworkingV1Api")
+    @patch("krkn_ai.utils.prometheus.config.load_kube_config")
+    @patch("krkn_ai.utils.prometheus.is_openshift", return_value=False)
+    def test_clusterip_service_is_ignored(
+        self, _ocp, _load, mock_net_cls, mock_core_cls
+    ):
+        """A ClusterIP Service (not externally reachable) is not used for discovery."""
+        mock_net_cls.return_value.list_namespaced_ingress.return_value = (
+            SimpleNamespace(items=[])
+        )
+        mock_core_cls.return_value.list_namespaced_service.return_value = (
+            SimpleNamespace(
+                items=[
+                    _service("prometheus-operated", ip="10.0.0.1", svc_type="ClusterIP")
+                ]
+            )
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(PrometheusConnectionError):
+                create_prometheus_client("/tmp/test-kubeconfig")
+
+    @patch("krkn_ai.utils.prometheus.client.CoreV1Api")
+    @patch("krkn_ai.utils.prometheus.client.NetworkingV1Api")
+    @patch("krkn_ai.utils.prometheus.config.load_kube_config")
+    @patch("krkn_ai.utils.prometheus.is_openshift", return_value=False)
+    def test_discovery_finds_nothing_raises(
+        self, _ocp, _load, mock_net_cls, mock_core_cls
+    ):
+        """When nothing reachable is found, the actionable config error is raised."""
+        mock_net_cls.return_value.list_namespaced_ingress.return_value = (
+            SimpleNamespace(items=[])
+        )
+        mock_core_cls.return_value.list_namespaced_service.return_value = (
+            SimpleNamespace(items=[])
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(PrometheusConnectionError) as exc:
+                create_prometheus_client("/tmp/test-kubeconfig")
+            assert "Prometheus configuration missing" in str(exc.value)


### PR DESCRIPTION
## Description

Fixes #443.

Prometheus auto-discovery was implemented for OpenShift only. On a generic (vanilla)
Kubernetes cluster, `create_prometheus_client()` refused to do any discovery and required
the user to set `PROMETHEUS_URL` / `PROMETHEUS_TOKEN` by hand, even when the cluster ran a
standard `kube-prometheus-stack` with a discoverable endpoint.

This PR adds a vanilla-Kubernetes discovery path, tried when the cluster is not OpenShift
and no `PROMETHEUS_URL` is set (Case 2). It looks, across the monitoring namespaces
(`monitoring`, `prometheus`, `kube-prometheus-stack`, plus an optional `PROMETHEUS_NAMESPACE`
override), for an **externally reachable** Prometheus endpoint:

1. an **Ingress** named like Prometheus/Thanos or routing to a Prometheus service
   (`https://` when TLS is configured, otherwise `http://`), then
2. a **LoadBalancer Service** named like Prometheus, using its external hostname/IP and
   first port.

A `ClusterIP` Service is intentionally **not** used: it is not reachable from outside the
cluster (this is exactly why the existing OpenShift path targets a `Route`). If nothing
reachable is found, the previous behavior is preserved: `create_prometheus_client()` raises
`PrometheusConnectionError` with the manual-configuration instructions.

Explicit `PROMETHEUS_URL` / `PROMETHEUS_TOKEN` env vars still take priority over all
discovery (unchanged Case 1), and OpenShift discovery is unchanged.

## Type of Change


- [x] New feature




## Testing

- New `TestVanillaPrometheusDiscovery` in `tests/unit/utils/test_prometheus.py`:
  - discovers a Prometheus **Ingress** (TLS -> `https://`);
  - discovers a **LoadBalancer** Service (`http://host:port`) when no Ingress exists;
  - **ignores a ClusterIP** Service (not externally reachable);
  - raises the actionable config error when nothing reachable is found.
- All existing Prometheus tests still pass (13 total), including the vanilla-k8s
  "missing config" case, which now degrades through discovery before raising.
- `pre-commit` (ruff, ruff-format, mypy) passes on the changed files.

## Additional Context

- Token discovery is not attempted for vanilla clusters (unlike OpenShift); the env
  `PROMETHEUS_TOKEN` is used if present, otherwise the client is created without one, which
  suits unauthenticated in-namespace Prometheus. NodePort discovery is intentionally left
  out for now, since its external reachability depends on node addresses; it can be a
  follow-up.
