### PR TITLE
fix: improve error handling in VMI/PVC discovery and fix ScenarioInit…

### DIFF
--- a/krkn_ai/cluster/cluster_manager.py
+++ b/krkn_ai/cluster/cluster_manager.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Optional, Union
 import requests
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from kubernetes.client.models import V1PodSpec
+from kubernetes.client.rest import ApiException
 from krkn_ai.utils import run_shell
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.models.custom_errors import ShellCommandTimeoutError
@@ -403,6 +404,19 @@ class ClusterManager:
                 "Discovered %d PVCs in namespace %s", len(pvc_list), namespace.name
             )
             return pvc_list
+        except ApiException as e:
+            if e.status == 403:
+                logger.warning(
+                    "RBAC denied listing PVCs in namespace %s, skipping",
+                    namespace.name,
+                )
+            else:
+                logger.warning(
+                    "Failed to list PVCs in namespace %s (HTTP %d), skipping",
+                    namespace.name,
+                    e.status,
+                )
+            return []
         except Exception as e:
             logger.warning(
                 "Failed to list PVCs in namespace %s: %s", namespace.name, str(e)
@@ -430,7 +444,7 @@ class ClusterManager:
                 logger.debug(
                     "Found %d vmis in namespace %s",
                     len(vmis),
-                    vmis[0]["metadata"]["name"],
+                    namespace.name,
                 )
             else:
                 logger.debug("No VMIs found in namespace %s", namespace.name)
@@ -442,9 +456,28 @@ class ClusterManager:
                 "Filtered %d vmis in namespace %s", len(vmi_list), namespace.name
             )
             return vmi_list
+        except ApiException as e:
+            if e.status == 404:
+                logger.debug(
+                    "KubeVirt CRDs not installed, skipping VMI discovery in namespace %s",
+                    namespace.name,
+                )
+            elif e.status == 403:
+                logger.warning(
+                    "RBAC denied listing virtualmachineinstances in namespace %s, skipping. "
+                    "Grant kubevirt.io list permission to the ServiceAccount.",
+                    namespace.name,
+                )
+            else:
+                logger.warning(
+                    "Failed to list VMIs in namespace %s (HTTP %d), skipping",
+                    namespace.name,
+                    e.status,
+                )
+            return []
         except Exception as e:
             logger.warning(
-                "Unable to find VMIs in namespace %s: %s",
+                "Failed to list VMIs in namespace %s: %s",
                 namespace.name,
                 e,
                 exc_info=True,

--- a/krkn_ai/models/scenario/factory.py
+++ b/krkn_ai/models/scenario/factory.py
@@ -152,7 +152,7 @@ class ScenarioFactory:
             _, cls = rng.choice(candidates)
             return cls(cluster_components=active_components)
         except Exception as error:
-            raise ScenarioInitError("Unable to initialize scenario: %s", error)
+            raise ScenarioInitError("Unable to initialize scenario: %s" % error)
 
     @staticmethod
     def create_dummy_scenario():


### PR DESCRIPTION
…Error message

Add ApiException handling to list_vmis() and list_pvcs() to distinguish RBAC denials (403), missing CRDs (404), and transient failures from generic errors, giving operators actionable log messages instead of silent empty results. Fix ScenarioInitError string interpolation and incorrect namespace logging in VMI discovery.

Fixes #258

## Description
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## AI Disclosure
<!-- See AI_CONTRIBUTION_POLICY.md for details -->
- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

**AI Tool(s) Used:** <!-- e.g., GitHub Copilot, Claude, ChatGPT -->
Generation

## Testing
<!-- How have you tested these changes? -->

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
