### PR TITLE
feat: add evolutionary lineage tracking

### DIFF
--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import os
 import time
+import uuid
 from typing import List, Optional
 
 from krkn_ai.algorithm.base import BaseEngine
@@ -16,6 +17,7 @@ from krkn_ai.models.scenario.base import (
     BaseScenario,
     CompositeDependency,
     CompositeScenario,
+    ScenarioOrigin,
 )
 from krkn_ai.models.scenario.factory import ScenarioFactory
 from krkn_ai.reporter.generations_reporter import GenerationsReporter
@@ -140,27 +142,30 @@ class GeneticAlgorithm(BaseEngine):
             self.population = []
             for _ in range(self.algo_config.population_size // 2):
                 parent1, parent2 = self.select_parents(fitness_scores)
-                child1, child2 = None, None
+                parent_ids = [parent1.id, parent2.id]
+
                 if rng.random() < self.algo_config.composition_rate:
-                    # Composition: merge two scenarios into a composite
                     child1 = self.composition(
                         copy.deepcopy(parent1), copy.deepcopy(parent2)
                     )
                     child1 = self.mutate(child1)
+                    self._tag_lineage(child1, parent_ids, ScenarioOrigin.COMPOSITION)
                     self.population.append(child1)
 
                     child2 = self.composition(
                         copy.deepcopy(parent2), copy.deepcopy(parent1)
                     )
                     child2 = self.mutate(child2)
+                    self._tag_lineage(child2, parent_ids, ScenarioOrigin.COMPOSITION)
                     self.population.append(child2)
                 else:
-                    # Standard crossover: swap parameters between parents
                     child1, child2 = self.crossover(
                         copy.deepcopy(parent1), copy.deepcopy(parent2)
                     )
                     child1 = self.mutate(child1)
                     child2 = self.mutate(child2)
+                    self._tag_lineage(child1, parent_ids, ScenarioOrigin.CROSSOVER)
+                    self._tag_lineage(child2, parent_ids, ScenarioOrigin.CROSSOVER)
 
                     self.population.append(child1)
                     self.population.append(child2)
@@ -282,6 +287,7 @@ class GeneticAlgorithm(BaseEngine):
             )
 
             if scenario and scenario not in already_seen:
+                scenario.origin = ScenarioOrigin.INITIAL
                 population.append(scenario)
                 already_seen.add(scenario)
 
@@ -305,6 +311,16 @@ class GeneticAlgorithm(BaseEngine):
                 population.append(rng.choice(available_scenarios))
 
         return population
+
+    @staticmethod
+    def _tag_lineage(
+        scenario: BaseScenario,
+        parent_ids: List[str],
+        origin: ScenarioOrigin,
+    ):
+        scenario.id = str(uuid.uuid4())
+        scenario.parent_ids = parent_ids
+        scenario.origin = origin
 
     def calculate_fitness(self, scenario: BaseScenario, generation_id: int):
         if scenario in self.seen_population:

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -195,7 +195,10 @@ class GeneticAlgorithm(BaseEngine):
     def save(self):
         self.generations_reporter.save_best_generations(self.best_of_generation)
         self.generations_reporter.save_best_generation_graph(self.best_of_generation)
-        self.health_check_reporter.save_report(self.seen_population.values())
+        health_check_results = list(self.seen_population.values())
+        if self.baseline_result is not None:
+            health_check_results.append(self.baseline_result)
+        self.health_check_reporter.save_report(health_check_results)
         self.health_check_reporter.sort_fitness_result_csv()
 
         summary_reporter = JSONSummaryReporter(

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -322,8 +322,9 @@ class GeneticAlgorithm(BaseEngine):
         origin: ScenarioOrigin,
     ):
         scenario.id = str(uuid.uuid4())
-        scenario.parent_ids = parent_ids
-        scenario.origin = origin
+        scenario.parent_ids = list(parent_ids)
+        if scenario.origin is None:
+            scenario.origin = origin
 
     def calculate_fitness(self, scenario: BaseScenario, generation_id: int):
         if scenario in self.seen_population:
@@ -350,10 +351,12 @@ class GeneticAlgorithm(BaseEngine):
         if rng.random() < self.current_scenario_mutation_rate:
             success, new_scenario = self.scenario_mutation(scenario)
             if success:
+                new_scenario.origin = ScenarioOrigin.TYPE_MUTATION
                 return new_scenario
 
         if hasattr(scenario, "mutate"):
             scenario.mutate()
+            scenario.origin = ScenarioOrigin.PARAMETER_MUTATION
         else:
             logger.warning("Scenario %s does not have mutate method", scenario)
         return scenario

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -9,7 +9,7 @@ from krkn_ai.models.custom_errors import (
     FitnessFunctionCalculationError,
     FitnessFunctionConfigurationError,
 )
-from krkn_ai.utils.fs import env_is_truthy
+from krkn_ai.utils.mock import MockType, is_mock_enabled
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.utils.rng import rng
 
@@ -44,7 +44,7 @@ class FitnessCalculator:
 
     def preflight_check(self) -> None:
         """Validate all fitness queries return data before the experiment starts."""
-        if env_is_truthy("MOCK_FITNESS"):
+        if is_mock_enabled(MockType.FITNESS):
             return
 
         now = datetime.datetime.now()
@@ -117,7 +117,7 @@ class FitnessCalculator:
 
     def calculate_fitness_value(self, start, end, query, fitness_type):
         """Calculate fitness score for scenario run"""
-        if env_is_truthy("MOCK_FITNESS"):
+        if is_mock_enabled(MockType.FITNESS):
             return rng.random()
 
         retries = 3

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+from typing import Optional
 
 from krkn_ai.chaos_engines.commands import build_scenario_command, inject_es_config
 from krkn_ai.chaos_engines.composite import build_graph_command
@@ -37,7 +38,7 @@ class KrknRunner:
         self,
         config: ConfigFile,
         output_dir: str,
-        runner_type: KrknRunnerType = None,
+        runner_type: Optional[KrknRunnerType] = None,
     ):
         self.config = config
 
@@ -106,6 +107,7 @@ class KrknRunner:
             time.sleep(rng.randint(1, 3))
             log, returncode = "", 0
         else:
+            assert self.runner_type is not None
             if isinstance(scenario, CompositeScenario):
                 command = build_graph_command(
                     scenario, self.config.kubeconfig_file_path, self.output_dir
@@ -202,7 +204,9 @@ class KrknRunner:
         return CommandRunResult(
             generation_id=generation_id,
             scenario=scenario,
-            cmd=inject_es_config(command, self.config, self.runner_type, False),
+            cmd=inject_es_config(command, self.config, self.runner_type, False)
+            if self.runner_type is not None
+            else "",
             log=log,
             returncode=returncode,
             start_time=start_time,
@@ -215,9 +219,11 @@ class KrknRunner:
         )
 
     def runner_command(self, scenario: Scenario) -> str:
+        assert self.runner_type is not None
         return build_scenario_command(scenario, self.config, self.runner_type)
 
     def process_es_env_string(self, command: str, enable: bool) -> str:
+        assert self.runner_type is not None
         return inject_es_config(command, self.config, self.runner_type, enable)
 
     def graph_command(self, scenario: CompositeScenario) -> str:

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -17,7 +17,11 @@ from krkn_ai.models.scenario.base import (
     CompositeScenario,
 )
 from krkn_ai.utils import run_shell
-from krkn_ai.utils.fs import env_is_truthy
+from krkn_ai.utils.mock import (
+    MockType,
+    is_mock_enabled,
+    generate_mock_health_check_results,
+)
 from krkn_ai.utils.logger import get_logger, is_verbose
 from krkn_ai.utils.prometheus import create_prometheus_client
 from krkn_ai.utils.rng import rng
@@ -41,7 +45,7 @@ class KrknRunner:
             self.prom_client, config.fitness_function
         )
 
-        if not env_is_truthy("MOCK_FITNESS"):
+        if not is_mock_enabled(MockType.FITNESS):
             logger.info("Running pre-flight fitness function validation...")
             self.fitness_calculator.preflight_check()
             logger.info("Pre-flight fitness validation passed.")
@@ -99,7 +103,7 @@ class KrknRunner:
             self.config.health_checks, self.config.parameters
         )
 
-        if env_is_truthy("MOCK_RUN"):
+        if is_mock_enabled(MockType.RUN):
             time.sleep(rng.randint(1, 3))
             log, returncode = "", 0
         else:
@@ -128,7 +132,12 @@ class KrknRunner:
 
         fitness_result: FitnessResult = FitnessResult()
 
-        health_check_results = health_check_watcher.get_results()
+        if is_mock_enabled(MockType.HEALTH_CHECK):
+            health_check_results = generate_mock_health_check_results(
+                self.config.health_checks
+            )
+        else:
+            health_check_results = health_check_watcher.get_results()
 
         if returncode != 0 and returncode != 2:
             logger.warning(

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -40,18 +40,25 @@ class KrknRunner:
         runner_type: KrknRunnerType = None,
     ):
         self.config = config
-        self.prom_client = create_prometheus_client(self.config.kubeconfig_file_path)
-        self.fitness_calculator = FitnessCalculator(
-            self.prom_client, config.fitness_function
-        )
 
-        if not is_mock_enabled(MockType.FITNESS):
+        if is_mock_enabled(MockType.FITNESS):
+            self.prom_client = None
+            self.fitness_calculator = FitnessCalculator(None, config.fitness_function)
+        else:
+            self.prom_client = create_prometheus_client(
+                self.config.kubeconfig_file_path
+            )
+            self.fitness_calculator = FitnessCalculator(
+                self.prom_client, config.fitness_function
+            )
             logger.info("Running pre-flight fitness function validation...")
             self.fitness_calculator.preflight_check()
             logger.info("Pre-flight fitness validation passed.")
 
         self.output_dir = output_dir
-        if runner_type is None:
+        if is_mock_enabled(MockType.RUN):
+            self.runner_type = runner_type
+        elif runner_type is None:
             self.runner_type = self.__check_runner_availability()
         else:
             logger.debug("Using user provided runner type: %s", runner_type)
@@ -90,14 +97,6 @@ class KrknRunner:
 
         log, returncode, run_uuid, resiliency_score = None, None, None, None
         command = ""
-        if isinstance(scenario, CompositeScenario):
-            command = build_graph_command(
-                scenario, self.config.kubeconfig_file_path, self.output_dir
-            )
-        elif isinstance(scenario, Scenario):
-            command = build_scenario_command(scenario, self.config, self.runner_type)
-        else:
-            raise NotImplementedError("Scenario unable to run")
 
         health_check_watcher = HealthCheckWatcher(
             self.config.health_checks, self.config.parameters
@@ -107,6 +106,17 @@ class KrknRunner:
             time.sleep(rng.randint(1, 3))
             log, returncode = "", 0
         else:
+            if isinstance(scenario, CompositeScenario):
+                command = build_graph_command(
+                    scenario, self.config.kubeconfig_file_path, self.output_dir
+                )
+            elif isinstance(scenario, Scenario):
+                command = build_scenario_command(
+                    scenario, self.config, self.runner_type
+                )
+            else:
+                raise NotImplementedError("Scenario unable to run")
+
             try:
                 health_check_watcher.run()
 

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -211,7 +211,7 @@ def run(
 @click.option("--port", "-p", help="Port to run Streamlit server on.", default=8501)
 @click.pass_context
 def monitor(ctx, output: str, port: int):
-    init_logger(output, False)
+    init_logger(None, False)
     logger = get_logger(__name__)
     logger.info(
         "Starting monitoring dashboard on port %s for output directory: %s",

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -18,6 +18,7 @@ from krkn_ai.dashboard.data_loader import (
     load_health_check_csv,
     load_detailed_scenarios_data,
     load_logs,
+    load_population_lineage,
 )
 from krkn_ai.dashboard.tabs.dashboard import (
     render_summary,
@@ -33,6 +34,7 @@ from krkn_ai.dashboard.tabs.detailed_scenarios import render_detailed_scenarios
 from krkn_ai.dashboard.tabs.logs import render_logs
 from krkn_ai.dashboard.tabs.config import render_config
 from krkn_ai.dashboard.tabs.anomalies import render_anomalies
+from krkn_ai.dashboard.tabs.lineage import render_lineage
 from krkn_ai.dashboard.report_generator import generate_html_report
 
 logger = logging.getLogger(__name__)
@@ -136,12 +138,14 @@ def main():
         health_file_found, df_health = load_health_check_csv.__wrapped__(output_dir)
         df_details = load_detailed_scenarios_data.__wrapped__(output_dir)
         df_logs = load_logs.__wrapped__(output_dir)
+        df_lineage = load_population_lineage.__wrapped__(output_dir)
     else:
         results_file_found, df_results = load_results_csv(output_dir)
         config_data = load_config_yaml(output_dir)
         health_file_found, df_health = load_health_check_csv(output_dir)
         df_details = load_detailed_scenarios_data(output_dir)
         df_logs = load_logs(output_dir)
+        df_lineage = load_population_lineage(output_dir)
 
     # fully unfiltered copy (baseline row included) for anomaly detection
     df_results_all = df_results.copy() if df_results is not None else None
@@ -451,18 +455,21 @@ def main():
             use_container_width=True,
         )
 
-    # Tabs
-    tab1, tab2, tab3, tab4, tab5, tab6, tab7 = st.tabs(
-        [
-            "Dashboard",
-            "Health Checks",
-            "Detailed Scenarios",
-            "Anomalies",
-            "Logs",
-            "Configuration",
-            "Failed Scenarios",
-        ]
-    )
+    # Tabs — include Lineage only when data exists
+    has_lineage = df_lineage is not None and not df_lineage.empty
+    tab_names = [
+        "Dashboard",
+        "Health Checks",
+        "Detailed Scenarios",
+        "Anomalies",
+        "Logs",
+        "Configuration",
+        "Failed Scenarios",
+    ]
+    if has_lineage:
+        tab_names.append("Lineage")
+    tabs = st.tabs(tab_names)
+    tab1, tab2, tab3, tab4, tab5, tab6, tab7 = tabs[:7]
 
     with tab1:
         if not has_any_data:
@@ -557,6 +564,10 @@ def main():
 
     with tab7:
         render_generation_details(df_failed, title="Failed Scenarios")
+
+    if has_lineage:
+        with tabs[7]:
+            render_lineage(df_lineage)
 
     # Refresh mechanism
     if auto_refresh:

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -26,6 +26,27 @@ def load_results_csv(output_dir: str):
 
 
 @st.cache_data(ttl=300)
+def load_population_lineage(output_dir: str):
+    """Load population_lineage from results.json. Returns a DataFrame or None."""
+    results_path = os.path.join(output_dir, "results.json")
+    if not os.path.exists(results_path):
+        return None
+    try:
+        with open(results_path, "r") as f:
+            data = json.load(f)
+        lineage = data.get("population_lineage")
+        if not lineage:
+            return None
+        df = pd.DataFrame(lineage)
+        if df.empty or "origin" not in df.columns:
+            return None
+        return df
+    except Exception as e:
+        logging.error(f"Failed to load lineage from {results_path}: {e}")
+        return None
+
+
+@st.cache_data(ttl=300)
 def load_config_yaml(output_dir: str):
     config_path = os.path.join(output_dir, "krkn-ai.yaml")
     if os.path.exists(config_path):

--- a/krkn_ai/dashboard/tabs/lineage.py
+++ b/krkn_ai/dashboard/tabs/lineage.py
@@ -1,0 +1,216 @@
+"""
+Evolutionary Lineage Tab for Krkn-AI Dashboard.
+
+Shows how scenarios evolved across generations:
+  1. Origin distribution — donut chart of crossover / composition / mutation / initial.
+  2. Per-generation origin breakdown — stacked bar showing GA strategy over time.
+  3. Lineage explorer — trace a selected scenario back to its ancestors.
+"""
+
+from __future__ import annotations
+
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+
+_ORIGIN_COLORS = {
+    "initial": "#64748b",
+    "crossover": "#3b82f6",
+    "composition": "#8b5cf6",
+    "parameter_mutation": "#f59e0b",
+    "type_mutation": "#ef4444",
+}
+
+_ORIGIN_LABELS = {
+    "initial": "Initial",
+    "crossover": "Crossover",
+    "composition": "Composition",
+    "parameter_mutation": "Param Mutation",
+    "type_mutation": "Type Mutation",
+}
+
+
+def render_lineage(df_lineage):
+    st.header("Evolutionary Lineage")
+
+    if df_lineage is None or df_lineage.empty:
+        st.info("No lineage data available for this run.")
+        return
+
+    has_origin = "origin" in df_lineage.columns and df_lineage["origin"].notna().any()
+    if not has_origin:
+        st.info("Lineage origin data not recorded for this run.")
+        return
+
+    col_a, col_b = st.columns(2)
+    with col_a:
+        _render_origin_distribution(df_lineage)
+    with col_b:
+        _render_generation_breakdown(df_lineage)
+
+    st.divider()
+    _render_lineage_explorer(df_lineage)
+
+
+def _render_origin_distribution(df):
+    counts = df["origin"].value_counts()
+    labels = [_ORIGIN_LABELS.get(o, o) for o in counts.index]
+    colors = [_ORIGIN_COLORS.get(o, "#94a3b8") for o in counts.index]
+
+    fig = go.Figure(
+        go.Pie(
+            labels=labels,
+            values=counts.values,
+            hole=0.45,
+            marker=dict(colors=colors),
+            textinfo="label+percent",
+            hovertemplate="%{label}: %{value} scenarios (%{percent})<extra></extra>",
+        )
+    )
+    fig.update_layout(
+        title="Origin Distribution",
+        showlegend=False,
+        height=350,
+        margin=dict(t=40, b=20, l=20, r=20),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _render_generation_breakdown(df):
+    if "generation" not in df.columns:
+        st.write("No generation data available.")
+        return
+
+    grouped = df.groupby(["generation", "origin"]).size().reset_index(name="count")
+    grouped["generation_display"] = grouped["generation"] + 1
+    grouped["origin_label"] = grouped["origin"].map(lambda o: _ORIGIN_LABELS.get(o, o))
+
+    color_map = {_ORIGIN_LABELS.get(k, k): v for k, v in _ORIGIN_COLORS.items()}
+
+    fig = px.bar(
+        grouped,
+        x="generation_display",
+        y="count",
+        color="origin_label",
+        color_discrete_map=color_map,
+        title="GA Strategy per Generation",
+        labels={
+            "generation_display": "Generation",
+            "count": "Scenarios",
+            "origin_label": "Origin",
+        },
+    )
+    fig.update_layout(
+        barmode="stack",
+        xaxis=dict(tickmode="linear", tick0=1, dtick=1),
+        height=350,
+        margin=dict(t=40, b=20, l=20, r=20),
+        legend_title_text="Origin",
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+def _render_lineage_explorer(df):
+    st.subheader("Lineage Explorer")
+
+    if "scenario_uuid" not in df.columns or "parent_ids" not in df.columns:
+        st.info("Scenario UUID data not available for lineage tracing.")
+        return
+
+    uuid_to_row = {}
+    for _, row in df.iterrows():
+        uid = row.get("scenario_uuid")
+        if uid:
+            uuid_to_row[uid] = row
+
+    sorted_df = df.sort_values("fitness_score", ascending=False)
+    options = []
+    option_map = {}
+    for _, row in sorted_df.iterrows():
+        sid = row.get("scenario_id", "?")
+        gen = row.get("generation", "?")
+        score = row.get("fitness_score", 0)
+        uid = row.get("scenario_uuid", "")
+        label = f"Scenario {sid} (Gen {int(gen) + 1}, Fitness {score:.2f})"
+        options.append(label)
+        option_map[label] = uid
+
+    if not options:
+        st.info("No scenarios to explore.")
+        return
+
+    selected = st.selectbox("Select a scenario to trace its lineage:", options)
+    selected_uuid = option_map.get(selected)
+    if not selected_uuid:
+        return
+
+    chain = _build_ancestry_chain(selected_uuid, uuid_to_row)
+
+    if len(chain) <= 1:
+        st.caption("This is an initial scenario with no ancestors.")
+
+    for i, node in enumerate(chain):
+        origin = node.get("origin", "unknown")
+        origin_label = _ORIGIN_LABELS.get(origin, origin or "—")
+        gen = node.get("generation", "?")
+        gen_display = int(gen) + 1 if gen != "?" else "?"
+        score = node.get("fitness_score", 0)
+        sid = node.get("scenario_id", "?")
+
+        prefix = "**Selected** | " if i == 0 else ""
+        parents = node.get("parent_ids", [])
+        parent_hint = ""
+        if parents and isinstance(parents, list) and len(parents) > 0:
+            parent_sids = []
+            for pid in parents:
+                prow = uuid_to_row.get(pid)
+                if prow is not None:
+                    parent_sids.append(str(prow.get("scenario_id", pid[:8])))
+                else:
+                    parent_sids.append(pid[:8] + "...")
+            parent_hint = f" | Parents: {', '.join(parent_sids)}"
+
+        st.markdown(
+            f":{_origin_to_streamlit_color(origin)}[**Gen {gen_display}**] "
+            f"{prefix}Scenario {sid} — "
+            f"Fitness **{score:.2f}** — "
+            f"Origin: {origin_label}{parent_hint}"
+        )
+
+        if i < len(chain) - 1:
+            st.markdown(
+                "<div style='border-left: 2px solid #475569; height: 16px; "
+                "margin-left: 24px;'></div>",
+                unsafe_allow_html=True,
+            )
+
+
+def _build_ancestry_chain(start_uuid, uuid_to_row, max_depth=20):
+    chain = []
+    current = start_uuid
+    visited = set()
+
+    for _ in range(max_depth):
+        if current in visited or current not in uuid_to_row:
+            break
+        visited.add(current)
+        row = uuid_to_row[current]
+        chain.append(row.to_dict())
+
+        parents = row.get("parent_ids", [])
+        if not parents or not isinstance(parents, list) or len(parents) == 0:
+            break
+        current = parents[0]
+
+    return chain
+
+
+def _origin_to_streamlit_color(origin):
+    return {
+        "initial": "gray",
+        "crossover": "blue",
+        "composition": "violet",
+        "parameter_mutation": "orange",
+        "type_mutation": "red",
+    }.get(origin, "gray")

--- a/krkn_ai/models/scenario/base.py
+++ b/krkn_ai/models/scenario/base.py
@@ -1,7 +1,18 @@
+import uuid
 from enum import Enum
-from pydantic import BaseModel, PrivateAttr
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, Field, PrivateAttr
+
 from krkn_ai.models.cluster_components import ClusterComponents
-from typing import Any
+
+
+class ScenarioOrigin(str, Enum):
+    INITIAL = "initial"
+    CROSSOVER = "crossover"
+    COMPOSITION = "composition"
+    PARAMETER_MUTATION = "parameter_mutation"
+    TYPE_MUTATION = "type_mutation"
 
 
 class BaseParameter(BaseModel):
@@ -20,9 +31,12 @@ class BaseParameter(BaseModel):
 
 
 class BaseScenario(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     krknctl_name: str  # Name of the scenario in krknctl
     krknhub_image: str  # Image of the scenario in krknhub
+    parent_ids: List[str] = Field(default_factory=list)
+    origin: Optional[ScenarioOrigin] = None
 
 
 class Scenario(BaseScenario):

--- a/krkn_ai/reporter/json_summary_reporter.py
+++ b/krkn_ai/reporter/json_summary_reporter.py
@@ -120,6 +120,7 @@ class JSONSummaryReporter:
             },
             "best_scenarios": best_scenarios,
             "fitness_progression": fitness_progression,
+            "population_lineage": self._build_population_lineage(),
         }
 
         if self.baseline_result is not None:
@@ -180,6 +181,23 @@ class JSONSummaryReporter:
                 }
             )
         return best_scenarios
+
+    def _build_population_lineage(self) -> List[Dict[str, Any]]:
+        """Build evolutionary lineage from scenario provenance in seen_population."""
+        lineage = []
+        for result in self.seen_population.values():
+            scenario = result.scenario
+            lineage.append(
+                {
+                    "scenario_id": result.scenario_id,
+                    "scenario_uuid": getattr(scenario, "id", None),
+                    "generation": result.generation_id,
+                    "fitness_score": result.fitness_result.fitness_score,
+                    "parent_ids": getattr(scenario, "parent_ids", []),
+                    "origin": getattr(scenario, "origin", None),
+                }
+            )
+        return lineage
 
     def save(self, output_dir: str):
         """

--- a/krkn_ai/utils/mock.py
+++ b/krkn_ai/utils/mock.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import Dict, List
+
+from krkn_ai.utils.fs import env_is_truthy
+from krkn_ai.utils.rng import rng
+
+
+class MockType(str, Enum):
+    RUN = "MOCK_RUN"
+    FITNESS = "MOCK_FITNESS"
+    HEALTH_CHECK = "MOCK_HEALTH_CHECK"
+
+
+_GLOBAL_VAR = "MOCK"
+
+
+def is_mock_enabled(mock_type: MockType) -> bool:
+    return env_is_truthy(_GLOBAL_VAR) or env_is_truthy(mock_type.value)
+
+
+def generate_mock_health_check_results(
+    health_check_config, sample_count: int = 5
+) -> Dict[str, List]:
+    from krkn_ai.models.config import HealthCheckResult
+
+    results: Dict[str, List] = {}
+    for app in health_check_config.applications:
+        samples = []
+        for _ in range(sample_count):
+            success = rng.random() > 0.1
+            samples.append(
+                HealthCheckResult(
+                    name=app.name,
+                    status_code=app.status_code if success else 503,
+                    success=success,
+                    response_time=rng.uniform(0.01, 0.5) if success else -1,
+                    error=None if success else "mock: service unavailable",
+                )
+            )
+        results[str(app.url)] = samples
+    return results

--- a/krkn_ai/utils/prometheus.py
+++ b/krkn_ai/utils/prometheus.py
@@ -1,7 +1,7 @@
 import os
 from kubernetes import client, config
 from krkn_lib.prometheus.krkn_prometheus import KrknPrometheus
-from krkn_ai.utils.fs import env_is_truthy
+from krkn_ai.utils.mock import MockType, is_mock_enabled
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.models.custom_errors import PrometheusConnectionError
 
@@ -175,7 +175,7 @@ def _validate_and_create_client(url: str, token: str) -> KrknPrometheus:
     try:
         client = KrknPrometheus(url.strip(), token.strip())
         # Connection test: run a dummy query unless in mock mode
-        if not env_is_truthy("MOCK_FITNESS"):
+        if not is_mock_enabled(MockType.FITNESS):
             client.process_query("1")
         return client
     except Exception as e:

--- a/tests/unit/algorithm/test_lineage.py
+++ b/tests/unit/algorithm/test_lineage.py
@@ -1,0 +1,63 @@
+"""
+Evolutionary lineage tracking tests
+"""
+
+from unittest.mock import patch
+
+from krkn_ai.algorithm.genetic.engine import GeneticAlgorithm
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.scenario.base import ScenarioOrigin
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
+
+
+class TestTagLineage:
+    """Test _tag_lineage helper"""
+
+    def test_tag_lineage_sets_fields(self, genetic_algorithm):
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        original_id = scenario.id
+
+        GeneticAlgorithm._tag_lineage(
+            scenario, ["parent-a", "parent-b"], ScenarioOrigin.CROSSOVER
+        )
+
+        assert scenario.id != original_id
+        assert scenario.parent_ids == ["parent-a", "parent-b"]
+        assert scenario.origin == ScenarioOrigin.CROSSOVER
+
+    def test_tag_lineage_assigns_unique_ids(self, genetic_algorithm):
+        s1 = DummyScenario(cluster_components=ClusterComponents())
+        s2 = DummyScenario(cluster_components=ClusterComponents())
+
+        GeneticAlgorithm._tag_lineage(s1, [], ScenarioOrigin.COMPOSITION)
+        GeneticAlgorithm._tag_lineage(s2, [], ScenarioOrigin.COMPOSITION)
+
+        assert s1.id != s2.id
+
+
+class TestInitialPopulationLineage:
+    """Test that create_population tags scenarios with INITIAL origin"""
+
+    def test_initial_population_has_initial_origin(self, genetic_algorithm):
+        mock_scenario = DummyScenario(cluster_components=ClusterComponents())
+
+        with patch(
+            "krkn_ai.algorithm.genetic.engine.ScenarioFactory.generate_random_scenario"
+        ) as mock_gen:
+            mock_gen.return_value = mock_scenario
+            population = genetic_algorithm.create_population(4)
+
+        for scenario in population:
+            assert scenario.origin == ScenarioOrigin.INITIAL
+
+    def test_initial_population_has_no_parents(self, genetic_algorithm):
+        mock_scenario = DummyScenario(cluster_components=ClusterComponents())
+
+        with patch(
+            "krkn_ai.algorithm.genetic.engine.ScenarioFactory.generate_random_scenario"
+        ) as mock_gen:
+            mock_gen.return_value = mock_scenario
+            population = genetic_algorithm.create_population(4)
+
+        for scenario in population:
+            assert scenario.parent_ids == []

--- a/tests/unit/algorithm/test_lineage.py
+++ b/tests/unit/algorithm/test_lineage.py
@@ -34,6 +34,33 @@ class TestTagLineage:
 
         assert s1.id != s2.id
 
+    def test_tag_lineage_copies_parent_ids(self, genetic_algorithm):
+        s1 = DummyScenario(cluster_components=ClusterComponents())
+        s2 = DummyScenario(cluster_components=ClusterComponents())
+        shared_ids = ["parent-a", "parent-b"]
+
+        GeneticAlgorithm._tag_lineage(s1, shared_ids, ScenarioOrigin.CROSSOVER)
+        GeneticAlgorithm._tag_lineage(s2, shared_ids, ScenarioOrigin.CROSSOVER)
+
+        assert s1.parent_ids is not s2.parent_ids
+        assert s1.parent_ids == s2.parent_ids
+
+    def test_tag_lineage_preserves_mutation_origin(self, genetic_algorithm):
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        scenario.origin = ScenarioOrigin.TYPE_MUTATION
+
+        GeneticAlgorithm._tag_lineage(scenario, ["p1"], ScenarioOrigin.CROSSOVER)
+
+        assert scenario.origin == ScenarioOrigin.TYPE_MUTATION
+
+    def test_tag_lineage_sets_origin_when_none(self, genetic_algorithm):
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        assert scenario.origin is None
+
+        GeneticAlgorithm._tag_lineage(scenario, ["p1"], ScenarioOrigin.COMPOSITION)
+
+        assert scenario.origin == ScenarioOrigin.COMPOSITION
+
 
 class TestInitialPopulationLineage:
     """Test that create_population tags scenarios with INITIAL origin"""

--- a/tests/unit/chaos_engines/test_fitness.py
+++ b/tests/unit/chaos_engines/test_fitness.py
@@ -307,7 +307,7 @@ class TestCalculateFitnessValueRetries:
     """Test calculate_fitness_value retry behavior with empty Prometheus data"""
 
     @patch("krkn_ai.chaos_engines.fitness.time.sleep")
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy", return_value=False)
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled", return_value=False)
     def test_calculate_fitness_value_does_not_retry_multi_series_error(
         self, mock_env, mock_sleep, mock_prom_client
     ):
@@ -339,7 +339,7 @@ class TestCalculateFitnessValueRetries:
         mock_sleep.assert_not_called()
 
     @patch("krkn_ai.chaos_engines.fitness.time.sleep")
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy", return_value=False)
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled", return_value=False)
     def test_calculate_fitness_value_retries_on_empty_data(
         self, mock_env, mock_sleep, mock_prom_client
     ):
@@ -369,7 +369,7 @@ class TestCalculateFitnessValueRetries:
         assert mock_prom_client.process_prom_query_in_range.call_count == 4
 
     @patch("krkn_ai.chaos_engines.fitness.time.sleep")
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy", return_value=False)
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled", return_value=False)
     def test_calculate_fitness_value_raises_after_retries_exhausted(
         self, mock_env, mock_sleep, mock_prom_client
     ):

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -65,7 +65,7 @@ class TestKrknRunnerInitialization:
 class TestKrknRunnerRun:
     """Test KrknRunner.run method core behavior"""
 
-    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=True)
+    @patch("krkn_ai.chaos_engines.krkn_runner.is_mock_enabled", return_value=True)
     @patch("krkn_ai.chaos_engines.krkn_runner.run_shell")
     def test_run_scenario_with_mock_mode(
         self, mock_run_shell, mock_env, minimal_config, temp_output_dir
@@ -92,7 +92,7 @@ class TestKrknRunnerRun:
             assert isinstance(result.start_time, datetime.datetime)
             assert isinstance(result.end_time, datetime.datetime)
 
-    @patch("krkn_ai.chaos_engines.krkn_runner.env_is_truthy", return_value=False)
+    @patch("krkn_ai.chaos_engines.krkn_runner.is_mock_enabled", return_value=False)
     @patch("krkn_ai.chaos_engines.krkn_runner.run_shell")
     def test_run_handles_misconfiguration_failure(
         self, mock_run_shell, mock_env, minimal_config, temp_output_dir

--- a/tests/unit/chaos_engines/test_krkn_runner.py
+++ b/tests/unit/chaos_engines/test_krkn_runner.py
@@ -65,18 +65,14 @@ class TestKrknRunnerInitialization:
 class TestKrknRunnerRun:
     """Test KrknRunner.run method core behavior"""
 
-    @patch("krkn_ai.chaos_engines.krkn_runner.is_mock_enabled", return_value=True)
-    @patch("krkn_ai.chaos_engines.krkn_runner.run_shell")
-    def test_run_scenario_with_mock_mode(
-        self, mock_run_shell, mock_env, minimal_config, temp_output_dir
-    ):
+    def test_run_scenario_with_mock_mode(self, minimal_config, temp_output_dir):
         """Test running scenario in mock mode returns successful result"""
         minimal_config.fitness_function = FitnessFunction(
             query="test_query", type=FitnessFunctionType.point
         )
         minimal_config.health_checks = HealthCheckConfig()
 
-        with patch("krkn_ai.chaos_engines.krkn_runner.create_prometheus_client"):
+        with patch.dict(os.environ, {"MOCK": "true"}):
             runner = KrknRunner(
                 config=minimal_config,
                 output_dir=temp_output_dir,

--- a/tests/unit/chaos_engines/test_preflight.py
+++ b/tests/unit/chaos_engines/test_preflight.py
@@ -13,7 +13,7 @@ class TestPreflightCheck:
 
         self.mock_prom_client = MagicMock()
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_mock_fitness_skips_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = True
         fitness_function = FitnessFunction(query="up")
@@ -23,7 +23,7 @@ class TestPreflightCheck:
 
         self.mock_prom_client.process_prom_query_in_range.assert_not_called()
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_valid_query_passes_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = [
@@ -40,7 +40,7 @@ class TestPreflightCheck:
         assert args[0] == "up"
         assert kwargs["granularity"] == 100
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_range_variable_substituted(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = [
@@ -55,7 +55,7 @@ class TestPreflightCheck:
         args, _ = self.mock_prom_client.process_prom_query_in_range.call_args
         assert args[0] == "sum(rate(up[5m]))"
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_empty_results_raises_error(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = []
@@ -68,7 +68,7 @@ class TestPreflightCheck:
 
         assert self.mock_prom_client.process_prom_query_in_range.call_count == 3
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_multiple_series_raises_error(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = [
@@ -84,7 +84,7 @@ class TestPreflightCheck:
         ):
             calculator.preflight_check()
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_validates_multiple_items(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = [
@@ -101,7 +101,7 @@ class TestPreflightCheck:
 
         assert self.mock_prom_client.process_prom_query_in_range.call_count == 2
 
-    @patch("krkn_ai.chaos_engines.fitness.env_is_truthy")
+    @patch("krkn_ai.chaos_engines.fitness.is_mock_enabled")
     def test_empty_query_fails_preflight(self, mock_env_is_truthy):
         mock_env_is_truthy.return_value = False
         self.mock_prom_client.process_prom_query_in_range.return_value = []

--- a/tests/unit/dashboard/tabs/test_lineage.py
+++ b/tests/unit/dashboard/tabs/test_lineage.py
@@ -1,0 +1,140 @@
+"""
+Lineage dashboard tab unit tests
+"""
+
+import pandas as pd
+
+from krkn_ai.dashboard.tabs.lineage import (
+    _build_ancestry_chain,
+    _origin_to_streamlit_color,
+)
+
+
+class TestBuildAncestryChain:
+    def _make_uuid_map(self, rows):
+        df = pd.DataFrame(rows)
+        return {row["scenario_uuid"]: df.iloc[i] for i, row in df.iterrows()}
+
+    def test_single_initial_scenario(self):
+        uuid_map = self._make_uuid_map(
+            [
+                {
+                    "scenario_uuid": "a",
+                    "parent_ids": [],
+                    "origin": "initial",
+                    "generation": 0,
+                    "fitness_score": 1.0,
+                    "scenario_id": 0,
+                },
+            ]
+        )
+        chain = _build_ancestry_chain("a", uuid_map)
+        assert len(chain) == 1
+        assert chain[0]["scenario_uuid"] == "a"
+
+    def test_follows_first_parent(self):
+        uuid_map = self._make_uuid_map(
+            [
+                {
+                    "scenario_uuid": "c",
+                    "parent_ids": ["b", "a"],
+                    "origin": "crossover",
+                    "generation": 2,
+                    "fitness_score": 3.0,
+                    "scenario_id": 2,
+                },
+                {
+                    "scenario_uuid": "b",
+                    "parent_ids": ["a"],
+                    "origin": "crossover",
+                    "generation": 1,
+                    "fitness_score": 2.0,
+                    "scenario_id": 1,
+                },
+                {
+                    "scenario_uuid": "a",
+                    "parent_ids": [],
+                    "origin": "initial",
+                    "generation": 0,
+                    "fitness_score": 1.0,
+                    "scenario_id": 0,
+                },
+            ]
+        )
+        chain = _build_ancestry_chain("c", uuid_map)
+        assert len(chain) == 3
+        assert [n["scenario_uuid"] for n in chain] == ["c", "b", "a"]
+
+    def test_stops_at_max_depth(self):
+        rows = []
+        for i in range(10):
+            rows.append(
+                {
+                    "scenario_uuid": str(i),
+                    "parent_ids": [str(i - 1)] if i > 0 else [],
+                    "origin": "crossover" if i > 0 else "initial",
+                    "generation": i,
+                    "fitness_score": float(i),
+                    "scenario_id": i,
+                }
+            )
+        uuid_map = self._make_uuid_map(rows)
+        chain = _build_ancestry_chain("9", uuid_map, max_depth=3)
+        assert len(chain) == 3
+
+    def test_handles_cycle(self):
+        uuid_map = self._make_uuid_map(
+            [
+                {
+                    "scenario_uuid": "a",
+                    "parent_ids": ["b"],
+                    "origin": "crossover",
+                    "generation": 0,
+                    "fitness_score": 1.0,
+                    "scenario_id": 0,
+                },
+                {
+                    "scenario_uuid": "b",
+                    "parent_ids": ["a"],
+                    "origin": "crossover",
+                    "generation": 1,
+                    "fitness_score": 2.0,
+                    "scenario_id": 1,
+                },
+            ]
+        )
+        chain = _build_ancestry_chain("a", uuid_map)
+        assert len(chain) == 2
+
+    def test_missing_parent_stops_chain(self):
+        uuid_map = self._make_uuid_map(
+            [
+                {
+                    "scenario_uuid": "b",
+                    "parent_ids": ["missing"],
+                    "origin": "crossover",
+                    "generation": 1,
+                    "fitness_score": 2.0,
+                    "scenario_id": 1,
+                },
+            ]
+        )
+        chain = _build_ancestry_chain("b", uuid_map)
+        assert len(chain) == 1
+
+    def test_unknown_start_returns_empty(self):
+        chain = _build_ancestry_chain("nonexistent", {})
+        assert chain == []
+
+
+class TestOriginToStreamlitColor:
+    def test_known_origins(self):
+        assert _origin_to_streamlit_color("initial") == "gray"
+        assert _origin_to_streamlit_color("crossover") == "blue"
+        assert _origin_to_streamlit_color("composition") == "violet"
+        assert _origin_to_streamlit_color("parameter_mutation") == "orange"
+        assert _origin_to_streamlit_color("type_mutation") == "red"
+
+    def test_unknown_origin_defaults_to_gray(self):
+        assert _origin_to_streamlit_color("something_else") == "gray"
+        assert _origin_to_streamlit_color(None) == "gray"

--- a/tests/unit/reporter/test_json_summary_reporter.py
+++ b/tests/unit/reporter/test_json_summary_reporter.py
@@ -8,6 +8,7 @@ import datetime
 
 from krkn_ai.reporter.json_summary_reporter import JSONSummaryReporter
 from krkn_ai.models.app import CommandRunResult, FitnessResult
+from krkn_ai.models.scenario.base import ScenarioOrigin
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 
 
@@ -189,3 +190,72 @@ class TestJSONSummaryReporter:
         with open(path, "r") as f:
             saved_content = json.load(f)
             assert saved_content == expected_summary
+
+    def test_population_lineage_in_summary(self, minimal_config):
+        """Test that population_lineage is built from scenario provenance"""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cc = minimal_config.cluster_components
+        scenario = DummyScenario(cluster_components=cc)
+        scenario.parent_ids = ["parent-a", "parent-b"]
+        scenario.origin = ScenarioOrigin.CROSSOVER
+
+        res = CommandRunResult(
+            generation_id=1,
+            scenario_id=42,
+            scenario=scenario,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=75.0),
+        )
+
+        reporter = JSONSummaryReporter(
+            run_uuid="lineage-test",
+            config=minimal_config,
+            algo_config=minimal_config.genetic,
+            seen_population={42: res},
+            best_of_generation=[],
+        )
+
+        lineage = reporter.generate_summary()["population_lineage"]
+        assert len(lineage) == 1
+        node = lineage[0]
+        assert node["scenario_id"] == 42
+        assert node["scenario_uuid"] == scenario.id
+        assert node["generation"] == 1
+        assert node["fitness_score"] == 75.0
+        assert node["parent_ids"] == ["parent-a", "parent-b"]
+        assert node["origin"] == ScenarioOrigin.CROSSOVER
+
+    def test_population_lineage_empty_for_initial_scenarios(self, minimal_config):
+        """Test that initial scenarios have no parent_ids"""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cc = minimal_config.cluster_components
+        scenario = DummyScenario(cluster_components=cc)
+        scenario.origin = ScenarioOrigin.INITIAL
+
+        res = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="test",
+            log="test",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=30.0),
+        )
+
+        reporter = JSONSummaryReporter(
+            run_uuid="initial-test",
+            config=minimal_config,
+            algo_config=minimal_config.genetic,
+            seen_population={1: res},
+            best_of_generation=[],
+        )
+
+        node = reporter.generate_summary()["population_lineage"][0]
+        assert node["parent_ids"] == []
+        assert node["origin"] == ScenarioOrigin.INITIAL


### PR DESCRIPTION
## Summary

- Add `ScenarioOrigin` enum and lineage fields (`id`, `parent_ids`, `origin`) to `BaseScenario` so every scenario carries its evolutionary provenance
- Tag lineage in the GA engine at orchestration level — after crossover/composition + mutation — via `_tag_lineage()` static method
- Emit `population_lineage` array in `results.json` through `JSONSummaryReporter`
- Add conditional **Lineage** dashboard tab (only shown when lineage data exists) with:
  - Origin distribution donut chart
  - Per-generation stacked bar showing GA strategy mix over time
  - Lineage explorer — select a scenario (sorted by fitness) and trace its ancestry chain

Fixes https://github.com/krkn-chaos/krkn-ai/issues/426

## Test plan

- [x] Unit tests for `_tag_lineage` helper (sets fields, assigns unique IDs)
- [x] Unit tests for `create_population` tagging `INITIAL` origin with no parents
- [x] Unit tests for `population_lineage` in reporter summary (crossover + initial scenarios)
- [ ] Run GA end-to-end and verify `population_lineage` in `results.json`
- [ ] Launch dashboard against a run with lineage data — confirm Lineage tab appears with all 3 visualizations
- [ ] Launch dashboard against a run without lineage data — confirm Lineage tab is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)