### PR TITLE
feat(config): add input validation for genetic algorithm parameters

### DIFF
--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -10,7 +10,7 @@ from krkn_ai.algorithm.genetic.stopping import StoppingCriteriaEvaluator
 from krkn_ai.constants import STATUS_IN_PROGRESS
 from krkn_ai.models.app import CommandRunResult, KrknRunnerType
 from krkn_ai.models.config import ConfigFile, GeneticAlgorithmConfig, SelectionStrategy
-from krkn_ai.models.custom_errors import PopulationSizeError, UniqueScenariosError
+from krkn_ai.models.custom_errors import UniqueScenariosError
 from krkn_ai.models.scenario.base import (
     Scenario,
     BaseScenario,
@@ -39,9 +39,6 @@ class GeneticAlgorithm(BaseEngine):
         runner_type: KrknRunnerType = None,
         run_uuid: Optional[str] = None,
     ):
-        if config.genetic.population_size < 2:
-            raise PopulationSizeError("Population size should be at least 2")
-
         if config.genetic.population_size % 2 != 0:
             logger.debug(
                 "Population size is odd, making it even for the genetic algorithm."
@@ -253,12 +250,6 @@ class GeneticAlgorithm(BaseEngine):
         else:
             self.stagnant_generations = 0
             rate_factor = 0.9
-
-        if cfg.min > cfg.max:
-            raise ValueError(
-                f"Invalid adaptive mutation configuration: min ({cfg.min}) "
-                f"must be less than or equal to max ({cfg.max})"
-            )
 
         # Increase rate when stagnating, decrease when improving
         old_rate = self.current_scenario_mutation_rate

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -74,7 +74,7 @@ class StorageThrottleScenarioConfig(BaseModel):
 
 class BaselineConfig(BaseModel):
     enable: bool = True
-    duration: int = 60 * 2  # 2 minutes
+    duration: int = Field(default=60 * 2, gt=0)
 
 
 class ScenarioConfig(BaseModel):
@@ -250,10 +250,19 @@ class HealthCheckResult(BaseModel):
 
 class AdaptiveMutation(BaseModel):
     enable: bool = False
-    min: float = 0.05
-    max: float = 0.9
+    min: float = Field(default=0.05, ge=0.0, le=1.0)
+    max: float = Field(default=0.9, ge=0.0, le=1.0)
     threshold: float = 0.1
-    generations: int = 5
+    generations: int = Field(default=5, gt=0)
+
+    @model_validator(mode="after")
+    def validate_min_less_than_max(self):
+        if self.enable and self.min >= self.max:
+            raise ValueError(
+                f"adaptive_mutation.min ({self.min}) must be less than "
+                f"adaptive_mutation.max ({self.max})"
+            )
+        return self
 
 
 class StoppingCriteria(BaseModel):
@@ -302,17 +311,32 @@ class AlgorithmType(str, Enum):
 class GeneticAlgorithmConfig(BaseModel):
     generations: Optional[int] = 20
     duration: Optional[int] = None
-    population_size: int = 10
-    mutation_rate: float = const.MUTATION_RATE
-    scenario_mutation_rate: float = const.SCENARIO_MUTATION_RATE
-    crossover_rate: float = const.CROSSOVER_RATE
-    composition_rate: float = 0
+    population_size: int = Field(default=10, ge=2)
+    mutation_rate: float = Field(default=const.MUTATION_RATE, ge=0.0, le=1.0)
+    scenario_mutation_rate: float = Field(
+        default=const.SCENARIO_MUTATION_RATE, ge=0.0, le=1.0
+    )
+    crossover_rate: float = Field(default=const.CROSSOVER_RATE, ge=0.0, le=1.0)
+    composition_rate: float = Field(default=0, ge=0.0, le=1.0)
     selection_strategy: SelectionStrategy = SelectionStrategy.roulette
-    tournament_size: int = 3
-    population_injection_rate: float = const.POPULATION_INJECTION_RATE
-    population_injection_size: int = const.POPULATION_INJECTION_SIZE
+    tournament_size: int = Field(default=3, ge=1)
+    population_injection_rate: float = Field(
+        default=const.POPULATION_INJECTION_RATE, ge=0.0, le=1.0
+    )
+    population_injection_size: int = Field(
+        default=const.POPULATION_INJECTION_SIZE, ge=1
+    )
     adaptive_mutation: AdaptiveMutation = AdaptiveMutation()
     stopping_criteria: StoppingCriteria = StoppingCriteria()
+
+    @field_validator("generations", "duration", mode="after")
+    @classmethod
+    def validate_positive_when_set(cls, value: Optional[int], info) -> Optional[int]:
+        if value is not None and value <= 0:
+            raise ValueError(
+                f"{info.field_name} must be a positive integer when set, got {value}"
+            )
+        return value
 
 
 class ConfigFile(BaseModel):
@@ -321,8 +345,8 @@ class ConfigFile(BaseModel):
 
     seed: Optional[int] = None  # Optional: Random seed for reproducible runs
 
-    wait_duration: int = (
-        const.WAIT_DURATION
+    wait_duration: int = Field(
+        default=const.WAIT_DURATION, ge=0
     )  # Time to wait after each scenario run (Default: 120 seconds)
 
     fitness_function: FitnessFunction

--- a/tests/unit/algorithm/test_adaptive_mutation.py
+++ b/tests/unit/algorithm/test_adaptive_mutation.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from krkn_ai.models.config import AdaptiveMutation
 from krkn_ai.models.app import FitnessResult
@@ -164,21 +165,12 @@ class TestAdaptMutationRateUpdate:
         )
         assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.35)
 
-    def test_raises_when_min_exceeds_max(self, genetic_algorithm):
-        """Should reject invalid adaptive mutation bounds"""
-        genetic_algorithm.algo_config.adaptive_mutation = AdaptiveMutation(
-            enable=True, threshold=0.5, generations=1, min=0.8, max=0.2
-        )
-        genetic_algorithm.current_scenario_mutation_rate = 0.3
-        genetic_algorithm.best_of_generation = [
-            make_generation_result(10.0),
-            make_generation_result(10.1),
-        ]
-
-        with pytest.raises(ValueError, match="Invalid adaptive mutation configuration"):
-            genetic_algorithm.adapt_mutation_rate()
-
-        assert genetic_algorithm.current_scenario_mutation_rate == pytest.approx(0.3)
+    def test_raises_when_min_exceeds_max(self):
+        """Should reject invalid adaptive mutation bounds at construction time"""
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveMutation(
+                enable=True, threshold=0.5, generations=1, min=0.8, max=0.2
+            )
 
     def test_save_config_uses_original_rate_after_adaptation(self, genetic_algorithm):
         """Saving config after adaptive mutation should keep the configured rate"""

--- a/tests/unit/algorithm/test_genetic_algorithm.py
+++ b/tests/unit/algorithm/test_genetic_algorithm.py
@@ -4,9 +4,10 @@ GeneticAlgorithm core functionality tests
 
 import pytest
 from unittest.mock import Mock, patch
+from pydantic import ValidationError
 
 from krkn_ai.algorithm.genetic import GeneticAlgorithm
-from krkn_ai.models.custom_errors import PopulationSizeError
+from krkn_ai.models.config import GeneticAlgorithmConfig
 
 
 class TestGeneticAlgorithmInitialization:
@@ -49,22 +50,10 @@ class TestGeneticAlgorithmInitialization:
 
                 assert first.run_uuid != second.run_uuid
 
-    def test_init_with_population_size_less_than_2(
-        self, minimal_config, temp_output_dir
-    ):
-        """Test raises error when population size is less than 2"""
-        minimal_config.genetic.population_size = 1
-        with patch("krkn_ai.algorithm.base.KrknRunner"):
-            with patch(
-                "krkn_ai.algorithm.base.ScenarioFactory.generate_valid_scenarios"
-            ) as mock_gen:
-                mock_gen.return_value = [("pod_scenarios", Mock)]
-                with pytest.raises(
-                    PopulationSizeError, match="Population size should be at least 2"
-                ):
-                    GeneticAlgorithm(
-                        config=minimal_config, output_dir=temp_output_dir, format="yaml"
-                    )
+    def test_init_with_population_size_less_than_2(self):
+        """Test raises ValidationError when population size is less than 2"""
+        with pytest.raises(ValidationError, match="population_size"):
+            GeneticAlgorithmConfig(population_size=1)
 
     def test_init_with_odd_population_size(self, minimal_config, temp_output_dir):
         """Test odd population size is adjusted to even"""

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -6,6 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from krkn_ai.models.config import (
+    AdaptiveMutation,
+    BaselineConfig,
     ConfigFile,
     GeneticAlgorithmConfig,
     FitnessFunction,
@@ -332,3 +334,170 @@ class TestStoppingCriteria:
         assert config.genetic.population_size == 20
         assert config.genetic.mutation_rate == 0.8
         assert config.genetic.stopping_criteria.fitness_threshold == 100.0
+
+
+# ---------------------------------------------------------------------------
+# GeneticAlgorithmConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestGeneticAlgorithmConfigValidation:
+    """Tests for GeneticAlgorithmConfig field constraints."""
+
+    RATE_FIELDS = [
+        "mutation_rate",
+        "scenario_mutation_rate",
+        "crossover_rate",
+        "composition_rate",
+        "population_injection_rate",
+    ]
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    def test_rate_accepts_boundaries(self, field):
+        assert getattr(GeneticAlgorithmConfig(**{field: 0.0}), field) == 0.0
+        assert getattr(GeneticAlgorithmConfig(**{field: 1.0}), field) == 1.0
+
+    @pytest.mark.parametrize("field", RATE_FIELDS)
+    @pytest.mark.parametrize("bad", [-0.1, 1.5, 99.0])
+    def test_rate_rejects_out_of_range(self, field, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(**{field: bad})
+
+    def test_population_size_accepts_minimum(self):
+        assert GeneticAlgorithmConfig(population_size=2).population_size == 2
+
+    @pytest.mark.parametrize("bad", [1, 0, -5])
+    def test_population_size_rejects_below_2(self, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(population_size=bad)
+
+    def test_population_injection_size_accepts_minimum(self):
+        assert (
+            GeneticAlgorithmConfig(
+                population_injection_size=1
+            ).population_injection_size
+            == 1
+        )
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_population_injection_size_rejects_below_1(self, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(population_injection_size=bad)
+
+    def test_tournament_size_accepts_minimum(self):
+        assert GeneticAlgorithmConfig(tournament_size=1).tournament_size == 1
+
+    @pytest.mark.parametrize("bad", [0, -1])
+    def test_tournament_size_rejects_below_1(self, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(tournament_size=bad)
+
+    def test_generations_accepts_positive(self):
+        assert GeneticAlgorithmConfig(generations=1).generations == 1
+
+    def test_generations_accepts_none(self):
+        assert GeneticAlgorithmConfig(generations=None).generations is None
+
+    @pytest.mark.parametrize("bad", [0, -10])
+    def test_generations_rejects_non_positive(self, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(generations=bad)
+
+    def test_duration_accepts_positive(self):
+        assert GeneticAlgorithmConfig(duration=3600).duration == 3600
+
+    def test_duration_accepts_none(self):
+        assert GeneticAlgorithmConfig(duration=None).duration is None
+
+    @pytest.mark.parametrize("bad", [0, -60])
+    def test_duration_rejects_non_positive(self, bad):
+        with pytest.raises(ValidationError):
+            GeneticAlgorithmConfig(duration=bad)
+
+    def test_defaults_pass_validation(self):
+        config = GeneticAlgorithmConfig()
+        assert config.population_size == 10
+        assert config.generations == 20
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveMutation validation
+# ---------------------------------------------------------------------------
+
+
+class TestAdaptiveMutationValidation:
+    """Tests for AdaptiveMutation field constraints."""
+
+    @pytest.mark.parametrize("field", ["min", "max"])
+    def test_rate_accepts_boundaries(self, field):
+        kwargs = {"min": 0.0, "max": 1.0, **{field: 0.0 if field == "min" else 1.0}}
+        am = AdaptiveMutation(**kwargs)
+        assert getattr(am, field) == kwargs[field]
+
+    @pytest.mark.parametrize("field", ["min", "max"])
+    @pytest.mark.parametrize("bad", [-0.1, 1.5])
+    def test_rate_rejects_out_of_range(self, field, bad):
+        with pytest.raises(ValidationError):
+            AdaptiveMutation(**{field: bad})
+
+    def test_min_equals_max_rejected_when_enabled(self):
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveMutation(enable=True, min=0.5, max=0.5)
+
+    def test_min_greater_than_max_rejected_when_enabled(self):
+        with pytest.raises(ValidationError, match="must be less than"):
+            AdaptiveMutation(enable=True, min=0.9, max=0.1)
+
+    def test_min_equals_max_allowed_when_disabled(self):
+        am = AdaptiveMutation(enable=False, min=0.5, max=0.5)
+        assert am.min == 0.5
+
+    def test_generations_accepts_positive(self):
+        assert AdaptiveMutation(generations=1).generations == 1
+
+    @pytest.mark.parametrize("bad", [0, -5])
+    def test_generations_rejects_non_positive(self, bad):
+        with pytest.raises(ValidationError):
+            AdaptiveMutation(generations=bad)
+
+
+# ---------------------------------------------------------------------------
+# BaselineConfig validation
+# ---------------------------------------------------------------------------
+
+
+class TestBaselineConfigValidation:
+    """Tests for BaselineConfig.duration constraint."""
+
+    def test_duration_accepts_positive(self):
+        assert BaselineConfig(duration=120).duration == 120
+
+    @pytest.mark.parametrize("bad", [0, -10])
+    def test_duration_rejects_non_positive(self, bad):
+        with pytest.raises(ValidationError):
+            BaselineConfig(duration=bad)
+
+
+# ---------------------------------------------------------------------------
+# ConfigFile.wait_duration validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFileWaitDurationValidation:
+    """Tests for ConfigFile.wait_duration constraint."""
+
+    def _make_config(self, **overrides):
+        defaults = {
+            "kubeconfig_file_path": "/path/to/kubeconfig",
+            "fitness_function": FitnessFunction(query="up"),
+            "cluster_components": ClusterComponents(namespaces=[], nodes=[]),
+        }
+        defaults.update(overrides)
+        return ConfigFile(**defaults)
+
+    def test_wait_duration_accepts_zero(self):
+        assert self._make_config(wait_duration=0).wait_duration == 0
+
+    def test_wait_duration_rejects_negative(self):
+        with pytest.raises(ValidationError):
+            self._make_config(wait_duration=-1)


### PR DESCRIPTION
Add Pydantic Field() constraints to fail fast on invalid config values instead of silently accepting garbage. Validates rate fields to [0.0, 1.0], population_size >= 2, generations/duration > 0 when set, and adaptive_mutation min < max cross-field check. Removes redundant runtime checks from engine.py that are now caught at parse time.

Closes #229

## Description
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## AI Disclosure
<!-- See AI_CONTRIBUTION_POLICY.md for details -->
- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

**AI Tool(s) Used:** <!-- e.g., GitHub Copilot, Claude, ChatGPT -->
Code generation.

## Testing
<!-- How have you tested these changes? -->

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
