### PR TITLE
fix(pattern-matcher): handle * wildcard in list input (#441, #465)

### DIFF
--- a/krkn_ai/cluster/pattern_matcher.py
+++ b/krkn_ai/cluster/pattern_matcher.py
@@ -66,19 +66,8 @@ class PatternMatcher:
         Raises:
             PatternValidationError: If any pattern contains invalid regex
         """
-        # Handle list input (pass through)
         if isinstance(pattern_string, list):
-            list_include: List[re.Pattern] = []
-            list_exclude: List[re.Pattern] = []
-            for pat in pattern_string:
-                if pat.startswith("!"):
-                    actual = pat[1:]
-                    if actual:
-                        list_exclude.append(cls._compile_pattern(actual))
-                else:
-                    list_include.append(cls._compile_pattern(pat))
-            list_match_all = len(list_include) == 0 and len(list_exclude) > 0
-            return cls(list_include, list_exclude, match_all=list_match_all)
+            pattern_string = ",".join(pattern_string)
 
         # Handle None or empty string
         if pattern_string is None or pattern_string.strip() == "":
@@ -222,16 +211,18 @@ class PatternMatcher:
         return not self.match_all and len(self.include_patterns) == 0
 
     @classmethod
-    def validate(cls, pattern_string: str) -> List[str]:
+    def validate(cls, pattern_string: Optional[Union[str, List[str]]]) -> List[str]:
         """
         Validate a pattern string without creating a matcher.
 
         Args:
-            pattern_string: The pattern string to validate
+            pattern_string: The pattern string or list to validate
 
         Returns:
             List of error messages (empty if valid)
         """
+        if isinstance(pattern_string, list):
+            pattern_string = ",".join(pattern_string)
         errors: List[str] = []
         if not pattern_string or pattern_string.strip() in ("", "*"):
             return errors

--- a/tests/unit/cluster/test_pattern_matcher.py
+++ b/tests/unit/cluster/test_pattern_matcher.py
@@ -73,6 +73,34 @@ class TestPatternMatcherCreation:
         assert matcher.matches("kube-system")
         assert not matcher.matches("test-ns")
 
+    def test_list_input_wildcard_creates_match_all_matcher(self):
+        """Test ['*'] produces match_all=True"""
+        matcher = PatternMatcher.from_string(["*"])
+        assert matcher.match_all
+        assert matcher.matches("anything")
+        assert matcher.matches("kube-system")
+
+    def test_list_input_wildcard_with_exclusion(self):
+        """Test ['*', '!kube-system'] matches everything except excluded"""
+        matcher = PatternMatcher.from_string(["*", "!kube-system"])
+        assert matcher.match_all
+        assert matcher.matches("default")
+        assert matcher.matches("prod-ns")
+        assert not matcher.matches("kube-system")
+
+    def test_list_input_wildcard_with_regex_exclusion(self):
+        """Test ['*', '!kube-.*'] matches everything except regex-excluded"""
+        matcher = PatternMatcher.from_string(["*", "!kube-.*"])
+        assert matcher.matches("default")
+        assert not matcher.matches("kube-system")
+        assert not matcher.matches("kube-public")
+
+    def test_list_input_wildcard_ignores_other_includes(self):
+        """Test ['*', 'default'] behaves same as '*' — extra includes are ignored"""
+        matcher = PatternMatcher.from_string(["*", "default"])
+        assert matcher.match_all
+        assert matcher.matches("anything")
+
 
 class TestPatternMatcherExclusion:
     """Test PatternMatcher exclusion patterns"""
@@ -192,6 +220,17 @@ class TestPatternMatcherValidation:
     def test_validate_returns_errors_for_invalid_regex(self):
         """Test validate returns errors for invalid regex patterns"""
         errors = PatternMatcher.validate("[invalid")
+        assert len(errors) == 1
+        assert "Invalid regex" in errors[0]
+
+    def test_validate_accepts_list_input(self):
+        """Test validate works with list input"""
+        assert PatternMatcher.validate(["default", "kube-.*"]) == []
+        assert PatternMatcher.validate(["*", "!kube-system"]) == []
+
+    def test_validate_returns_errors_for_invalid_regex_in_list(self):
+        """Test validate returns errors for invalid regex in list input"""
+        errors = PatternMatcher.validate(["default", "[invalid"])
         assert len(errors) == 1
         assert "Invalid regex" in errors[0]
 


### PR DESCRIPTION
Normalize list input to comma-joined string so the existing string path handles wildcard, exclusion, and match-all semantics uniformly. Also accept List[str] in validate().

Closes https://github.com/krkn-chaos/krkn-ai/issues/441 and https://github.com/krkn-chaos/krkn-ai/issues/465

## Description
<!-- What does this PR do? Why is it needed? -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## AI Disclosure
<!-- See AI_CONTRIBUTION_POLICY.md for details -->
- [ ] No AI tools were used in this contribution
- [x] AI tools were used (describe below)

**AI Tool(s) Used:** Claude-Code (Opus 4.6)
**How AI was used:** Code Generation

## Testing
<!-- How have you tested these changes? -->

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
