### PR TITLE
feat: Fitness Function Improvements

### DIFF
--- a/krkn_ai/algorithm/base.py
+++ b/krkn_ai/algorithm/base.py
@@ -17,6 +17,8 @@ from krkn_ai.utils.elastic_client import ElasticSearchClient
 from krkn_ai.utils.logger import get_logger
 from krkn_ai.utils.output import format_result_filename
 from krkn_ai.utils.rng import rng
+from krkn_ai.chaos_engines.health_check_watcher import compute_baseline_response_stats
+
 
 logger = get_logger(__name__)
 
@@ -83,6 +85,13 @@ class BaseEngine(ABC):
         self.baseline_result = self.krkn_client.run(baseline_scenario, 0)
         self.baseline_result.scenario_id = "baseline"
 
+        if self.config.fitness_function.include_health_check_response_time:
+            stats = compute_baseline_response_stats(
+                self.baseline_result.health_check_results
+            )
+            self.krkn_client.set_baseline_response_stats(stats)
+            logger.info("Baseline response stats computed for %d URLs", len(stats))
+
         self.save_scenario_result(self.baseline_result)
         self.health_check_reporter.plot_report(self.baseline_result)
         self.health_check_reporter.write_fitness_result(self.baseline_result)
@@ -126,6 +135,11 @@ class BaseEngine(ABC):
         with open(log_save_path, "w", encoding="utf-8") as f:
             f.write(command_result.log)
         return log_save_path
+
+    def update_scenario_results(self, results: list) -> None:
+        """Re-save scenario result files after in-place mutation (e.g. normalization)."""
+        for result in results:
+            self.save_scenario_result(result)
 
     def save_scenario_result(self, fitness_result: CommandRunResult):
         logger.debug(

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -27,6 +27,7 @@ from krkn_ai.utils.output import format_duration
 from krkn_ai.utils.rng import rng
 from krkn_ai.utils.weight_learning import learn_weights, save_learned_weights
 from krkn_ai.chaos_engines.fitness import normalize_generation_scores
+from krkn_ai.utils.console import print_generation_table, print_run_summary
 
 LEARNED_WEIGHTS_FILE = "learned_weights.json"
 
@@ -105,14 +106,13 @@ class GeneticAlgorithm(BaseEngine):
                     format_duration(remaining_time),
                 )
 
-            logger.info("| Population |")
-            logger.info("--------------------------------------------------------")
-            for scenario in self.population:
-                logger.info("%s, ", scenario)
-            logger.info("--------------------------------------------------------")
-
-            logger.info("| Generation %d |", cur_generation + 1)
-            logger.info("--------------------------------------------------------")
+            logger.info(
+                "Generation %d — %d scenarios",
+                cur_generation + 1,
+                len(self.population),
+            )
+            for i, scenario in enumerate(self.population):
+                logger.debug("  [%d] %s", i, scenario)
 
             fitness_scores = [
                 self.calculate_fitness(member, cur_generation)
@@ -132,9 +132,7 @@ class GeneticAlgorithm(BaseEngine):
                 reverse=True,
             )
             self.best_of_generation.append(fitness_scores[0])
-            logger.info(
-                "Best Fitness: %f", fitness_scores[0].fitness_result.fitness_score
-            )
+            print_generation_table(cur_generation, fitness_scores)
 
             self.adapt_mutation_rate()
 
@@ -192,12 +190,8 @@ class GeneticAlgorithm(BaseEngine):
         if should_stop:
             self.end_time = datetime.datetime.now(datetime.timezone.utc)
             logger.info("Stopping algorithm: %s", reason)
-            logger.info(
-                "Completed %d generations in %s",
-                cur_generation,
-                format_duration(elapsed_time),
-            )
             self.completed_generations = cur_generation
+            print_run_summary(self.best_of_generation, cur_generation, elapsed_time)
             return True
         return False
 

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -120,11 +120,17 @@ class GeneticAlgorithm(BaseEngine):
             ]
 
             if len(self.config.fitness_function.items) > 0:
+                to_normalize = list(fitness_scores)
+                if cur_generation == 0 and self.baseline_result is not None:
+                    to_normalize.append(self.baseline_result)
+
                 normalize_generation_scores(
-                    fitness_scores, self.config.fitness_function.items
+                    to_normalize,
+                    self.config.fitness_function.items,
+                    self.config.fitness_function.num_components,
                 )
-                self.health_check_reporter.update_normalized_scores(fitness_scores)
-                self.update_scenario_results(fitness_scores)
+                self.health_check_reporter.update_normalized_scores(to_normalize)
+                self.update_scenario_results(to_normalize)
 
             fitness_scores = sorted(
                 fitness_scores,
@@ -132,11 +138,7 @@ class GeneticAlgorithm(BaseEngine):
                 reverse=True,
             )
             self.best_of_generation.append(fitness_scores[0])
-            print_generation_table(
-                cur_generation,
-                fitness_scores,
-                self.config.fitness_function.num_components,
-            )
+            print_generation_table(cur_generation, fitness_scores)
 
             self.adapt_mutation_rate()
 
@@ -199,7 +201,6 @@ class GeneticAlgorithm(BaseEngine):
                 self.best_of_generation,
                 cur_generation,
                 elapsed_time,
-                self.config.fitness_function.num_components,
             )
             return True
         return False

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -132,7 +132,11 @@ class GeneticAlgorithm(BaseEngine):
                 reverse=True,
             )
             self.best_of_generation.append(fitness_scores[0])
-            print_generation_table(cur_generation, fitness_scores)
+            print_generation_table(
+                cur_generation,
+                fitness_scores,
+                self.config.fitness_function.num_components,
+            )
 
             self.adapt_mutation_rate()
 
@@ -191,7 +195,12 @@ class GeneticAlgorithm(BaseEngine):
             self.end_time = datetime.datetime.now(datetime.timezone.utc)
             logger.info("Stopping algorithm: %s", reason)
             self.completed_generations = cur_generation
-            print_run_summary(self.best_of_generation, cur_generation, elapsed_time)
+            print_run_summary(
+                self.best_of_generation,
+                cur_generation,
+                elapsed_time,
+                self.config.fitness_function.num_components,
+            )
             return True
         return False
 

--- a/krkn_ai/algorithm/genetic/engine.py
+++ b/krkn_ai/algorithm/genetic/engine.py
@@ -26,6 +26,7 @@ from krkn_ai.utils.logger import get_logger
 from krkn_ai.utils.output import format_duration
 from krkn_ai.utils.rng import rng
 from krkn_ai.utils.weight_learning import learn_weights, save_learned_weights
+from krkn_ai.chaos_engines.fitness import normalize_generation_scores
 
 LEARNED_WEIGHTS_FILE = "learned_weights.json"
 
@@ -117,6 +118,14 @@ class GeneticAlgorithm(BaseEngine):
                 self.calculate_fitness(member, cur_generation)
                 for member in self.population
             ]
+
+            if len(self.config.fitness_function.items) > 0:
+                normalize_generation_scores(
+                    fitness_scores, self.config.fitness_function.items
+                )
+                self.health_check_reporter.update_normalized_scores(fitness_scores)
+                self.update_scenario_results(fitness_scores)
+
             fitness_scores = sorted(
                 fitness_scores,
                 key=lambda x: x.fitness_result.fitness_score,

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -119,7 +119,8 @@ class FitnessCalculator:
     def calculate_fitness_value(self, start, end, query, fitness_type):
         """Calculate fitness score for scenario run"""
         if is_mock_enabled(MockType.FITNESS):
-            return rng.random()
+            scale = rng.choice([1.0, 1e3, 1e6, 1e9])
+            return rng.random() * scale
 
         retries = 3
         retry_delay = 10

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -1,10 +1,11 @@
 import math
 import datetime
 import time
-from typing import Iterable, List
+from collections import defaultdict
+from typing import Dict, Iterable, List
 
-from krkn_ai.models.app import FitnessResult, FitnessScoreResult
-from krkn_ai.models.config import FitnessFunctionType
+from krkn_ai.models.app import CommandRunResult, FitnessResult, FitnessScoreResult
+from krkn_ai.models.config import FitnessFunctionItem, FitnessFunctionType
 from krkn_ai.models.custom_errors import (
     FitnessFunctionCalculationError,
     FitnessFunctionConfigurationError,
@@ -251,4 +252,59 @@ class FitnessCalculator:
                 f"range fitness [{start}, {end}]",
                 no_data_error,
             )
+        )
+
+
+def _log_transform(x: float) -> float:
+    return math.copysign(math.log1p(abs(x)), x)
+
+
+def normalize_generation_scores(
+    results: List[CommandRunResult],
+    fitness_items: List[FitnessFunctionItem],
+) -> None:
+    """Apply log + per-generation min-max normalization to Prometheus scores.
+
+    Mutates results in-place.  Skips misconfiguration results (fitness == -1).
+    """
+    valid = [
+        r
+        for r in results
+        if r.fitness_result.scores and r.fitness_result.fitness_score != -1.0
+    ]
+    if len(valid) < 2:
+        return
+
+    by_item: Dict[int, List[FitnessScoreResult]] = defaultdict(list)
+    for r in valid:
+        for s in r.fitness_result.scores:
+            by_item[s.id].append(s)
+
+    for item_id, score_entries in by_item.items():
+        log_values = [_log_transform(s.fitness_score) for s in score_entries]
+        lo = min(log_values)
+        hi = max(log_values)
+
+        for s, lv in zip(score_entries, log_values):
+            if hi == lo:
+                s.normalized_score = 0.5
+            else:
+                s.normalized_score = (lv - lo) / (hi - lo)
+
+    weights = normalize_weights(item.weight for item in fitness_items)
+    item_weight = {item.id: w for item, w in zip(fitness_items, weights)}
+
+    for r in valid:
+        for s in r.fitness_result.scores:
+            ns = s.normalized_score if s.normalized_score is not None else 0.0
+            s.weighted_score = item_weight.get(s.id, 0.0) * ns
+
+        prometheus_score = sum(s.weighted_score for s in r.fitness_result.scores)
+        r.fitness_result.fitness_score = sum(
+            [
+                prometheus_score,
+                r.fitness_result.krkn_failure_score,
+                r.fitness_result.health_check_failure_score,
+                r.fitness_result.health_check_response_time_score,
+            ]
         )

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -263,6 +263,7 @@ def _log_transform(x: float) -> float:
 def normalize_generation_scores(
     results: List[CommandRunResult],
     fitness_items: List[FitnessFunctionItem],
+    num_components: int = 4,
 ) -> None:
     """Apply log + per-generation min-max normalization to Prometheus scores.
 
@@ -301,11 +302,14 @@ def normalize_generation_scores(
             s.weighted_score = item_weight.get(s.id, 0.0) * ns
 
         prometheus_score = sum(s.weighted_score for s in r.fitness_result.scores)
-        r.fitness_result.fitness_score = sum(
+        raw_total = sum(
             [
                 prometheus_score,
                 r.fitness_result.krkn_failure_score,
                 r.fitness_result.health_check_failure_score,
                 r.fitness_result.health_check_response_time_score,
             ]
+        )
+        r.fitness_result.fitness_score = (
+            (raw_total / num_components * 100) if num_components else 0.0
         )

--- a/krkn_ai/chaos_engines/fitness.py
+++ b/krkn_ai/chaos_engines/fitness.py
@@ -289,7 +289,7 @@ def normalize_generation_scores(
 
         for s, lv in zip(score_entries, log_values):
             if hi == lo:
-                s.normalized_score = 0.5
+                s.normalized_score = 0.0
             else:
                 s.normalized_score = (lv - lo) / (hi - lo)
 

--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -166,7 +166,7 @@ class HealthCheckWatcher:
                 current_streak = 0
         streak_ratio = max_streak / total
 
-        score = (failure_rate + streak_ratio) * 5.0
+        score = (failure_rate + streak_ratio) / 2.0
         logger.debug(
             "Health check failure score: %.3f (rate=%.3f, streak=%d/%d)",
             score,
@@ -187,13 +187,13 @@ class HealthCheckWatcher:
         Primary signal (always computed):
           CV  = stddev / mean  (relative variability)
           jitter = mean(|rt[i+1] - rt[i]|) / mean  (oscillation)
-          variability_score = min((CV + jitter) * 2.5, 10)
+          variability_score = min((CV + jitter) * 0.25, 1.0)
 
         Additive bonus (when baseline_stats has data for the URL):
           degradation = (scenario_median - baseline_median) / max(MAD, 0.001)
-          bonus = clamp(degradation, 0, 10)
+          bonus = clamp(degradation, 0, 1)
 
-        Returns the average per-URL score, capped at [0, 10].
+        Returns the average per-URL score, capped at [0, 1].
         """
         url_scores: List[float] = []
 
@@ -213,7 +213,7 @@ class HealthCheckWatcher:
             cv = float(np.std(arr)) / mean_rt
             diffs = np.abs(np.diff(arr))
             jitter = float(np.mean(diffs)) / mean_rt if len(diffs) > 0 else 0.0
-            variability_score = min((cv + jitter) * 2.5, 10.0)
+            variability_score = min((cv + jitter) * 0.25, 1.0)
 
             url_score = variability_score
 
@@ -222,8 +222,8 @@ class HealthCheckWatcher:
                 effective_mad = max(bl_mad, 0.001)
                 scenario_median = float(np.median(arr))
                 degradation = (scenario_median - bl_median) / effective_mad
-                degradation_bonus = min(max(degradation, 0.0), 10.0)
-                url_score = min(variability_score + degradation_bonus, 10.0)
+                degradation_bonus = min(max(degradation, 0.0), 1.0)
+                url_score = min(variability_score + degradation_bonus, 1.0)
 
             url_scores.append(url_score)
 

--- a/krkn_ai/chaos_engines/health_check_watcher.py
+++ b/krkn_ai/chaos_engines/health_check_watcher.py
@@ -13,6 +13,7 @@ import threading
 import time
 import requests
 from typing import Dict, List, Optional, Tuple
+
 import numpy as np
 
 from krkn_ai.utils.logger import get_logger
@@ -138,46 +139,114 @@ class HealthCheckWatcher:
     def summarize_success_rate(
         self, results: Dict[str, List[HealthCheckResult]]
     ) -> float:
+        """Score combining failure rate and consecutive-failure streak severity.
+
+        failure_rate captures breadth (what fraction failed) while max_streak
+        captures depth (how sustained the worst outage was).  A service with
+        5/100 failures all in a row scores higher than 5/100 scattered.
         """
-        Overall fail score across different URL results
-        """
-        # Flatten all results from all URLs into a single list
-        all_results = []
+        all_results: List[HealthCheckResult] = []
         for result_list in results.values():
             all_results.extend(result_list)
 
         total = len(all_results)
         if total == 0:
-            return 0
+            return 0.0
+
         failed = sum(1 for r in all_results if not r.success)
-        score = (failed / total) * 10
-        logger.debug(f"Health check failure rate score: {score}")
+        failure_rate = failed / total
+
+        current_streak = 0
+        max_streak = 0
+        for r in all_results:
+            if not r.success:
+                current_streak += 1
+                max_streak = max(max_streak, current_streak)
+            else:
+                current_streak = 0
+        streak_ratio = max_streak / total
+
+        score = (failure_rate + streak_ratio) * 5.0
+        logger.debug(
+            "Health check failure score: %.3f (rate=%.3f, streak=%d/%d)",
+            score,
+            failure_rate,
+            max_streak,
+            total,
+        )
         return score
 
     def summarize_response_time(
-        self, health_check_results: Dict[str, List[HealthCheckResult]]
+        self,
+        health_check_results: Dict[str, List[HealthCheckResult]],
+        baseline_stats: Optional[Dict[str, Tuple[float, float]]] = None,
     ) -> float:
-        score: float = 0.0
-        total = 0
-        for _, results in health_check_results.items():
-            response_times = []
-            for result in results:
-                if result.success:
-                    response_times.append(result.response_time)
+        """Score response-time degradation using CV + jitter, with optional
+        baseline degradation bonus.
 
-            if len(response_times) < 4:  # Not enough data to calculate outliers
-                continue  # Skip this URL, but continue processing remaining URLs
+        Primary signal (always computed):
+          CV  = stddev / mean  (relative variability)
+          jitter = mean(|rt[i+1] - rt[i]|) / mean  (oscillation)
+          variability_score = min((CV + jitter) * 2.5, 10)
 
-            q1 = np.percentile(response_times, 25)
-            q3 = np.percentile(response_times, 75)
-            iqr = q3 - q1
-            upper_bound = q3 + (1.5 * iqr)
+        Additive bonus (when baseline_stats has data for the URL):
+          degradation = (scenario_median - baseline_median) / max(MAD, 0.001)
+          bonus = clamp(degradation, 0, 10)
 
-            outliers = [t for t in response_times if t > upper_bound]
-            score += len(outliers)
-            total += len(response_times)
-        if total == 0:
+        Returns the average per-URL score, capped at [0, 10].
+        """
+        url_scores: List[float] = []
+
+        for url, results in health_check_results.items():
+            response_times = [
+                r.response_time for r in results if r.success and r.response_time >= 0
+            ]
+            if len(response_times) < 2:
+                continue
+
+            arr = np.array(response_times, dtype=float)
+            mean_rt = float(np.mean(arr))
+            if mean_rt <= 0:
+                url_scores.append(0.0)
+                continue
+
+            cv = float(np.std(arr)) / mean_rt
+            diffs = np.abs(np.diff(arr))
+            jitter = float(np.mean(diffs)) / mean_rt if len(diffs) > 0 else 0.0
+            variability_score = min((cv + jitter) * 2.5, 10.0)
+
+            url_score = variability_score
+
+            if baseline_stats is not None and url in baseline_stats:
+                bl_median, bl_mad = baseline_stats[url]
+                effective_mad = max(bl_mad, 0.001)
+                scenario_median = float(np.median(arr))
+                degradation = (scenario_median - bl_median) / effective_mad
+                degradation_bonus = min(max(degradation, 0.0), 10.0)
+                url_score = min(variability_score + degradation_bonus, 10.0)
+
+            url_scores.append(url_score)
+
+        if not url_scores:
             return 0.0
-        score = (score / total) * 10.0
-        logger.debug(f"Response time outlier score: {score}")
+        score = float(np.mean(url_scores))
+        logger.debug("Response time score: %.3f (%d URLs)", score, len(url_scores))
         return score
+
+
+def compute_baseline_response_stats(
+    health_check_results: Dict[str, List[HealthCheckResult]],
+) -> Dict[str, Tuple[float, float]]:
+    """Compute per-URL (median, MAD) from a baseline run's health check results."""
+    stats: Dict[str, Tuple[float, float]] = {}
+    for url, results in health_check_results.items():
+        response_times = [
+            r.response_time for r in results if r.success and r.response_time >= 0
+        ]
+        if len(response_times) < 2:
+            continue
+        arr = np.array(response_times, dtype=float)
+        median = float(np.median(arr))
+        mad = float(np.median(np.abs(arr - median)))
+        stats[url] = (median, mad)
+    return stats

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -30,7 +30,7 @@ from krkn_ai.chaos_engines.telemetry_parser import extract_telemetry_from_log
 
 logger = get_logger(__name__)
 
-KRKN_HUB_FAILURE_SCORE = 5
+KRKN_HUB_FAILURE_SCORE = 0.5
 
 
 class KrknRunner:
@@ -188,7 +188,7 @@ class KrknRunner:
                 if resiliency_score is not None:
                     fitness_result.krkn_failure_score = (
                         100.0 - resiliency_score
-                    ) / 10.0
+                    ) / 100.0
                 elif returncode == 2:
                     fitness_result.krkn_failure_score = KRKN_HUB_FAILURE_SCORE
 
@@ -213,9 +213,11 @@ class KrknRunner:
                 ]
             )
             slo_total = sum(s.weighted_score for s in fitness_result.scores)
+            n = self.config.fitness_function.num_components
+            pct = (fitness_result.fitness_score / n * 100) if n else 0.0
             logger.info(
-                "Fitness: %.3f  (SLO: %.3f | HC fail: %.3f | HC resp: %.3f | krkn: %.3f)",
-                fitness_result.fitness_score,
+                "Fitness: %.1f%%  (SLO: %.3f | HC fail: %.3f | HC resp: %.3f | krkn: %.3f)",
+                pct,
                 slo_total,
                 fitness_result.health_check_failure_score,
                 fitness_result.health_check_response_time_score,

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -1,6 +1,6 @@
 import datetime
 import time
-from typing import Optional
+from typing import Dict, Optional, Tuple
 
 from krkn_ai.chaos_engines.commands import build_scenario_command, inject_es_config
 from krkn_ai.chaos_engines.composite import build_graph_command
@@ -56,6 +56,8 @@ class KrknRunner:
             self.fitness_calculator.preflight_check()
             logger.info("Pre-flight fitness validation passed.")
 
+        self._baseline_response_stats: Optional[Dict[str, Tuple[float, float]]] = None
+
         self.output_dir = output_dir
         if is_mock_enabled(MockType.RUN):
             self.runner_type = runner_type
@@ -89,6 +91,11 @@ class KrknRunner:
         if podman_available:
             logger.debug("Using krknhub as runner.")
             return KrknRunnerType.HUB_RUNNER
+
+    def set_baseline_response_stats(
+        self, stats: Dict[str, Tuple[float, float]]
+    ) -> None:
+        self._baseline_response_stats = stats
 
     def run(self, scenario: BaseScenario, generation_id: int) -> CommandRunResult:
         logger.info("Running scenario: %s", scenario)
@@ -178,7 +185,11 @@ class KrknRunner:
                 )
 
             if self.config.fitness_function.include_krkn_failure:
-                if returncode == 2:
+                if resiliency_score is not None:
+                    fitness_result.krkn_failure_score = (
+                        100.0 - resiliency_score
+                    ) / 10.0
+                elif returncode == 2:
                     fitness_result.krkn_failure_score = KRKN_HUB_FAILURE_SCORE
 
             if self.config.fitness_function.include_health_check_failure:
@@ -187,7 +198,10 @@ class KrknRunner:
                 )
             if self.config.fitness_function.include_health_check_response_time:
                 fitness_result.health_check_response_time_score = (
-                    health_check_watcher.summarize_response_time(health_check_results)
+                    health_check_watcher.summarize_response_time(
+                        health_check_results,
+                        baseline_stats=self._baseline_response_stats,
+                    )
                 )
 
             logger.debug("Fitness result: %s", fitness_result)

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -204,7 +204,8 @@ class KrknRunner:
                     )
                 )
 
-            fitness_result.fitness_score = sum(
+            n = self.config.fitness_function.num_components
+            raw_total = sum(
                 [
                     fitness_result.fitness_score,
                     fitness_result.krkn_failure_score,
@@ -212,12 +213,11 @@ class KrknRunner:
                     fitness_result.health_check_response_time_score,
                 ]
             )
+            fitness_result.fitness_score = (raw_total / n * 100) if n else 0.0
             slo_total = sum(s.weighted_score for s in fitness_result.scores)
-            n = self.config.fitness_function.num_components
-            pct = (fitness_result.fitness_score / n * 100) if n else 0.0
             logger.info(
                 "Fitness: %.1f%%  (SLO: %.3f | HC fail: %.3f | HC resp: %.3f | krkn: %.3f)",
-                pct,
+                fitness_result.fitness_score,
                 slo_total,
                 fitness_result.health_check_failure_score,
                 fitness_result.health_check_response_time_score,

--- a/krkn_ai/chaos_engines/krkn_runner.py
+++ b/krkn_ai/chaos_engines/krkn_runner.py
@@ -204,7 +204,6 @@ class KrknRunner:
                     )
                 )
 
-            logger.debug("Fitness result: %s", fitness_result)
             fitness_result.fitness_score = sum(
                 [
                     fitness_result.fitness_score,
@@ -213,7 +212,22 @@ class KrknRunner:
                     fitness_result.health_check_response_time_score,
                 ]
             )
-            logger.info("Fitness score: %s", fitness_result.fitness_score)
+            slo_total = sum(s.weighted_score for s in fitness_result.scores)
+            logger.info(
+                "Fitness: %.3f  (SLO: %.3f | HC fail: %.3f | HC resp: %.3f | krkn: %.3f)",
+                fitness_result.fitness_score,
+                slo_total,
+                fitness_result.health_check_failure_score,
+                fitness_result.health_check_response_time_score,
+                fitness_result.krkn_failure_score,
+            )
+            if fitness_result.scores:
+                logger.debug(
+                    "SLO breakdown: %s",
+                    "  ".join(
+                        f"[{s.id}]={s.fitness_score:.4f}" for s in fitness_result.scores
+                    ),
+                )
 
         return CommandRunResult(
             generation_id=generation_id,

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -199,11 +199,10 @@ def run(
                 except Exception as e:
                     logger.exception("Failed to write results.json: %s", e)
             logger.info("Check run.log file in '%s' for more details.", new_output_path)
-            if monitoring:
-                logger.info(
-                    "To inspect results interactively, run: krkn-ai monitor -o %s",
-                    output,
-                )
+            logger.info(
+                "To inspect results interactively, run:\n\n  krkn-ai monitor -o %s\n",
+                new_output_path,
+            )
 
 
 @main.command(help="Monitor results from previous completed runs")

--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -200,7 +200,7 @@ def run(
                     logger.exception("Failed to write results.json: %s", e)
             logger.info("Check run.log file in '%s' for more details.", new_output_path)
             logger.info(
-                "To inspect results interactively, run:\n\n  krkn-ai monitor -o %s\n",
+                "To inspect results interactively, run:\n\n  krkn_ai monitor -o %s\n",
                 new_output_path,
             )
 

--- a/krkn_ai/cluster/pvc_utils.py
+++ b/krkn_ai/cluster/pvc_utils.py
@@ -7,6 +7,7 @@ import time
 from krkn_lib.k8s.krkn_kubernetes import KrknKubernetes
 from krkn_lib.telemetry.k8s import KrknTelemetryKubernetes
 from krkn_ai.utils.logger import get_logger
+from krkn_ai.utils.mock import MockType, is_mock_enabled
 from krkn_lib.utils import SafeLogger
 
 logger = get_logger(__name__)
@@ -60,6 +61,9 @@ def resolve_pod_name(
     Returns:
         Current pod name, or the stored name as fallback
     """
+    if is_mock_enabled(MockType.CLUSTER):
+        return pod_name
+
     kubeconfig_path = kubeconfig or _kubeconfig_path
     if not kubeconfig_path:
         return pod_name
@@ -121,6 +125,9 @@ def get_pvc_usage_percentage(
     Returns:
         Usage percentage (0-100) or None if unable to get
     """
+    if is_mock_enabled(MockType.CLUSTER):
+        return None
+
     # Use provided kubeconfig or fall back to global one
     kubeconfig_path = kubeconfig or _kubeconfig_path
     if not kubeconfig_path:

--- a/krkn_ai/dashboard/report_generator.py
+++ b/krkn_ai/dashboard/report_generator.py
@@ -457,12 +457,12 @@ def generate_html_report(
     )
     n_sc = len(non_bl)
     best_fit = (
-        f"{non_bl['fitness_score'].max():.4f}"
+        f"{non_bl['fitness_score'].max():.1f}%"
         if "fitness_score" in non_bl.columns and not non_bl.empty
         else "—"
     )
     avg_fit = (
-        f"{non_bl['fitness_score'].mean():.4f}"
+        f"{non_bl['fitness_score'].mean():.1f}%"
         if "fitness_score" in non_bl.columns and not non_bl.empty
         else "—"
     )

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -21,8 +21,8 @@ def render_summary(df):
     col1, col2, col3, col4 = st.columns(4)
     col1.metric("Generations Completed", generations_completed)
     col2.metric("Scenarios Executed", scenarios_executed)
-    col3.metric("Best Fitness Score", f"{best_fitness:.4f}")
-    col4.metric("Avg Fitness Score", f"{avg_fitness:.4f}")
+    col3.metric("Best Fitness Score", f"{best_fitness:.1f}%")
+    col4.metric("Avg Fitness Score", f"{avg_fitness:.1f}%")
 
 
 def create_fitness_evolution_plot(df):
@@ -62,7 +62,7 @@ def create_fitness_evolution_plot(df):
     fig.update_layout(
         title="Fitness Performance Over Generations",
         xaxis_title="Generation",
-        yaxis_title="Fitness Score",
+        yaxis_title="Fitness Score (%)",
         hovermode="x unified",
         xaxis={"tickmode": "linear", "tick0": 1, "dtick": 1},
     )
@@ -126,7 +126,7 @@ def create_scenario_fitness_variation_plot(df):
     )
     fig.update_layout(
         xaxis_title="Generation",
-        yaxis_title="Best Fitness Score",
+        yaxis_title="Best Fitness Score (%)",
         hovermode="x unified",
         xaxis={"tickmode": "linear", "tick0": 1, "dtick": 1},
     )
@@ -306,7 +306,7 @@ def create_improvement_trend_plot(df_all):
         y=0,
         line_color="#06b6d4",
         line_dash="dash",
-        annotation_text=f"Baseline ({bl_fitness:.3f})",
+        annotation_text=f"Baseline ({bl_fitness:.1f}%)",
     )
 
     fig.update_layout(
@@ -378,15 +378,22 @@ def render_generation_details(df, title="Generation & Scenario Details"):
         # Default sort-- best fitness first (user can click column headers to re-sort)
         gen_scenarios = gen_scenarios.sort_values(by="fitness_score", ascending=False)
 
-        # Detect SLO columns dynamically from CSV data
-        slo_cols = sorted(c for c in gen_scenarios.columns if c.startswith("slo_"))
+        # Compute a single SLO score column (sum of per-item weighted scores)
+        weighted_cols = sorted(
+            (c for c in gen_scenarios.columns if c.endswith("_weighted")),
+            key=lambda c: int(c.split("_")[1]),
+        )
+        if weighted_cols:
+            gen_scenarios["slo_score"] = gen_scenarios[weighted_cols].sum(axis=1)
+        else:
+            gen_scenarios["slo_score"] = 0.0
 
         display_cols = [
             "generation_id",
             "scenario_id",
             "scenario",
             "duration_seconds",
-            *slo_cols,
+            "slo_score",
             "health_check_failure_score",
             "health_check_response_time_score",
             "krkn_failure_score",
@@ -405,28 +412,21 @@ def render_generation_details(df, title="Generation & Scenario Details"):
             "duration_seconds": st.column_config.NumberColumn(
                 "Scenario Execution Time (s)", format="%.1f"
             ),
+            "slo_score": st.column_config.NumberColumn("SLO Score", format="%.4f"),
             "health_check_failure_score": st.column_config.NumberColumn(
-                "Health Check Failure Score", format="%.4f"
+                "HC Failure", format="%.4f"
             ),
             "health_check_response_time_score": st.column_config.NumberColumn(
-                "Health Check Response Score", format="%.4f"
+                "HC Response", format="%.4f"
             ),
             "krkn_failure_score": st.column_config.NumberColumn(
-                "Krkn Failure Score", format="%.4f"
+                "Krkn Failure", format="%.4f"
             ),
             "fitness_score": st.column_config.NumberColumn(
-                "Fitness Score", format="%.4f"
+                "Fitness (%)", format="%.1f%%"
             ),
             "parameters": st.column_config.TextColumn("Parameters"),
         }
-        for col in slo_cols:
-            if col.endswith("_normalized"):
-                label = col.replace("slo_", "SLO ").replace("_normalized", " (Norm)")
-            elif col.endswith("_weighted"):
-                label = col.replace("slo_", "SLO ").replace("_weighted", " (Weighted)")
-            else:
-                label = col.replace("slo_", "SLO ") + " (Raw)"
-            column_cfg[col] = st.column_config.NumberColumn(label, format="%.4f")
         st.dataframe(
             view,
             column_config=column_cfg,

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -378,11 +378,15 @@ def render_generation_details(df, title="Generation & Scenario Details"):
         # Default sort-- best fitness first (user can click column headers to re-sort)
         gen_scenarios = gen_scenarios.sort_values(by="fitness_score", ascending=False)
 
+        # Detect SLO columns dynamically from CSV data
+        slo_cols = sorted(c for c in gen_scenarios.columns if c.startswith("slo_"))
+
         display_cols = [
             "generation_id",
             "scenario_id",
             "scenario",
             "duration_seconds",
+            *slo_cols,
             "health_check_failure_score",
             "health_check_response_time_score",
             "krkn_failure_score",
@@ -415,6 +419,14 @@ def render_generation_details(df, title="Generation & Scenario Details"):
             ),
             "parameters": st.column_config.TextColumn("Parameters"),
         }
+        for col in slo_cols:
+            if col.endswith("_normalized"):
+                label = col.replace("slo_", "SLO ").replace("_normalized", " (Norm)")
+            elif col.endswith("_weighted"):
+                label = col.replace("slo_", "SLO ").replace("_weighted", " (Weighted)")
+            else:
+                label = col.replace("slo_", "SLO ") + " (Raw)"
+            column_cfg[col] = st.column_config.NumberColumn(label, format="%.4f")
         st.dataframe(
             view,
             column_config=column_cfg,

--- a/krkn_ai/models/app.py
+++ b/krkn_ai/models/app.py
@@ -3,7 +3,7 @@ import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 from dataclasses import dataclass
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from krkn_ai.models.scenario.base import BaseScenario
 from krkn_ai.models.config import HealthCheckResult
@@ -19,9 +19,12 @@ class AppContext:
 
 
 class FitnessScoreResult(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     id: int
     fitness_score: float
     weighted_score: float
+    normalized_score: Optional[float] = None
 
 
 class FitnessResult(BaseModel):

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -327,8 +327,8 @@ class GeneticAlgorithmConfig(BaseModel):
     )
     crossover_rate: float = Field(default=const.CROSSOVER_RATE, ge=0.0, le=1.0)
     composition_rate: float = Field(default=0, ge=0.0, le=1.0)
-    selection_strategy: SelectionStrategy = SelectionStrategy.roulette
-    tournament_size: int = Field(default=3, ge=1)
+    selection_strategy: SelectionStrategy = SelectionStrategy.tournament
+    tournament_size: int = Field(default=6, ge=1)
     population_injection_rate: float = Field(
         default=const.POPULATION_INJECTION_RATE, ge=0.0, le=1.0
     )

--- a/krkn_ai/models/config.py
+++ b/krkn_ai/models/config.py
@@ -163,6 +163,17 @@ class FitnessFunction(BaseModel):
     include_health_check_response_time: bool = True
     items: List[FitnessFunctionItem] = []
 
+    @property
+    def num_components(self) -> int:
+        return sum(
+            [
+                bool(self.query or self.items),
+                self.include_krkn_failure,
+                self.include_health_check_failure,
+                self.include_health_check_response_time,
+            ]
+        )
+
     @model_validator(mode="after")
     def check_fitness_definition_exists(self):
         """Validates whether there is at least one fitness function is defined."""

--- a/krkn_ai/reporter/health_check_reporter.py
+++ b/krkn_ai/reporter/health_check_reporter.py
@@ -200,11 +200,17 @@ class HealthCheckReporter:
                 for param in fitness_result.scenario.parameters
             ]
 
-        # SLO breakdown
-        fitness_function_slos = {}
+        # SLO breakdown (raw, normalized, weighted per item)
+        fitness_function_slos: dict = {}
         for fitness_function_item in fitness_result.fitness_result.scores:
             fitness_function_slos[f"slo_{fitness_function_item.id}"] = (
                 fitness_function_item.fitness_score
+            )
+            fitness_function_slos[f"slo_{fitness_function_item.id}_normalized"] = (
+                fitness_function_item.normalized_score
+            )
+            fitness_function_slos[f"slo_{fitness_function_item.id}_weighted"] = (
+                fitness_function_item.weighted_score
             )
 
         new_row = pd.DataFrame(
@@ -242,6 +248,45 @@ class HealthCheckReporter:
 
         df.to_csv(report_path, index=False)
         logger.debug("Fitness result updated.")
+
+    def update_normalized_scores(self, results: List[CommandRunResult]) -> None:
+        """Patch CSV rows with post-normalization scores for a generation.
+
+        Called after ``normalize_generation_scores`` mutates the in-memory
+        results so that ``normalized_score``, ``weighted_score`` and the
+        recomputed ``fitness_score`` are persisted to ``all.csv``.
+        """
+        report_path = os.path.join(self.output_dir, "all.csv")
+        if not os.path.isfile(report_path):
+            return
+
+        try:
+            df = pd.read_csv(report_path)
+        except Exception as e:
+            logger.warning("Could not read CSV for normalization update: %s", e)
+            return
+
+        for result in results:
+            mask = (df["generation_id"] == result.generation_id) & (
+                df["scenario_id"].astype(str) == str(result.scenario_id)
+            )
+            if not mask.any():
+                continue
+
+            for score in result.fitness_result.scores:
+                norm_col = f"slo_{score.id}_normalized"
+                weighted_col = f"slo_{score.id}_weighted"
+                if norm_col not in df.columns:
+                    df[norm_col] = pd.NA
+                if weighted_col not in df.columns:
+                    df[weighted_col] = pd.NA
+                df.loc[mask, norm_col] = score.normalized_score
+                df.loc[mask, weighted_col] = score.weighted_score
+
+            df.loc[mask, "fitness_score"] = result.fitness_result.fitness_score
+
+        df.to_csv(report_path, index=False)
+        logger.debug("CSV updated with normalized scores")
 
     def sort_fitness_result_csv(self):
         """Read the CSV file, sort it by fitness_score, and write it back"""

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -1,13 +1,24 @@
 kubeconfig_file_path: "{{ kubeconfig_file_path }}"
 wait_duration: 120
 
+
+# Cluster-critical scenarios (e.g. service-disruption, which deletes whole
+# namespaces) are skipped unless this is set to true, even when their own
+# `enable` flag is on. Leave it false unless you really intend to run them.
+allow_dangerous_scenarios: false
+
+# Random seed for reproducible runs
+# seed: 42
+
 baseline:
   enable: true
   duration: 120
 
-# Optional: Random seed for reproducible runs
-# seed: 42
-
+scenario:
+{%- for name, enabled in scenario_enables.items() %}
+  {{ name | replace("_", "-") }}:
+    enable: {{ "true" if enabled else "false" }}
+{%- endfor %}
 
 # Algorithm selection: "genetic" (default)
 algorithm: genetic
@@ -15,15 +26,16 @@ algorithm: genetic
 # Genetic algorithm configuration
 genetic:
   generations: 2
-  # duration: 600  # Run for 600 seconds (run until time limit is reached, generations will be ignored)
   population_size: 2
   composition_rate: 0
   population_injection_rate: 0
 
-  selection_strategy: "roulette"
+  # Uncomment this to enable overall run timeout
+  # duration: 600
 
-  # selection_strategy: "tournament"
-  # tournament_size: 3
+  selection_strategy: "tournament"
+  tournament_size: 6
+  # selection_strategy: "roulette"
 
   adaptive_mutation:
     enable: false
@@ -93,6 +105,7 @@ fitness_function:
 {%- endfor %}
 {%- endif %}
 
+
 {%- set enabled_apps = health_check_apps | default([]) | selectattr('probe') | selectattr('active') | list -%}
 {%- set disabled_apps = health_check_apps | default([]) | rejectattr('probe') | list + health_check_apps | default([]) | selectattr('probe') | rejectattr('active') | list %}
 {% if enabled_apps %}
@@ -137,17 +150,6 @@ health_checks:
 #   - name: ratings
 #     url: "$HOST/ratings/api/fetch/Watson"
 {% endif %}
-
-# Cluster-critical scenarios (e.g. service-disruption, which deletes whole
-# namespaces) are skipped unless this is set to true, even when their own
-# `enable` flag is on. Leave it false unless you really intend to run them.
-allow_dangerous_scenarios: false
-
-scenario:
-{%- for name, enabled in scenario_enables.items() %}
-  {{ name | replace("_", "-") }}:
-    enable: {{ "true" if enabled else "false" }}
-{%- endfor %}
 
 cluster_components:
 {{ cluster_components }}

--- a/krkn_ai/utils/console.py
+++ b/krkn_ai/utils/console.py
@@ -1,0 +1,110 @@
+from typing import List
+
+from rich.console import Console
+from rich.table import Table
+
+from krkn_ai.models.app import CommandRunResult
+from krkn_ai.utils.logger import get_logger
+from krkn_ai.utils.output import format_duration
+
+logger = get_logger(__name__)
+_console = Console(highlight=False)
+
+
+def print_generation_table(
+    generation_id: int,
+    results: List[CommandRunResult],
+) -> None:
+    sorted_results = sorted(
+        results,
+        key=lambda r: r.fitness_result.fitness_score,
+        reverse=True,
+    )
+    best = sorted_results[0] if sorted_results else None
+
+    table = Table(
+        title=f"Generation {generation_id + 1} Results",
+        title_style="bold cyan",
+        show_lines=False,
+        pad_edge=True,
+    )
+    table.add_column("ID", style="dim", justify="right", width=4)
+    table.add_column("Scenario", style="white", min_width=20, max_width=30)
+    table.add_column("SLO", justify="right")
+    table.add_column("HC Fail", justify="right")
+    table.add_column("HC Resp", justify="right")
+    table.add_column("Krkn", justify="right")
+    table.add_column("Fitness", justify="right", style="bold")
+
+    for r in sorted_results:
+        fr = r.fitness_result
+        slo_total = sum(s.weighted_score for s in fr.scores)
+        is_best = r is best
+        style = "bold green" if is_best else ""
+
+        table.add_row(
+            str(r.scenario_id),
+            r.scenario.name,
+            f"{slo_total:.3f}",
+            f"{fr.health_check_failure_score:.3f}",
+            f"{fr.health_check_response_time_score:.3f}",
+            f"{fr.krkn_failure_score:.3f}",
+            f"{fr.fitness_score:.3f}",
+            style=style,
+        )
+
+    _console.print(table)
+
+    if best:
+        _console.print(
+            f"  Best: [bold]{best.scenario.name}[/bold] ({best.fitness_result.fitness_score:.3f})\n"
+        )
+        logger.debug(
+            "Generation %d best: %s (%.4f)",
+            generation_id + 1,
+            best.scenario.name,
+            best.fitness_result.fitness_score,
+        )
+
+
+def print_run_summary(
+    best_of_generation: List[CommandRunResult],
+    completed_generations: int,
+    elapsed_seconds: float,
+) -> None:
+    if not best_of_generation:
+        return
+
+    table = Table(
+        title="Run Summary",
+        title_style="bold cyan",
+        show_lines=False,
+    )
+    table.add_column("Generation", justify="right", style="dim")
+    table.add_column("Best Scenario", min_width=20, max_width=30)
+    table.add_column("Fitness", justify="right", style="bold")
+
+    overall_best = max(
+        best_of_generation,
+        key=lambda r: r.fitness_result.fitness_score,
+    )
+
+    for i, r in enumerate(best_of_generation):
+        is_best = r is overall_best
+        table.add_row(
+            str(i + 1),
+            r.scenario.name,
+            f"{r.fitness_result.fitness_score:.3f}",
+            style="bold green" if is_best else "",
+        )
+
+    _console.print()
+    _console.print(table)
+    _console.print(
+        f"  Completed [bold]{completed_generations}[/bold] generations "
+        f"in [bold]{format_duration(elapsed_seconds)}[/bold]"
+    )
+    _console.print(
+        f"  Overall best: [bold green]{overall_best.scenario.name}[/bold green] "
+        f"({overall_best.fitness_result.fitness_score:.3f})\n"
+    )

--- a/krkn_ai/utils/console.py
+++ b/krkn_ai/utils/console.py
@@ -11,16 +11,9 @@ logger = get_logger(__name__)
 _console = Console(highlight=False)
 
 
-def _to_pct(score: float, num_components: int) -> str:
-    if num_components == 0:
-        return "0.0%"
-    return f"{score / num_components * 100:.1f}%"
-
-
 def print_generation_table(
     generation_id: int,
     results: List[CommandRunResult],
-    num_components: int = 4,
 ) -> None:
     sorted_results = sorted(
         results,
@@ -56,7 +49,7 @@ def print_generation_table(
             f"{fr.health_check_failure_score:.3f}",
             f"{fr.health_check_response_time_score:.3f}",
             f"{fr.krkn_failure_score:.3f}",
-            _to_pct(fr.fitness_score, num_components),
+            f"{fr.fitness_score:.1f}%",
             style=style,
         )
 
@@ -65,10 +58,10 @@ def print_generation_table(
     if best:
         _console.print(
             f"  Best: [bold]{best.scenario.name}[/bold]"
-            f" ({_to_pct(best.fitness_result.fitness_score, num_components)})\n"
+            f" ({best.fitness_result.fitness_score:.1f}%)\n"
         )
         logger.debug(
-            "Generation %d best: %s (%.4f)",
+            "Generation %d best: %s (%.1f%%)",
             generation_id + 1,
             best.scenario.name,
             best.fitness_result.fitness_score,
@@ -79,7 +72,6 @@ def print_run_summary(
     best_of_generation: List[CommandRunResult],
     completed_generations: int,
     elapsed_seconds: float,
-    num_components: int = 4,
 ) -> None:
     if not best_of_generation:
         return
@@ -103,7 +95,7 @@ def print_run_summary(
         table.add_row(
             str(i + 1),
             r.scenario.name,
-            _to_pct(r.fitness_result.fitness_score, num_components),
+            f"{r.fitness_result.fitness_score:.1f}%",
             style="bold green" if is_best else "",
         )
 
@@ -115,5 +107,5 @@ def print_run_summary(
     )
     _console.print(
         f"  Overall best: [bold green]{overall_best.scenario.name}[/bold green] "
-        f"({_to_pct(overall_best.fitness_result.fitness_score, num_components)})\n"
+        f"({overall_best.fitness_result.fitness_score:.1f}%)\n"
     )

--- a/krkn_ai/utils/console.py
+++ b/krkn_ai/utils/console.py
@@ -11,9 +11,16 @@ logger = get_logger(__name__)
 _console = Console(highlight=False)
 
 
+def _to_pct(score: float, num_components: int) -> str:
+    if num_components == 0:
+        return "0.0%"
+    return f"{score / num_components * 100:.1f}%"
+
+
 def print_generation_table(
     generation_id: int,
     results: List[CommandRunResult],
+    num_components: int = 4,
 ) -> None:
     sorted_results = sorted(
         results,
@@ -49,7 +56,7 @@ def print_generation_table(
             f"{fr.health_check_failure_score:.3f}",
             f"{fr.health_check_response_time_score:.3f}",
             f"{fr.krkn_failure_score:.3f}",
-            f"{fr.fitness_score:.3f}",
+            _to_pct(fr.fitness_score, num_components),
             style=style,
         )
 
@@ -57,7 +64,8 @@ def print_generation_table(
 
     if best:
         _console.print(
-            f"  Best: [bold]{best.scenario.name}[/bold] ({best.fitness_result.fitness_score:.3f})\n"
+            f"  Best: [bold]{best.scenario.name}[/bold]"
+            f" ({_to_pct(best.fitness_result.fitness_score, num_components)})\n"
         )
         logger.debug(
             "Generation %d best: %s (%.4f)",
@@ -71,6 +79,7 @@ def print_run_summary(
     best_of_generation: List[CommandRunResult],
     completed_generations: int,
     elapsed_seconds: float,
+    num_components: int = 4,
 ) -> None:
     if not best_of_generation:
         return
@@ -94,7 +103,7 @@ def print_run_summary(
         table.add_row(
             str(i + 1),
             r.scenario.name,
-            f"{r.fitness_result.fitness_score:.3f}",
+            _to_pct(r.fitness_result.fitness_score, num_components),
             style="bold green" if is_best else "",
         )
 
@@ -106,5 +115,5 @@ def print_run_summary(
     )
     _console.print(
         f"  Overall best: [bold green]{overall_best.scenario.name}[/bold green] "
-        f"({overall_best.fitness_result.fitness_score:.3f})\n"
+        f"({_to_pct(overall_best.fitness_result.fitness_score, num_components)})\n"
     )

--- a/krkn_ai/utils/logger.py
+++ b/krkn_ai/utils/logger.py
@@ -2,6 +2,7 @@
 import logging
 import os
 from typing import Optional
+from rich.logging import RichHandler
 
 _LOGGER_INITIALIZED = False
 _LOG_DIR: Optional[str] = None
@@ -35,10 +36,19 @@ def init_logger(output_dir: Optional[str] = None, verbose: bool = False):
     parent.setLevel(logging.DEBUG)  # accept all levels; handler controls output
     parent.propagate = False  # don't let messages go to root
 
-    # Console handler
-    console = logging.StreamHandler()
-    console.setLevel(log_level)
-    console.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    # Console handler (rich gives color-coded levels and clean formatting)
+    try:
+        console = RichHandler(
+            level=log_level,
+            show_path=False,
+            show_time=False,
+            markup=True,
+            rich_tracebacks=True,
+        )
+    except ImportError:
+        console = logging.StreamHandler()
+        console.setLevel(log_level)
+        console.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
     parent.addHandler(console)
 
     # Optional file handler

--- a/krkn_ai/utils/mock.py
+++ b/krkn_ai/utils/mock.py
@@ -1,7 +1,8 @@
+import os
 from enum import Enum
 from typing import Dict, List
 
-from krkn_ai.utils.fs import env_is_truthy
+from krkn_ai.models.config import HealthCheckResult
 from krkn_ai.utils.rng import rng
 
 
@@ -9,20 +10,23 @@ class MockType(str, Enum):
     RUN = "MOCK_RUN"
     FITNESS = "MOCK_FITNESS"
     HEALTH_CHECK = "MOCK_HEALTH_CHECK"
+    CLUSTER = "MOCK_CLUSTER"
 
 
 _GLOBAL_VAR = "MOCK"
 
 
+def _env_is_truthy(var: str) -> bool:
+    return os.getenv(var, "false").lower().strip() in ("yes", "y", "true", "1")
+
+
 def is_mock_enabled(mock_type: MockType) -> bool:
-    return env_is_truthy(_GLOBAL_VAR) or env_is_truthy(mock_type.value)
+    return _env_is_truthy(_GLOBAL_VAR) or _env_is_truthy(mock_type.value)
 
 
 def generate_mock_health_check_results(
     health_check_config, sample_count: int = 5
 ) -> Dict[str, List]:
-    from krkn_ai.models.config import HealthCheckResult
-
     results: Dict[str, List] = {}
     for app in health_check_config.applications:
         samples = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ dependencies = [
   "streamlit>=1.55.0",
   "kubernetes>=34.1.0,<36",
   "krkn-lib @ git+https://github.com/krkn-chaos/krkn-lib@a89b299b1789eeb8f8ed07213eccd77414f03283",
-  "setuptools"
+  "setuptools",
+  "rich"
 ]
 
 [project.scripts]

--- a/tests/unit/chaos_engines/test_fitness.py
+++ b/tests/unit/chaos_engines/test_fitness.py
@@ -6,15 +6,23 @@ import datetime
 import pytest
 from unittest.mock import Mock, patch
 
-from krkn_ai.chaos_engines.fitness import FitnessCalculator, normalize_weights
+from krkn_ai.chaos_engines.fitness import (
+    FitnessCalculator,
+    normalize_generation_scores,
+    normalize_weights,
+)
+from krkn_ai.models.app import CommandRunResult, FitnessResult, FitnessScoreResult
 from krkn_ai.models.config import (
     FitnessFunction,
+    FitnessFunctionItem,
     FitnessFunctionType,
 )
 from krkn_ai.models.custom_errors import (
     FitnessFunctionCalculationError,
     FitnessFunctionConfigurationError,
 )
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 
 
 @pytest.fixture
@@ -423,3 +431,133 @@ class TestFitnessWeightAllocation:
 
         assert result.fitness_score == 12.0
         assert [score.weighted_score for score in result.scores] == [8.0, 4.0]
+
+
+def _make_result(
+    scores: list,
+    hc_failure: float = 0.0,
+    hc_response: float = 0.0,
+    krkn: float = 0.0,
+    fitness: float = 0.0,
+) -> CommandRunResult:
+    """Helper to build a CommandRunResult with given per-SLO scores."""
+    fitness_result = FitnessResult(
+        scores=[
+            FitnessScoreResult(id=s[0], fitness_score=s[1], weighted_score=s[2])
+            for s in scores
+        ],
+        health_check_failure_score=hc_failure,
+        health_check_response_time_score=hc_response,
+        krkn_failure_score=krkn,
+        fitness_score=fitness,
+    )
+    return CommandRunResult(
+        generation_id=0,
+        scenario=DummyScenario(cluster_components=ClusterComponents()),
+        cmd="",
+        log="",
+        returncode=0,
+        start_time=datetime.datetime(2024, 1, 1),
+        end_time=datetime.datetime(2024, 1, 1, 0, 5),
+        fitness_result=fitness_result,
+        health_check_results={},
+    )
+
+
+class TestNormalizeGenerationScores:
+    """Tests for log + min-max normalization of Prometheus scores."""
+
+    def test_equalizes_scales_across_items(self):
+        """Weight 0.8 item should dominate weight 0.2 item regardless of raw scale."""
+        items = [
+            FitnessFunctionItem(id=1, query="q1", weight=8),
+            FitnessFunctionItem(id=2, query="q2", weight=2),
+        ]
+        # Scenario A: item1=3 (small), item2=500_000_000 (huge)
+        # Scenario B: item1=1 (smaller), item2=100_000_000 (less huge)
+        r_a = _make_result([(1, 3.0, 0.0), (2, 500_000_000.0, 0.0)], fitness=0.0)
+        r_b = _make_result([(1, 1.0, 0.0), (2, 100_000_000.0, 0.0)], fitness=0.0)
+
+        normalize_generation_scores([r_a, r_b], items)
+
+        # After normalization, item 1 (weight 0.8) should contribute most
+        score_a = r_a.fitness_result.fitness_score
+        score_b = r_b.fitness_result.fitness_score
+        # r_a has higher item1 (weight 0.8) and higher item2 (weight 0.2)
+        assert score_a > score_b
+
+        # The 0.8-weighted item's contribution should exceed the 0.2-weighted
+        item1_contribution_a = r_a.fitness_result.scores[0].weighted_score
+        item2_contribution_a = r_a.fitness_result.scores[1].weighted_score
+        assert item1_contribution_a > item2_contribution_a
+
+    def test_preserves_raw_fitness_score(self):
+        """Raw fitness_score on FitnessScoreResult should not be modified."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r_a = _make_result([(1, 42.0, 42.0)], fitness=42.0)
+        r_b = _make_result([(1, 10.0, 10.0)], fitness=10.0)
+
+        normalize_generation_scores([r_a, r_b], items)
+
+        assert r_a.fitness_result.scores[0].fitness_score == 42.0
+        assert r_b.fitness_result.scores[0].fitness_score == 10.0
+
+    def test_sets_normalized_score(self):
+        """normalized_score should be set on each FitnessScoreResult."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r_a = _make_result([(1, 100.0, 0.0)], fitness=0.0)
+        r_b = _make_result([(1, 10.0, 0.0)], fitness=0.0)
+
+        normalize_generation_scores([r_a, r_b], items)
+
+        assert r_a.fitness_result.scores[0].normalized_score == 1.0
+        assert r_b.fitness_result.scores[0].normalized_score == 0.0
+
+    def test_skips_misconfiguration_results(self):
+        """Results with fitness_score == -1.0 should be untouched."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r_good = _make_result([(1, 50.0, 0.0)], fitness=50.0)
+        r_bad = _make_result([(1, 99.0, 0.0)], fitness=-1.0)
+
+        normalize_generation_scores([r_good, r_bad], items)
+
+        assert r_bad.fitness_result.fitness_score == -1.0
+        assert r_bad.fitness_result.scores[0].normalized_score is None
+
+    def test_single_result_is_noop(self):
+        """With only one valid result, normalization is skipped."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r = _make_result([(1, 42.0, 42.0)], fitness=42.0)
+
+        normalize_generation_scores([r], items)
+
+        assert r.fitness_result.scores[0].normalized_score is None
+        assert r.fitness_result.fitness_score == 42.0
+
+    def test_identical_values_normalize_to_midpoint(self):
+        """When all scenarios return the same raw score, normalize to 0.5."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r_a = _make_result([(1, 7.0, 0.0)], fitness=0.0)
+        r_b = _make_result([(1, 7.0, 0.0)], fitness=0.0)
+
+        normalize_generation_scores([r_a, r_b], items)
+
+        assert r_a.fitness_result.scores[0].normalized_score == 0.5
+        assert r_b.fitness_result.scores[0].normalized_score == 0.5
+
+    def test_recomputes_overall_fitness_with_other_scores(self):
+        """Overall fitness_score should be normalized_prometheus + other sub-scores."""
+        items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
+        r_a = _make_result(
+            [(1, 100.0, 0.0)], hc_failure=3.0, hc_response=2.0, krkn=1.0, fitness=0.0
+        )
+        r_b = _make_result(
+            [(1, 10.0, 0.0)], hc_failure=0.0, hc_response=0.0, krkn=0.0, fitness=0.0
+        )
+
+        normalize_generation_scores([r_a, r_b], items)
+
+        # r_a: normalized prometheus = 1.0 * 1.0 = 1.0, + 3 + 2 + 1 = 7.0
+        assert r_a.fitness_result.fitness_score == pytest.approx(7.0)
+        # r_b: normalized prometheus = 0.0 * 1.0 = 0.0, + 0 + 0 + 0 = 0.0
+        assert r_b.fitness_result.fitness_score == pytest.approx(0.0)

--- a/tests/unit/chaos_engines/test_fitness.py
+++ b/tests/unit/chaos_engines/test_fitness.py
@@ -534,16 +534,16 @@ class TestNormalizeGenerationScores:
         assert r.fitness_result.scores[0].normalized_score is None
         assert r.fitness_result.fitness_score == 42.0
 
-    def test_identical_values_normalize_to_midpoint(self):
-        """When all scenarios return the same raw score, normalize to 0.5."""
+    def test_identical_values_normalize_to_zero(self):
+        """When all scenarios return the same raw score, normalize to 0.0 (no signal)."""
         items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
         r_a = _make_result([(1, 7.0, 0.0)], fitness=0.0)
         r_b = _make_result([(1, 7.0, 0.0)], fitness=0.0)
 
         normalize_generation_scores([r_a, r_b], items)
 
-        assert r_a.fitness_result.scores[0].normalized_score == 0.5
-        assert r_b.fitness_result.scores[0].normalized_score == 0.5
+        assert r_a.fitness_result.scores[0].normalized_score == 0.0
+        assert r_b.fitness_result.scores[0].normalized_score == 0.0
 
     def test_recomputes_overall_fitness_with_other_scores(self):
         """Overall fitness_score should be normalized_prometheus + other sub-scores."""

--- a/tests/unit/chaos_engines/test_fitness.py
+++ b/tests/unit/chaos_engines/test_fitness.py
@@ -555,9 +555,9 @@ class TestNormalizeGenerationScores:
             [(1, 10.0, 0.0)], hc_failure=0.0, hc_response=0.0, krkn=0.0, fitness=0.0
         )
 
-        normalize_generation_scores([r_a, r_b], items)
+        normalize_generation_scores([r_a, r_b], items, num_components=4)
 
-        # r_a: normalized prometheus = 1.0 * 1.0 = 1.0, + 0.3 + 0.2 + 0.1 = 1.6
-        assert r_a.fitness_result.fitness_score == pytest.approx(1.6)
-        # r_b: normalized prometheus = 0.0 * 1.0 = 0.0, + 0 + 0 + 0 = 0.0
+        # r_a: raw = 1.0 + 0.3 + 0.2 + 0.1 = 1.6 → pct = 1.6/4*100 = 40.0
+        assert r_a.fitness_result.fitness_score == pytest.approx(40.0)
+        # r_b: raw = 0.0 + 0 + 0 + 0 = 0.0 → pct = 0.0
         assert r_b.fitness_result.fitness_score == pytest.approx(0.0)

--- a/tests/unit/chaos_engines/test_fitness.py
+++ b/tests/unit/chaos_engines/test_fitness.py
@@ -549,7 +549,7 @@ class TestNormalizeGenerationScores:
         """Overall fitness_score should be normalized_prometheus + other sub-scores."""
         items = [FitnessFunctionItem(id=1, query="q1", weight=1)]
         r_a = _make_result(
-            [(1, 100.0, 0.0)], hc_failure=3.0, hc_response=2.0, krkn=1.0, fitness=0.0
+            [(1, 100.0, 0.0)], hc_failure=0.3, hc_response=0.2, krkn=0.1, fitness=0.0
         )
         r_b = _make_result(
             [(1, 10.0, 0.0)], hc_failure=0.0, hc_response=0.0, krkn=0.0, fitness=0.0
@@ -557,7 +557,7 @@ class TestNormalizeGenerationScores:
 
         normalize_generation_scores([r_a, r_b], items)
 
-        # r_a: normalized prometheus = 1.0 * 1.0 = 1.0, + 3 + 2 + 1 = 7.0
-        assert r_a.fitness_result.fitness_score == pytest.approx(7.0)
+        # r_a: normalized prometheus = 1.0 * 1.0 = 1.0, + 0.3 + 0.2 + 0.1 = 1.6
+        assert r_a.fitness_result.fitness_score == pytest.approx(1.6)
         # r_b: normalized prometheus = 0.0 * 1.0 = 0.0, + 0 + 0 + 0 = 0.0
         assert r_b.fitness_result.fitness_score == pytest.approx(0.0)

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -5,7 +5,10 @@ HealthCheckWatcher core functionality tests
 import time
 from unittest.mock import Mock, patch
 
-from krkn_ai.chaos_engines.health_check_watcher import HealthCheckWatcher
+from krkn_ai.chaos_engines.health_check_watcher import (
+    HealthCheckWatcher,
+    compute_baseline_response_stats,
+)
 from krkn_ai.models.config import (
     HealthCheckConfig,
     HealthCheckApplicationConfig,
@@ -317,27 +320,17 @@ class TestHealthCheckWatcherResults:
     def test_summarize_response_time_returns_zero_only_when_all_urls_have_insufficient_data(
         self,
     ):
-        """Test summarize_response_time returns 0 only when ALL URLs have <4 samples."""
+        """Test summarize_response_time returns 0 when ALL URLs have <2 samples."""
         watcher = HealthCheckWatcher(HealthCheckConfig(applications=[]))
 
-        # All URLs have insufficient data
         first_url_results = [
             HealthCheckResult(
                 name="app1", status_code=200, success=True, response_time=0.1
-            ),
-            HealthCheckResult(
-                name="app1", status_code=200, success=True, response_time=0.15
             ),
         ]
         second_url_results = [
             HealthCheckResult(
                 name="app2", status_code=200, success=True, response_time=0.1
-            ),
-            HealthCheckResult(
-                name="app2", status_code=200, success=True, response_time=0.15
-            ),
-            HealthCheckResult(
-                name="app2", status_code=200, success=True, response_time=0.2
             ),
         ]
 
@@ -348,7 +341,6 @@ class TestHealthCheckWatcherResults:
 
         score = watcher.summarize_response_time(health_check_results)
 
-        # Should return 0 since ALL URLs have insufficient data
         assert score == 0
 
     def test_summarize_response_time_middle_url_insufficient_does_not_stop_processing(
@@ -357,7 +349,6 @@ class TestHealthCheckWatcherResults:
         """Test that an insufficient URL in the middle doesn't stop processing subsequent URLs."""
         watcher = HealthCheckWatcher(HealthCheckConfig(applications=[]))
 
-        # Three URLs where the middle one has insufficient data
         first_url_results = [
             HealthCheckResult(
                 name="app1", status_code=200, success=True, response_time=0.1
@@ -376,10 +367,7 @@ class TestHealthCheckWatcherResults:
             HealthCheckResult(
                 name="app2", status_code=200, success=True, response_time=0.1
             ),
-            HealthCheckResult(
-                name="app2", status_code=200, success=True, response_time=0.15
-            ),
-        ]  # Only 2 - insufficient
+        ]  # Only 1 - insufficient (< 2)
         last_url_results = [
             HealthCheckResult(
                 name="app3", status_code=200, success=True, response_time=0.1
@@ -395,7 +383,7 @@ class TestHealthCheckWatcherResults:
             ),
             HealthCheckResult(
                 name="app3", status_code=200, success=True, response_time=3.0
-            ),  # outlier
+            ),
         ]
 
         health_check_results = {
@@ -408,6 +396,81 @@ class TestHealthCheckWatcherResults:
 
         # Should NOT return 0 - first and last URLs have sufficient data
         assert score > 0
+
+    def test_summarize_response_time_baseline_degradation_adds_bonus(self):
+        """With baseline stats, uniform slowdown is detected via degradation bonus."""
+        watcher = HealthCheckWatcher(HealthCheckConfig(applications=[]))
+
+        scenario_results = [
+            HealthCheckResult(
+                name="app", status_code=200, success=True, response_time=5.0
+            ),
+            HealthCheckResult(
+                name="app", status_code=200, success=True, response_time=5.1
+            ),
+            HealthCheckResult(
+                name="app", status_code=200, success=True, response_time=5.05
+            ),
+        ]
+
+        baseline_stats = {"http://app": (0.1, 0.01)}
+
+        score_without = watcher.summarize_response_time(
+            {"http://app": scenario_results}, baseline_stats=None
+        )
+        score_with = watcher.summarize_response_time(
+            {"http://app": scenario_results}, baseline_stats=baseline_stats
+        )
+
+        # Baseline degradation should add a bonus on top of the variability score
+        assert score_with > score_without
+
+    def test_summarize_success_rate_streak_increases_score(self):
+        """Consecutive failures score higher than scattered failures."""
+        watcher = HealthCheckWatcher(HealthCheckConfig(applications=[]))
+
+        # 3 consecutive failures
+        consecutive = [
+            HealthCheckResult(
+                name="a", status_code=200, success=True, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=200, success=True, response_time=0.1
+            ),
+        ]
+
+        # 3 scattered failures (same count but no streak)
+        scattered = [
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=200, success=True, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=200, success=True, response_time=0.1
+            ),
+            HealthCheckResult(
+                name="a", status_code=500, success=False, response_time=0.1
+            ),
+        ]
+
+        score_consecutive = watcher.summarize_success_rate({"http://a": consecutive})
+        score_scattered = watcher.summarize_success_rate({"http://a": scattered})
+
+        assert score_consecutive > score_scattered
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_handles_request_exceptions_gracefully(self, mock_get):
@@ -568,3 +631,60 @@ class TestHealthCheckWatcherHeaders:
         assert (
             mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer $MISSING"
         )
+
+
+class TestComputeBaselineResponseStats:
+    """Tests for compute_baseline_response_stats."""
+
+    def test_basic_stats(self):
+        results = {
+            "http://app": [
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.10
+                ),
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.12
+                ),
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.14
+                ),
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.16
+                ),
+            ]
+        }
+        stats = compute_baseline_response_stats(results)
+        assert "http://app" in stats
+        median, mad = stats["http://app"]
+        assert 0.12 < median < 0.14  # median of [0.10, 0.12, 0.14, 0.16]
+        assert mad > 0
+
+    def test_skips_failed_checks(self):
+        results = {
+            "http://app": [
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.10
+                ),
+                HealthCheckResult(
+                    name="a", status_code=500, success=False, response_time=0.50
+                ),
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.12
+                ),
+            ]
+        }
+        stats = compute_baseline_response_stats(results)
+        median, _ = stats["http://app"]
+        # Only successful results (0.10, 0.12) should be used
+        assert 0.10 <= median <= 0.12
+
+    def test_skips_url_with_insufficient_data(self):
+        results = {
+            "http://app": [
+                HealthCheckResult(
+                    name="a", status_code=200, success=True, response_time=0.10
+                ),
+            ]
+        }
+        stats = compute_baseline_response_stats(results)
+        assert len(stats) == 0

--- a/tests/unit/chaos_engines/test_health_check_watcher.py
+++ b/tests/unit/chaos_engines/test_health_check_watcher.py
@@ -204,7 +204,7 @@ class TestHealthCheckWatcherResults:
         # Should have some failures, score should be > 0
         assert score >= 0
         # Score is (failed / total) * 10
-        assert score <= 10
+        assert score <= 1.0
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_summarize_success_rate_returns_zero_for_empty_results(self, mock_get):
@@ -241,7 +241,7 @@ class TestHealthCheckWatcherResults:
 
         # Should detect outliers and return score > 0
         assert score >= 0
-        assert score <= 10
+        assert score <= 1.0
 
     @patch("krkn_ai.chaos_engines.health_check_watcher.requests.get")
     def test_summarize_response_time_returns_zero_with_insufficient_data(

--- a/tests/unit/reporter/test_health_check_reporter.py
+++ b/tests/unit/reporter/test_health_check_reporter.py
@@ -8,7 +8,7 @@ import datetime
 from unittest.mock import patch, MagicMock
 
 from krkn_ai.reporter.health_check_reporter import HealthCheckReporter
-from krkn_ai.models.app import CommandRunResult, FitnessResult
+from krkn_ai.models.app import CommandRunResult, FitnessResult, FitnessScoreResult
 from krkn_ai.models.config import HealthCheckResult
 from krkn_ai.models.scenario.scenario_dummy import DummyScenario
 from krkn_ai.models.cluster_components import ClusterComponents
@@ -362,3 +362,89 @@ class TestHealthCheckReporter:
 
         report_path = os.path.join(temp_output_dir, "reports", "all.csv")
         assert not os.path.exists(report_path)
+
+    def test_write_fitness_result_includes_slo_columns(self, temp_output_dir):
+        """Test that SLO raw, normalized, and weighted columns are written."""
+        reporter = HealthCheckReporter(output_dir=temp_output_dir)
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        now = datetime.datetime.now()
+
+        result = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="cmd",
+            log="log",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(
+                fitness_score=5.0,
+                scores=[
+                    FitnessScoreResult(
+                        id=0,
+                        fitness_score=100.0,
+                        weighted_score=3.0,
+                        normalized_score=0.8,
+                    ),
+                    FitnessScoreResult(
+                        id=1,
+                        fitness_score=0.5,
+                        weighted_score=0.1,
+                        normalized_score=0.2,
+                    ),
+                ],
+            ),
+        )
+
+        reporter.write_fitness_result(result)
+        report_path = os.path.join(temp_output_dir, "reports", "all.csv")
+        df = pd.read_csv(report_path)
+
+        assert df.iloc[0]["slo_0"] == 100.0
+        assert df.iloc[0]["slo_0_normalized"] == 0.8
+        assert df.iloc[0]["slo_0_weighted"] == 3.0
+        assert df.iloc[0]["slo_1"] == 0.5
+        assert df.iloc[0]["slo_1_normalized"] == 0.2
+        assert df.iloc[0]["slo_1_weighted"] == 0.1
+
+    def test_update_normalized_scores_patches_csv(self, temp_output_dir):
+        """Test that update_normalized_scores patches existing CSV rows."""
+        reporter = HealthCheckReporter(output_dir=temp_output_dir)
+        scenario = DummyScenario(cluster_components=ClusterComponents())
+        now = datetime.datetime.now()
+
+        scores = [
+            FitnessScoreResult(id=0, fitness_score=500.0, weighted_score=500.0),
+        ]
+        result = CommandRunResult(
+            generation_id=0,
+            scenario_id=1,
+            scenario=scenario,
+            cmd="cmd",
+            log="log",
+            returncode=0,
+            start_time=now,
+            end_time=now,
+            fitness_result=FitnessResult(fitness_score=500.0, scores=scores),
+        )
+
+        reporter.write_fitness_result(result)
+
+        # Simulate normalization mutating the result in-place
+        scores[0].normalized_score = 0.75
+        scores[0].weighted_score = 0.6
+        result.fitness_result.fitness_score = 0.6
+
+        reporter.update_normalized_scores([result])
+
+        report_path = os.path.join(temp_output_dir, "reports", "all.csv")
+        df = pd.read_csv(report_path)
+        assert df.iloc[0]["slo_0_normalized"] == 0.75
+        assert df.iloc[0]["slo_0_weighted"] == 0.6
+        assert df.iloc[0]["fitness_score"] == 0.6
+
+    def test_update_normalized_scores_no_csv(self, temp_output_dir):
+        """Test that update_normalized_scores is a no-op when CSV doesn't exist."""
+        reporter = HealthCheckReporter(output_dir=temp_output_dir)
+        reporter.update_normalized_scores([])


### PR DESCRIPTION
## Description

Rework the fitness scoring pipeline to produce meaningful, comparable scores across scenarios within a generation. Previously raw Prometheus values were used directly — making scores unstable and hard to compare. This PR adds per-generation normalization, improves health-check scoring, adds baseline-aware response time scoring, and improves CLI output readability.

## Changes

### Fitness Scoring

**Added: Per-generation score normalization** (`krkn_ai/chaos_engines/fitness.py`)
- `normalize_generation_scores()` applies log-transform + min-max normalization to Prometheus SLO scores within each generation
- Normalized scores are weighted by configured item weights (with coefficient normalization)
- Final fitness is recomputed as: `weighted_SLO_sum + HC_failure + HC_response_time + krkn_failure`
- `FitnessScoreResult.normalized_score` field added to the model (`krkn_ai/models/app.py`)

**Changed: Health check failure scoring** (`krkn_ai/chaos_engines/health_check_watcher.py`)
- `summarize_success_rate()` now combines failure rate with consecutive-failure streak severity (was: simple failure ratio)
- A service with 5/100 failures all in a row now scores higher than 5/100 scattered failures

**Changed: Health check response time scoring** (`krkn_ai/chaos_engines/health_check_watcher.py`)
- Replaced IQR-based outlier counting with CV + jitter variability scoring
- Added baseline-aware degradation bonus: `compute_baseline_response_stats()` computes per-URL (median, MAD) from baseline run
- `summarize_response_time()` now accepts optional `baseline_stats` to add a degradation component
- Baseline stats computed automatically in `BaseEngine.run_baseline()` and passed to `KrknRunner`

**Changed: Krkn failure scoring** (`krkn_ai/chaos_engines/krkn_runner.py`)
- Now uses actual resiliency score from telemetry when available: `(100 - resiliency_score) / 10`
- Falls back to flat `KRKN_HUB_FAILURE_SCORE` only when resiliency score is unavailable

**Changed: GA defaults** (`krkn_ai/models/config.py`)
- Default selection strategy changed from `roulette` to `tournament`
- Default tournament size changed from `3` to `6`

### CSV / YAML Result Persistence

**Added: Post-normalization CSV patching** (`krkn_ai/reporter/health_check_reporter.py`)
- `update_normalized_scores()` patches `all.csv` rows with normalized/weighted scores and recomputed fitness after normalization
- `write_fitness_result()` now writes per-SLO `_normalized` and `_weighted` columns alongside raw scores

**Added: Post-normalization YAML re-save** (`krkn_ai/algorithm/base.py`)
- `update_scenario_results()` re-saves scenario YAML/JSON files after in-place normalization so `normalized_score` is no longer `null`

### CLI Output

**Added: Generation summary table** (`krkn_ai/utils/console.py` — new file)
- `print_generation_table()` renders a Rich table after each generation showing all scenarios with SLO, HC Fail, HC Resp, Krkn, and Fitness columns. Best scenario highlighted in green.
- `print_run_summary()` renders end-of-run summary table with per-generation best and overall best

**Changed: Engine output** (`krkn_ai/algorithm/genetic/engine.py`)
- Replaced verbose population dump (dashed separators + raw scenario logging) with concise `Generation N — M scenarios` log line
- Replaced `Best Fitness: ...` log with `print_generation_table()` call
- Replaced text-only stop message with `print_run_summary()` table

**Changed: Per-scenario fitness log** (`krkn_ai/chaos_engines/krkn_runner.py`)
- Replaced raw `FitnessResult` object dump with compact one-line INFO: `Fitness: 5.91 (SLO: 0.46 | HC fail: 1.29 | HC resp: 4.17 | krkn: 0.00)`
- Full SLO breakdown available at DEBUG level

**Changed: Console logging** (`krkn_ai/utils/logger.py`)
- Console handler now uses `RichHandler` for color-coded log levels (with `ImportError` fallback to plain `StreamHandler`)
- File handler unchanged (plain text)

**Added: `rich` dependency** (`pyproject.toml`)

### Dashboard

**Changed: Generation details table** (`krkn_ai/dashboard/tabs/dashboard.py`)
- Dynamically detects `slo_*` columns from CSV and displays them with labeled headers (Raw / Norm / Weighted)

### Mock Mode

**Added: `MockType.CLUSTER`** (`krkn_ai/utils/mock.py`)
- New mock type that skips Kubernetes API calls during scenario init

**Changed: PVC utils guarded in mock mode** (`krkn_ai/cluster/pvc_utils.py`)
- `resolve_pod_name()` returns stored pod name immediately when `MOCK_CLUSTER` is enabled
- `get_pvc_usage_percentage()` returns `None` immediately when `MOCK_CLUSTER` is enabled

**Changed: Circular import fix** (`krkn_ai/utils/mock.py`)
- `mock.py` no longer imports from `fs.py` (which triggered a circular chain through `generator` → `factory` → `cluster` → `pvc_utils`). `env_is_truthy` inlined as `_env_is_truthy`.

### Template

**Changed: Default config template** (`krkn_ai/templates/krkn-ai.yaml.j2`)

### Tests

- `test_fitness.py`: 139 new lines — normalization, weight normalization, edge cases
- `test_health_check_watcher.py`: 139 new lines — streak scoring, CV+jitter scoring, baseline degradation
- `test_health_check_reporter.py`: 87 new lines — SLO column output, normalized score CSV patching

## AI Disclosure
- [x] AI tools were used (describe below)

**AI Tool(s) Used:** Claude Code
**How AI was used:** Code generation, implementation planning

## Testing
- All 727 unit tests pass
- `ruff check` and `mypy` clean on all changed files
- Verified with `MOCK=true` run: no k8s API calls, colored output, generation tables, run summary

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings or errors