### PR TITLE
 feat(dashboard): per-query fitness breakdown

### DIFF
--- a/krkn_ai/dashboard/anomaly_config.yaml
+++ b/krkn_ai/dashboard/anomaly_config.yaml
@@ -26,6 +26,14 @@ fitness_regression:
   high_drop_pct: 20.0
   medium_drop_pct: 10.0
   z_div: 10.0
+  # Below this baseline magnitude, drops are scored in absolute terms instead of
+  # percentages — counter-based fitness queries sit at 0 on a healthy cluster
+  min_scale: 0.001
+  # Absolute drop thresholds used in that mode
+  high_abs_drop: 0.2
+  medium_abs_drop: 0.05
+  # Ignore drops smaller than this (floating-point noise)
+  min_abs_drop: 0.000001
 
 hc_response_time:
   z_threshold: 1.5

--- a/krkn_ai/dashboard/anomaly_config.yaml
+++ b/krkn_ai/dashboard/anomaly_config.yaml
@@ -26,13 +26,8 @@ fitness_regression:
   high_drop_pct: 20.0
   medium_drop_pct: 10.0
   z_div: 10.0
-  # Below this baseline magnitude, drops are scored in absolute terms instead of
-  # percentages — counter-based fitness queries sit at 0 on a healthy cluster
-  min_scale: 0.001
-  # Absolute drop thresholds used in that mode
   high_abs_drop: 0.2
   medium_abs_drop: 0.05
-  # Ignore drops smaller than this (floating-point noise)
   min_abs_drop: 0.000001
 
 hc_response_time:

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -19,6 +19,10 @@ from krkn_ai.dashboard.data_loader import (
     load_detailed_scenarios_data,
     load_logs,
     load_population_lineage,
+    load_fitness_items,
+    load_learned_weights,
+    load_health_check_recos,
+    map_slo_columns,
 )
 from krkn_ai.dashboard.tabs.dashboard import (
     render_summary,
@@ -29,6 +33,7 @@ from krkn_ai.dashboard.tabs.dashboard import (
     render_baseline_delta,
     render_improvement_trend,
 )
+from krkn_ai.dashboard.tabs.fitness import render_fitness
 from krkn_ai.dashboard.tabs.health_checks import render_health_checks
 from krkn_ai.dashboard.tabs.detailed_scenarios import render_detailed_scenarios
 from krkn_ai.dashboard.tabs.logs import render_logs
@@ -139,6 +144,9 @@ def main():
         df_details = load_detailed_scenarios_data.__wrapped__(output_dir)
         df_logs = load_logs.__wrapped__(output_dir)
         df_lineage = load_population_lineage.__wrapped__(output_dir)
+        fitness_items = load_fitness_items.__wrapped__(output_dir)
+        learned_weights = load_learned_weights.__wrapped__(output_dir)
+        health_check_recos = load_health_check_recos.__wrapped__(output_dir)
     else:
         results_file_found, df_results = load_results_csv(output_dir)
         config_data = load_config_yaml(output_dir)
@@ -146,6 +154,9 @@ def main():
         df_details = load_detailed_scenarios_data(output_dir)
         df_logs = load_logs(output_dir)
         df_lineage = load_population_lineage(output_dir)
+        fitness_items = load_fitness_items(output_dir)
+        learned_weights = load_learned_weights(output_dir)
+        health_check_recos = load_health_check_recos(output_dir)
 
     # fully unfiltered copy (baseline row included) for anomaly detection
     df_results_all = df_results.copy() if df_results is not None else None
@@ -276,7 +287,13 @@ def main():
     ]
     if df_results is not None and not df_results.empty:
         st.sidebar.subheader("Best Iterations Scope")
-        available_score_cols = [c for c in SCORE_COLS if c in df_results.columns]
+        slo_labels = {
+            col: item["name"]
+            for col, item in map_slo_columns(fitness_items, df_results.columns).items()
+        }
+        available_score_cols = [
+            c for c in SCORE_COLS if c in df_results.columns
+        ] + list(slo_labels)
         sort_col = st.sidebar.selectbox(
             "Sort by:",
             options=available_score_cols,
@@ -285,6 +302,7 @@ def main():
                 "health_check_failure_score": "Health Check Failure Score",
                 "health_check_response_time_score": "Health Check Response Time Score",
                 "krkn_failure_score": "Krkn Failure Score",
+                **slo_labels,
             }.get(c, c),
             key="best_iter_sort_col",
         )
@@ -442,6 +460,8 @@ def main():
                     global_services=global_services,
                     filtered_scenario_ids=filtered_scenario_ids,
                     anomaly_mode=amode,
+                    fitness_items=fitness_items,
+                    learned_weights=learned_weights,
                 ).encode("utf-8")
 
         from datetime import datetime as _dt
@@ -459,6 +479,7 @@ def main():
     has_lineage = df_lineage is not None and not df_lineage.empty
     tab_names = [
         "Dashboard",
+        "Fitness",
         "Health Checks",
         "Detailed Scenarios",
         "Anomalies",
@@ -469,7 +490,7 @@ def main():
     if has_lineage:
         tab_names.append("Lineage")
     tabs = st.tabs(tab_names)
-    tab1, tab2, tab3, tab4, tab5, tab6, tab7 = tabs[:7]
+    tab1, tab_fitness, tab2, tab3, tab4, tab5, tab6, tab7 = tabs[:8]
 
     with tab1:
         if not has_any_data:
@@ -502,17 +523,39 @@ def main():
             st.divider()
             render_fitness_evolution(df_results)
             st.divider()
-            render_generation_details(df_results)
+            render_generation_details(df_results, items=fitness_items)
             st.divider()
             render_baseline_delta(df_results_all)
             st.divider()
             render_improvement_trend(df_results_all)
+
+    with tab_fitness:
+        if not has_any_data:
+            st.warning("No valid Krkn-AI data found in the selected folder.")
+        else:
+            render_fitness(
+                df_results,
+                fitness_items,
+                learned_weights=learned_weights,
+                output_dir=output_dir,
+            )
+
+    hc_configured = bool(
+        ((config_data or {}).get("health_checks") or {}).get("applications")
+    )
 
     with tab2:
         if not has_any_data:
             st.warning("No valid Krkn-AI data found in the selected folder.")
         elif health_empty_file:
             st.info("`reports/health_check_report.csv` exists but is empty.")
+        elif df_health is None and config_data is not None and not hc_configured:
+            st.info(
+                "No health checks are configured for this run, so no health-check "
+                "data will be produced. Discover leaves a service out when it has "
+                "no HTTP probe or its URL is unreachable — see the Configuration "
+                "tab for what it found and why."
+            )
         elif df_health is None:
             st.info("No health check data found yet.")
         elif filters_active and (df_health is None or df_health.empty):
@@ -560,10 +603,16 @@ def main():
         render_logs(df_logs, scen_id_to_name=scen_id_to_name)
 
     with tab6:
-        render_config(config_data)
+        render_config(
+            config_data,
+            items=fitness_items,
+            health_check_recos=health_check_recos,
+        )
 
     with tab7:
-        render_generation_details(df_failed, title="Failed Scenarios")
+        render_generation_details(
+            df_failed, title="Failed Scenarios", items=fitness_items
+        )
 
     if has_lineage:
         with tabs[7]:

--- a/krkn_ai/dashboard/app.py
+++ b/krkn_ai/dashboard/app.py
@@ -615,7 +615,7 @@ def main():
         )
 
     if has_lineage:
-        with tabs[7]:
+        with tabs[-1]:
             render_lineage(df_lineage)
 
     # Refresh mechanism

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -10,6 +10,33 @@ import json
 from krkn_ai.models.config import OutputConfig
 from krkn_ai.utils.output import fmt_to_glob, fmt_to_id_regex
 
+LEARNED_WEIGHTS_FILE = "learned_weights.json"
+
+_SLO_RE = re.compile(r"^slo_\d+$")
+# "- query: 'sum(...)'", with or without the leading comment marker already stripped
+_QUERY_RE = re.compile(r"^-\s*query:\s*(?P<query>.+?)\s*$")
+_TYPE_RE = re.compile(r"^type:\s*(?P<type>\w+)\s*$")
+# "pod-restarts:default" or "pod-restarts:default (metric(s) not scraped: x)"
+_NAME_RE = re.compile(r"^(?P<name>\S+?)(?:\s*\((?P<reason>.*)\))?$")
+# fallback layout when no query was enabled: "name (reason): query"
+_INLINE_DISABLED_RE = re.compile(
+    r"^(?P<name>\S+)\s*\((?P<reason>.*?)\):\s*(?P<query>.+?)\s*$"
+)
+_HC_REASON_RE = re.compile(r"^\((?P<reason>[^)]*)\)$")
+_HC_NAME_RE = re.compile(r"^-\s*name:\s*(?P<name>.+?)\s*$")
+_HC_URL_RE = re.compile(r"^url:\s*(?P<url>.+?)\s*$")
+
+_CATALOG_MATCHERS = None
+
+
+def _unquote(value: str) -> str:
+    return (value or "").strip().strip("'\"")
+
+
+def _short_query(query: str, width: int = 60) -> str:
+    query = (query or "").strip()
+    return query if len(query) <= width else f"{query[: width - 1]}…"
+
 
 @st.cache_data(ttl=300)
 def load_results_csv(output_dir: str):
@@ -56,6 +83,252 @@ def load_config_yaml(output_dir: str):
         except Exception as e:
             logging.error(f"Failed to read {config_path}: {e}")
     return None
+
+
+@st.cache_data(ttl=300)
+def load_config_text(output_dir: str):
+    """Raw krkn-ai.yaml text — keeps the comments yaml.safe_load throws away."""
+    config_path = os.path.join(output_dir, "krkn-ai.yaml")
+    if os.path.exists(config_path):
+        try:
+            with open(config_path, "r") as f:
+                return f.read()
+        except Exception as e:
+            logging.error(f"Failed to read {config_path}: {e}")
+    return ""
+
+
+@st.cache_data(ttl=300)
+def load_learned_weights(output_dir: str):
+    """Weights the engine learned from this run, keyed by query. Empty when absent."""
+    path = os.path.join(output_dir, LEARNED_WEIGHTS_FILE)
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r") as f:
+            return json.load(f) or {}
+    except Exception as e:
+        logging.error(f"Failed to read {path}: {e}")
+        return {}
+
+
+def _catalog_matchers():
+    """Regex per catalog entry, with $ns left open, to recognise a query in a config."""
+    global _CATALOG_MATCHERS
+    if _CATALOG_MATCHERS is None:
+        matchers = []
+        try:
+            from krkn_ai.utils.catalog import get_base_catalog
+
+            catalog = get_base_catalog()
+        except Exception as e:  # catalog is optional for the dashboard
+            logging.error(f"Could not load the fitness catalog: {e}")
+            catalog = []
+
+        for entry in catalog:
+            pattern = re.escape(entry.query_template)
+            # a template can name $ns several times, but always the same namespace
+            pattern = pattern.replace(re.escape("$ns"), r"(?P<ns>[^\"]+)", 1).replace(
+                re.escape("$ns"), r"(?P=ns)"
+            )
+            # discover wraps queries in `(...) or vector(0)`
+            pattern = rf"^\(?{pattern}\)?(?:\s+or\s+vector\(0\))?$"
+            try:
+                matchers.append((re.compile(pattern), entry))
+            except re.error as e:
+                logging.error(f"Skipping catalog entry {entry.key}: {e}")
+        _CATALOG_MATCHERS = matchers
+    return _CATALOG_MATCHERS
+
+
+def describe_query(query: str):
+    """Return (name, category) for a query by matching it against the catalog."""
+    for pattern, entry in _catalog_matchers():
+        m = pattern.match(query or "")
+        if not m:
+            continue
+        namespace = m.groupdict().get("ns")
+        name = f"{entry.key}:{namespace}" if namespace else entry.key
+        category = entry.category.value if entry.category else None
+        return name, category
+    return None, None
+
+
+def _fitness_block(text: str):
+    """Lines of the fitness_function block, comments included."""
+    block, inside = [], False
+    for line in (text or "").splitlines():
+        if line.startswith("fitness_function:"):
+            inside = True
+            continue
+        if inside:
+            if line.strip() and not line[0].isspace():
+                break
+            block.append(line)
+    return block
+
+
+def _parse_fitness_comments(text: str):
+    """Read the annotations discover leaves in the config.
+
+    Returns (names_by_query, disabled) where names_by_query labels the enabled
+    items and disabled holds the queries discover commented out, with reasons.
+    """
+    names, disabled = {}, []
+    pending_name = pending_reason = None
+
+    for line in _fitness_block(text):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            body = stripped.lstrip("#").strip()
+            inline = _INLINE_DISABLED_RE.match(body)
+            if inline:
+                disabled.append(
+                    {
+                        "name": inline.group("name"),
+                        "reason": inline.group("reason"),
+                        "query": _unquote(inline.group("query")),
+                        "type": None,
+                    }
+                )
+                pending_name = pending_reason = None
+                continue
+
+            query_match = _QUERY_RE.match(body)
+            if query_match:
+                disabled.append(
+                    {
+                        "name": pending_name,
+                        "reason": pending_reason or "",
+                        "query": _unquote(query_match.group("query")),
+                        "type": None,
+                    }
+                )
+                pending_name = pending_reason = None
+                continue
+
+            type_match = _TYPE_RE.match(body)
+            if type_match and disabled:
+                disabled[-1]["type"] = type_match.group("type")
+                continue
+
+            named = _NAME_RE.match(body)
+            pending_name = named.group("name") if named else None
+            pending_reason = named.group("reason") if named else None
+            continue
+
+        query_match = _QUERY_RE.match(stripped)
+        if query_match and pending_name and not pending_reason:
+            names[_unquote(query_match.group("query"))] = pending_name
+        pending_name = pending_reason = None
+
+    return names, disabled
+
+
+@st.cache_data(ttl=300)
+def load_fitness_items(output_dir: str):
+    """Per-query fitness metadata: the items in use plus the ones discover rejected.
+
+    Each entry carries name, category, query, type, weight, enabled and reason.
+    """
+    config = load_config_yaml(output_dir) or {}
+    fitness_function = config.get("fitness_function") or {}
+    names, disabled = _parse_fitness_comments(load_config_text(output_dir))
+
+    items = []
+    for item in fitness_function.get("items") or []:
+        query = item.get("query", "")
+        catalog_name, category = describe_query(query)
+        items.append(
+            {
+                "name": names.get(query) or catalog_name or _short_query(query),
+                "category": category,
+                "query": query,
+                "type": item.get("type", ""),
+                "weight": float(item.get("weight", 1.0)),
+                "enabled": True,
+                "reason": "",
+            }
+        )
+
+    for entry in disabled:
+        catalog_name, category = describe_query(entry["query"])
+        items.append(
+            {
+                "name": entry["name"] or catalog_name or _short_query(entry["query"]),
+                "category": category,
+                "query": entry["query"],
+                "type": entry["type"] or "",
+                "weight": 0.0,
+                "enabled": False,
+                "reason": entry["reason"],
+            }
+        )
+
+    return items
+
+
+def map_slo_columns(items, columns):
+    """Attach each enabled item to its slo_* column in all.csv.
+
+    The CSV names those columns after the auto-generated item id, so they line up
+    with the config items in order. Skipped when the counts disagree.
+    """
+    slo_cols = sorted(
+        (c for c in columns if _SLO_RE.match(str(c))),
+        key=lambda c: int(str(c).split("_")[1]),
+    )
+    enabled = [item for item in items if item["enabled"]]
+    if not slo_cols or len(slo_cols) != len(enabled):
+        return {}
+    return {col: item for col, item in zip(slo_cols, enabled)}
+
+
+def slo_columns(columns):
+    """All slo_* columns present, in id order."""
+    return sorted(
+        (c for c in columns if _SLO_RE.match(str(c))),
+        key=lambda c: int(str(c).split("_")[1]),
+    )
+
+
+def _health_check_block(text: str):
+    block, inside = [], False
+    for line in (text or "").splitlines():
+        marker = line.lstrip("#").strip()
+        if line and marker.startswith("health_checks:") and not line[0].isspace():
+            inside = True
+            continue
+        if inside:
+            if line.strip() and not line[0].isspace() and not line.startswith("#"):
+                break
+            block.append(line)
+    return block
+
+
+@st.cache_data(ttl=300)
+def load_health_check_recos(output_dir: str):
+    """Health-check applications discover commented out, with the reason it gave."""
+    disabled, pending = [], None
+    for line in _health_check_block(load_config_text(output_dir)):
+        stripped = line.strip()
+        if not stripped.startswith("#"):
+            continue
+        body = stripped.lstrip("#").strip()
+        reason = _HC_REASON_RE.match(body)
+        if reason:
+            pending = reason.group("reason")
+            continue
+        name = _HC_NAME_RE.match(body)
+        if name:
+            disabled.append(
+                {"name": _unquote(name.group("name")), "url": "", "reason": pending}
+            )
+            continue
+        url = _HC_URL_RE.match(body)
+        if url and disabled:
+            disabled[-1]["url"] = _unquote(url.group("url"))
+    return [d for d in disabled if d["reason"]]
 
 
 @st.cache_data(ttl=300)

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -9,16 +9,14 @@ import json
 
 from krkn_ai.models.config import OutputConfig
 from krkn_ai.utils.output import fmt_to_glob, fmt_to_id_regex
+from krkn_ai.utils.weight_learning import load_learned_weights as read_learned_weights
 
 LEARNED_WEIGHTS_FILE = "learned_weights.json"
 
 _SLO_RE = re.compile(r"^slo_\d+$")
-# "- query: 'sum(...)'", with or without the leading comment marker already stripped
 _QUERY_RE = re.compile(r"^-\s*query:\s*(?P<query>.+?)\s*$")
 _TYPE_RE = re.compile(r"^type:\s*(?P<type>\w+)\s*$")
-# "pod-restarts:default" or "pod-restarts:default (metric(s) not scraped: x)"
 _NAME_RE = re.compile(r"^(?P<name>\S+?)(?:\s*\((?P<reason>.*)\))?$")
-# fallback layout when no query was enabled: "name (reason): query"
 _INLINE_DISABLED_RE = re.compile(
     r"^(?P<name>\S+)\s*\((?P<reason>.*?)\):\s*(?P<query>.+?)\s*$"
 )
@@ -74,18 +72,6 @@ def load_population_lineage(output_dir: str):
 
 
 @st.cache_data(ttl=300)
-def load_config_yaml(output_dir: str):
-    config_path = os.path.join(output_dir, "krkn-ai.yaml")
-    if os.path.exists(config_path):
-        try:
-            with open(config_path, "r") as f:
-                return yaml.safe_load(f)
-        except Exception as e:
-            logging.error(f"Failed to read {config_path}: {e}")
-    return None
-
-
-@st.cache_data(ttl=300)
 def load_config_text(output_dir: str):
     """Raw krkn-ai.yaml text — keeps the comments yaml.safe_load throws away."""
     config_path = os.path.join(output_dir, "krkn-ai.yaml")
@@ -99,17 +85,18 @@ def load_config_text(output_dir: str):
 
 
 @st.cache_data(ttl=300)
+def load_config_yaml(output_dir: str):
+    try:
+        return yaml.safe_load(load_config_text(output_dir)) or None
+    except Exception as e:
+        logging.error(f"Failed to parse {output_dir}/krkn-ai.yaml: {e}")
+        return None
+
+
+@st.cache_data(ttl=300)
 def load_learned_weights(output_dir: str):
     """Weights the engine learned from this run, keyed by query. Empty when absent."""
-    path = os.path.join(output_dir, LEARNED_WEIGHTS_FILE)
-    if not os.path.exists(path):
-        return {}
-    try:
-        with open(path, "r") as f:
-            return json.load(f) or {}
-    except Exception as e:
-        logging.error(f"Failed to read {path}: {e}")
-        return {}
+    return read_learned_weights(os.path.join(output_dir, LEARNED_WEIGHTS_FILE))
 
 
 def _catalog_matchers():
@@ -127,11 +114,9 @@ def _catalog_matchers():
 
         for entry in catalog:
             pattern = re.escape(entry.query_template)
-            # a template can name $ns several times, but always the same namespace
             pattern = pattern.replace(re.escape("$ns"), r"(?P<ns>[^\"]+)", 1).replace(
                 re.escape("$ns"), r"(?P=ns)"
             )
-            # discover wraps queries in `(...) or vector(0)`
             pattern = rf"^\(?{pattern}\)?(?:\s+or\s+vector\(0\))?$"
             try:
                 matchers.append((re.compile(pattern), entry))
@@ -154,30 +139,35 @@ def describe_query(query: str):
     return None, None
 
 
-def _fitness_block(text: str):
-    """Lines of the fitness_function block, comments included."""
+def _config_block(text: str, key: str):
+    """Lines under a top-level config key, comments included.
+
+    The key itself may be commented out, which is how discover writes a section
+    it wants to suggest but not enable.
+    """
     block, inside = [], False
     for line in (text or "").splitlines():
-        if line.startswith("fitness_function:"):
+        if not line:
+            if inside:
+                block.append(line)
+            continue
+        heading = line.lstrip("#").strip()
+        if not line[0].isspace() and heading.startswith(f"{key}:"):
             inside = True
             continue
         if inside:
-            if line.strip() and not line[0].isspace():
+            if line.strip() and not line[0].isspace() and not line.startswith("#"):
                 break
             block.append(line)
     return block
 
 
 def _parse_fitness_comments(text: str):
-    """Read the annotations discover leaves in the config.
-
-    Returns (names_by_query, disabled) where names_by_query labels the enabled
-    items and disabled holds the queries discover commented out, with reasons.
-    """
+    """Read discover's annotations: (names by query, queries it commented out)."""
     names, disabled = {}, []
     pending_name = pending_reason = None
 
-    for line in _fitness_block(text):
+    for line in _config_block(text, "fitness_function"):
         stripped = line.strip()
         if stripped.startswith("#"):
             body = stripped.lstrip("#").strip()
@@ -227,10 +217,7 @@ def _parse_fitness_comments(text: str):
 
 @st.cache_data(ttl=300)
 def load_fitness_items(output_dir: str):
-    """Per-query fitness metadata: the items in use plus the ones discover rejected.
-
-    Each entry carries name, category, query, type, weight, enabled and reason.
-    """
+    """Fitness queries in use plus the ones discover rejected, with their reason."""
     config = load_config_yaml(output_dir) or {}
     fitness_function = config.get("fitness_function") or {}
     names, disabled = _parse_fitness_comments(load_config_text(output_dir))
@@ -268,22 +255,6 @@ def load_fitness_items(output_dir: str):
     return items
 
 
-def map_slo_columns(items, columns):
-    """Attach each enabled item to its slo_* column in all.csv.
-
-    The CSV names those columns after the auto-generated item id, so they line up
-    with the config items in order. Skipped when the counts disagree.
-    """
-    slo_cols = sorted(
-        (c for c in columns if _SLO_RE.match(str(c))),
-        key=lambda c: int(str(c).split("_")[1]),
-    )
-    enabled = [item for item in items if item["enabled"]]
-    if not slo_cols or len(slo_cols) != len(enabled):
-        return {}
-    return {col: item for col, item in zip(slo_cols, enabled)}
-
-
 def slo_columns(columns):
     """All slo_* columns present, in id order."""
     return sorted(
@@ -292,25 +263,20 @@ def slo_columns(columns):
     )
 
 
-def _health_check_block(text: str):
-    block, inside = [], False
-    for line in (text or "").splitlines():
-        marker = line.lstrip("#").strip()
-        if line and marker.startswith("health_checks:") and not line[0].isspace():
-            inside = True
-            continue
-        if inside:
-            if line.strip() and not line[0].isspace() and not line.startswith("#"):
-                break
-            block.append(line)
-    return block
+def map_slo_columns(items, columns):
+    """Pair each enabled item with its slo_* column in all.csv."""
+    slo_cols = slo_columns(columns)
+    enabled = [item for item in items if item["enabled"]]
+    if not slo_cols or len(slo_cols) != len(enabled):
+        return {}
+    return {col: item for col, item in zip(slo_cols, enabled)}
 
 
 @st.cache_data(ttl=300)
 def load_health_check_recos(output_dir: str):
     """Health-check applications discover commented out, with the reason it gave."""
     disabled, pending = [], None
-    for line in _health_check_block(load_config_text(output_dir)):
+    for line in _config_block(load_config_text(output_dir), "health_checks"):
         stripped = line.strip()
         if not stripped.startswith("#"):
             continue

--- a/krkn_ai/dashboard/data_loader.py
+++ b/krkn_ai/dashboard/data_loader.py
@@ -7,6 +7,8 @@ import streamlit as st
 import re
 import json
 
+from typing import List
+
 from krkn_ai.models.config import OutputConfig
 from krkn_ai.utils.output import fmt_to_glob, fmt_to_id_regex
 from krkn_ai.utils.weight_learning import load_learned_weights as read_learned_weights
@@ -14,6 +16,8 @@ from krkn_ai.utils.weight_learning import load_learned_weights as read_learned_w
 LEARNED_WEIGHTS_FILE = "learned_weights.json"
 
 _SLO_RE = re.compile(r"^slo_\d+$")
+_COMMENT_MARKER_RE = re.compile(r"^#\s?")
+_TOP_KEY_RE = re.compile(r"^[A-Za-z_][\w-]*:")
 _QUERY_RE = re.compile(r"^-\s*query:\s*(?P<query>.+?)\s*$")
 _TYPE_RE = re.compile(r"^type:\s*(?P<type>\w+)\s*$")
 _NAME_RE = re.compile(r"^(?P<name>\S+?)(?:\s*\((?P<reason>.*)\))?$")
@@ -139,24 +143,22 @@ def describe_query(query: str):
     return None, None
 
 
-def _config_block(text: str, key: str):
-    """Lines under a top-level config key, comments included.
-
-    The key itself may be commented out, which is how discover writes a section
-    it wants to suggest but not enable.
-    """
-    block, inside = [], False
+def _config_block(text: str, key: str) -> List[str]:
+    """Lines under a top-level config key, comments included."""
+    block: List[str] = []
+    inside = False
     for line in (text or "").splitlines():
         if not line:
             if inside:
                 block.append(line)
             continue
-        heading = line.lstrip("#").strip()
-        if not line[0].isspace() and heading.startswith(f"{key}:"):
+        bare = _COMMENT_MARKER_RE.sub("", line, count=1)
+        top_level = bool(bare) and not bare[0].isspace()
+        if top_level and bare.startswith(f"{key}:"):
             inside = True
             continue
         if inside:
-            if line.strip() and not line[0].isspace() and not line.startswith("#"):
+            if top_level and _TOP_KEY_RE.match(bare):
                 break
             block.append(line)
     return block
@@ -233,6 +235,7 @@ def load_fitness_items(output_dir: str):
                 "query": query,
                 "type": item.get("type", ""),
                 "weight": float(item.get("weight", 1.0)),
+                "id": item.get("id"),
                 "enabled": True,
                 "reason": "",
             }
@@ -247,6 +250,7 @@ def load_fitness_items(output_dir: str):
                 "query": entry["query"],
                 "type": entry["type"] or "",
                 "weight": 0.0,
+                "id": None,
                 "enabled": False,
                 "reason": entry["reason"],
             }
@@ -265,8 +269,17 @@ def slo_columns(columns):
 
 def map_slo_columns(items, columns):
     """Pair each enabled item with its slo_* column in all.csv."""
-    slo_cols = slo_columns(columns)
     enabled = [item for item in items if item["enabled"]]
+    if not enabled:
+        return {}
+
+    if all(item.get("id") is not None for item in enabled):
+        by_id = {f"slo_{item['id']}": item for item in enabled}
+        if all(col in columns for col in by_id):
+            return by_id
+        return {}
+
+    slo_cols = slo_columns(columns)
     if not slo_cols or len(slo_cols) != len(enabled):
         return {}
     return {col: item for col, item in zip(slo_cols, enabled)}

--- a/krkn_ai/dashboard/report_generator.py
+++ b/krkn_ai/dashboard/report_generator.py
@@ -54,6 +54,7 @@ from krkn_ai.dashboard.tabs.anomalies import (
 from krkn_ai.dashboard.tabs.fitness import (
     build_contribution_frame,
     build_query_summary,
+    build_rejected_frame,
     build_weights_frame,
     create_contribution_plot,
     create_weights_plot,
@@ -206,21 +207,10 @@ def _fit_weights(weights_df: pd.DataFrame) -> str:
 
 
 def _fit_rejected(fitness_items: Optional[List]) -> str:
-    rejected = [item for item in (fitness_items or []) if not item["enabled"]]
-    if not rejected:
+    rejected = build_rejected_frame(fitness_items or [])
+    if rejected.empty:
         return _na("No queries were rejected.")
-    return _df_table(
-        pd.DataFrame(
-            [
-                {
-                    "name": item["name"],
-                    "reason": item["reason"],
-                    "query": item["query"],
-                }
-                for item in rejected
-            ]
-        )
-    )
+    return _df_table(rejected)
 
 
 # Health Checks

--- a/krkn_ai/dashboard/report_generator.py
+++ b/krkn_ai/dashboard/report_generator.py
@@ -58,6 +58,7 @@ from krkn_ai.dashboard.tabs.fitness import (
     build_weights_frame,
     create_contribution_plot,
     create_weights_plot,
+    runtime_weights,
 )
 from krkn_ai.dashboard.data_loader import map_slo_columns
 
@@ -460,7 +461,7 @@ def generate_html_report(
     learned_weights: Optional[dict] = None,
 ) -> str:
     """
-    Generate a complete self-contained HTML report covering all five dashboard tabs.
+    Generate a complete self-contained HTML report covering all six dashboard tabs.
 
     Parameters
     ----------
@@ -599,7 +600,7 @@ def generate_html_report(
                     ),
                     (
                         "Total Weight",
-                        f"{sum(item['weight'] for item in enabled_items):.4f}",
+                        f"{sum(runtime_weights(fitness_items or []).values()):.4f}",
                     ),
                 ]
             )

--- a/krkn_ai/dashboard/report_generator.py
+++ b/krkn_ai/dashboard/report_generator.py
@@ -4,12 +4,13 @@ report_generator.py
 Generates a single self-contained HTML report of the full Krkn-AI dashboard
 suitable for CI/CD artifact capture.
 
-Covers all five tabs:
+Covers all six tabs:
   1. Dashboard        — summary, fitness evolution, baseline delta, improvement trend
-  2. Health Checks    — heatmap, success/failure bar, radar-style coverage
-  3. Detailed Scenarios — runtime RT chart, success timeline heatmap
-  4. Anomaly Detection  — bubble map, anomaly table
-  5. Failed Scenarios   — failed run table
+  2. Fitness          — per-query contributions, query stats, learned weights
+  3. Health Checks    — heatmap, success/failure bar, radar-style coverage
+  4. Detailed Scenarios — runtime RT chart, success timeline heatmap
+  5. Anomaly Detection  — bubble map, anomaly table
+  6. Failed Scenarios   — failed run table
 
 Public API
 ----------
@@ -50,6 +51,14 @@ from krkn_ai.dashboard.tabs.anomalies import (
     create_anomaly_type_distribution_plot,
     create_service_response_time_heatmap_plot,
 )
+from krkn_ai.dashboard.tabs.fitness import (
+    build_contribution_frame,
+    build_query_summary,
+    build_weights_frame,
+    create_contribution_plot,
+    create_weights_plot,
+)
+from krkn_ai.dashboard.data_loader import map_slo_columns
 
 
 # Utilities
@@ -145,9 +154,10 @@ def _dash_improvement_trend(df_all: pd.DataFrame) -> str:
     return _fig_html(fig, 330)
 
 
-def _dash_gen_details(df: pd.DataFrame) -> str:
+def _dash_gen_details(df: pd.DataFrame, fitness_items: Optional[List] = None) -> str:
     if df is None or df.empty:
         return _na()
+    slo_map = map_slo_columns(fitness_items or [], df.columns)
     cols = [
         c
         for c in [
@@ -160,12 +170,57 @@ def _dash_gen_details(df: pd.DataFrame) -> str:
             "health_check_response_time_score",
             "krkn_failure_score",
         ]
+        + list(slo_map)
         if c in df.columns
     ]
     tbl = df[cols].copy()
     if "generation_id" in tbl.columns:
         tbl["generation_id"] = tbl["generation_id"] + 1
+    tbl = tbl.rename(columns={col: item["name"] for col, item in slo_map.items()})
     return _df_table(tbl.sort_values("fitness_score", ascending=False))
+
+
+# Fitness
+def _fit_contribution(long_df: pd.DataFrame) -> str:
+    fig = create_contribution_plot(long_df)
+    if fig is None:
+        return _na("No per-query fitness scores recorded.")
+    return _fig_html(fig, 420)
+
+
+def _fit_query_table(long_df: pd.DataFrame) -> str:
+    summary = build_query_summary(long_df)
+    if summary is None or summary.empty:
+        return _na()
+    return _df_table(summary)
+
+
+def _fit_weights(weights_df: pd.DataFrame) -> str:
+    if weights_df is None or weights_df.empty:
+        return _na("No weighted fitness items in this run.")
+    fig = create_weights_plot(weights_df)
+    table = _df_table(weights_df)
+    if fig is None:
+        return _na("No learned weights found for this run.") + table
+    return _fig_html(fig, 380) + table
+
+
+def _fit_rejected(fitness_items: Optional[List]) -> str:
+    rejected = [item for item in (fitness_items or []) if not item["enabled"]]
+    if not rejected:
+        return _na("No queries were rejected.")
+    return _df_table(
+        pd.DataFrame(
+            [
+                {
+                    "name": item["name"],
+                    "reason": item["reason"],
+                    "query": item["query"],
+                }
+                for item in rejected
+            ]
+        )
+    )
 
 
 # Health Checks
@@ -411,6 +466,8 @@ def generate_html_report(
     global_services: Optional[List[str]] = None,
     filtered_scenario_ids: Optional[List] = None,
     anomaly_mode: str = "z_score",
+    fitness_items: Optional[List] = None,
+    learned_weights: Optional[dict] = None,
 ) -> str:
     """
     Generate a complete self-contained HTML report covering all five dashboard tabs.
@@ -425,6 +482,8 @@ def generate_html_report(
     global_services      : Active service filter list.
     filtered_scenario_ids: Active scenario IDs.
     anomaly_mode          : "z_score" or "pct_deviation" — determines which anomaly detectors fire.
+    fitness_items        : Per-query fitness metadata from the run config.
+    learned_weights      : Weights the engine learned from the run, keyed by query.
 
     Returns
     -------
@@ -483,6 +542,7 @@ def generate_html_report(
     # Nav tabs
     tab_defs = [
         ("Dashboard", "tab-dashboard"),
+        ("Fitness", "tab-fitness"),
         ("Health Checks", "tab-health"),
         ("Detailed Scenarios", "tab-detailed"),
         ("Anomaly Detection", "tab-anomalies"),
@@ -525,9 +585,43 @@ def generate_html_report(
                 "Fitness Improvement Trend vs Baseline", _dash_improvement_trend(src)
             )
             + "<hr class='d'/>"
-            + _subsec("Generation & Scenario Details", _dash_gen_details(df_results))
+            + _subsec(
+                "Generation & Scenario Details",
+                _dash_gen_details(df_results, fitness_items),
+            )
         ),
         "tab-dashboard",
+    )
+
+    # Fitness
+    long_df = build_contribution_frame(non_bl, fitness_items or [])
+    weights_df = build_weights_frame(fitness_items or [], learned_weights)
+    enabled_items = [item for item in (fitness_items or []) if item["enabled"]]
+    tab_fit = _sec(
+        "Fitness",
+        (
+            _cards(
+                [
+                    ("Queries In Use", len(enabled_items)),
+                    (
+                        "Queries Rejected",
+                        len(fitness_items or []) - len(enabled_items),
+                    ),
+                    (
+                        "Total Weight",
+                        f"{sum(item['weight'] for item in enabled_items):.4f}",
+                    ),
+                ]
+            )
+            + _subsec("Fitness Contribution by Query", _fit_contribution(long_df))
+            + "<hr class='d'/>"
+            + _subsec("Query Statistics", _fit_query_table(long_df))
+            + "<hr class='d'/>"
+            + _subsec("Configured vs Learned Weights", _fit_weights(weights_df))
+            + "<hr class='d'/>"
+            + _subsec("Queries Discover Rejected", _fit_rejected(fitness_items))
+        ),
+        "tab-fitness",
     )
 
     # Health Checks
@@ -624,5 +718,5 @@ def generate_html_report(
         "tab-failed",
     )
 
-    body = "\n".join([header, tab1, tab2, tab3, tab4, tab5])
+    body = "\n".join([header, tab1, tab_fit, tab2, tab3, tab4, tab5])
     return _full_page(body, ts)

--- a/krkn_ai/dashboard/tabs/anomalies.py
+++ b/krkn_ai/dashboard/tabs/anomalies.py
@@ -314,17 +314,40 @@ def detect_fitness_regression(df: pd.DataFrame) -> pd.DataFrame:
     anomalies = []
     prev_gen = prev_best = None
     cfg = get_anomaly_config().get("fitness_regression", {})
+    min_abs_drop = cfg.get("min_abs_drop", 1e-6)
     for gen_id, best_fs in gen_best.items():
         if prev_best is not None and prev_gen is not None and best_fs < prev_best:
-            drop_pct = ((prev_best - best_fs) / max(prev_best, 1e-6)) * 100
-            z = -drop_pct / cfg.get("z_div", 10.0)
-            severity = (
-                "High"
-                if drop_pct > cfg.get("high_drop_pct", 20.0)
-                else "Medium"
-                if drop_pct > cfg.get("medium_drop_pct", 10.0)
-                else "Low"
-            )
+            abs_drop = prev_best - best_fs
+            if abs_drop < min_abs_drop:
+                prev_gen, prev_best = gen_id, best_fs
+                continue
+
+            # Counter-based fitness queries sit at 0 on a healthy cluster, where a
+            # percentage drop is meaningless — score those in absolute terms.
+            scale = abs(prev_best)
+            relative = scale > cfg.get("min_scale", 1e-3)
+            if relative:
+                drop_pct = abs_drop / scale * 100
+                severity = (
+                    "High"
+                    if drop_pct > cfg.get("high_drop_pct", 20.0)
+                    else "Medium"
+                    if drop_pct > cfg.get("medium_drop_pct", 10.0)
+                    else "Low"
+                )
+                z = -drop_pct / cfg.get("z_div", 10.0)
+                detail_tail = f" — {drop_pct:.1f}% regression"
+            else:
+                severity = (
+                    "High"
+                    if abs_drop > cfg.get("high_abs_drop", 0.2)
+                    else "Medium"
+                    if abs_drop > cfg.get("medium_abs_drop", 0.05)
+                    else "Low"
+                )
+                z = -abs_drop / cfg.get("z_div", 10.0)
+                detail_tail = f" — {abs_drop:.4f} absolute regression"
+
             anomalies.append(
                 {
                     "scenario_id": int(gen_id) + 1,
@@ -339,7 +362,7 @@ def detect_fitness_regression(df: pd.DataFrame) -> pd.DataFrame:
                     "detail": (
                         f"Best fitness dropped from Gen {int(prev_gen) + 1} ({prev_best:.3f})"
                         f" to Gen {int(gen_id) + 1} ({best_fs:.3f})"
-                        f" — {drop_pct:.1f}% regression"
+                        f"{detail_tail}"
                     ),
                 }
             )
@@ -1351,7 +1374,7 @@ Upper fence = Q3 + 1.5 × IQR
 | **Low / High Fitness** | `fitness_score` | IQR fence | x < Q1−1.5·IQR or x > Q3+1.5·IQR |
 | **Duration Anomaly** | `duration_seconds` | Z-score (RMS σ vs baseline if available) | `|z| ≥ 1.5` |
 | **HC Failure Surge** | `health_check_failure_score` | IQR fence | x > Q3+1.5·IQR |
-| **Fitness Regression** | Best fitness per generation | Gen-over-gen delta | `drop% = (prev−cur)/prev×100`; High if drop > 20% |
+| **Fitness Regression** | Best fitness per generation | Gen-over-gen delta | `drop% = (prev−cur)/prev×100`; High if drop > 20%. When `|prev| ≤ 0.001` the absolute drop is used instead (High if > 0.2) |
 | **Service Failure Rate** | Per-service failure_rate | Z-score vs service distribution | `|z| ≥ 1.5` |
 | **Krkn Failure Score** | `krkn_failure_score` | Non-zero sentinel + IQR | Non-zero → Medium; above IQR upper fence → High |
 | **HC Response Time** | `health_check_response_time_score` | IQR + Z-score | IQR breach OR `|z| ≥ 1.5` |
@@ -1380,7 +1403,7 @@ For each value **x** and its baseline reference **b**:
 | **Low / High Fitness** | Baseline scenario `fitness_score` | IQR fence breach **and/or** `Δ% < 0` below baseline |
 | **Duration Anomaly** | Baseline scenario `duration_seconds` | `|Δ%| ≥ 30` |
 | **HC Failure Surge** | Baseline `health_check_failure_score` | `|Δ%| ≥ 30` |
-| **Fitness Regression** | Previous generation best fitness | `drop% = (prev−cur)/prev×100`; High if drop > 20%, Medium if drop > 10% |
+| **Fitness Regression** | Previous generation best fitness | `drop% = (prev−cur)/prev×100`; High if drop > 20%, Medium if drop > 10%. Falls back to absolute drop when `|prev| ≤ 0.001` |
 | **Service Failure Rate** | Baseline per-service failure rate | `|Δ%| ≥ 30` |
 | **Krkn Failure Score** | — (non-zero sentinel) | Non-zero → Medium; above IQR upper fence → High |
 | **HC Response Time** | Baseline `health_check_response_time_score` | `|Δ%| ≥ 30` |

--- a/krkn_ai/dashboard/tabs/anomalies.py
+++ b/krkn_ai/dashboard/tabs/anomalies.py
@@ -19,6 +19,8 @@ import plotly.graph_objects as go
 import plotly.express as px
 import streamlit as st
 
+from krkn_ai.dashboard.tabs.dashboard import use_relative_baseline
+
 
 # Detection mode constants
 MODE_ZSCORE = "z_score"
@@ -322,12 +324,8 @@ def detect_fitness_regression(df: pd.DataFrame) -> pd.DataFrame:
                 prev_gen, prev_best = gen_id, best_fs
                 continue
 
-            # Counter-based fitness queries sit at 0 on a healthy cluster, where a
-            # percentage drop is meaningless — score those in absolute terms.
-            scale = abs(prev_best)
-            relative = scale > cfg.get("min_scale", 1e-3)
-            if relative:
-                drop_pct = abs_drop / scale * 100
+            if use_relative_baseline(prev_best, gen_best):
+                drop_pct = abs_drop / abs(prev_best) * 100
                 severity = (
                     "High"
                     if drop_pct > cfg.get("high_drop_pct", 20.0)
@@ -1374,7 +1372,7 @@ Upper fence = Q3 + 1.5 × IQR
 | **Low / High Fitness** | `fitness_score` | IQR fence | x < Q1−1.5·IQR or x > Q3+1.5·IQR |
 | **Duration Anomaly** | `duration_seconds` | Z-score (RMS σ vs baseline if available) | `|z| ≥ 1.5` |
 | **HC Failure Surge** | `health_check_failure_score` | IQR fence | x > Q3+1.5·IQR |
-| **Fitness Regression** | Best fitness per generation | Gen-over-gen delta | `drop% = (prev−cur)/prev×100`; High if drop > 20%. When `|prev| ≤ 0.001` the absolute drop is used instead (High if > 0.2) |
+| **Fitness Regression** | Best fitness per generation | Gen-over-gen delta | `drop% = (prev−cur)/prev×100`; High if drop > 20%. When prev is under 1% of the observed scores the absolute drop is used instead (High if > 0.2) |
 | **Service Failure Rate** | Per-service failure_rate | Z-score vs service distribution | `|z| ≥ 1.5` |
 | **Krkn Failure Score** | `krkn_failure_score` | Non-zero sentinel + IQR | Non-zero → Medium; above IQR upper fence → High |
 | **HC Response Time** | `health_check_response_time_score` | IQR + Z-score | IQR breach OR `|z| ≥ 1.5` |
@@ -1403,7 +1401,7 @@ For each value **x** and its baseline reference **b**:
 | **Low / High Fitness** | Baseline scenario `fitness_score` | IQR fence breach **and/or** `Δ% < 0` below baseline |
 | **Duration Anomaly** | Baseline scenario `duration_seconds` | `|Δ%| ≥ 30` |
 | **HC Failure Surge** | Baseline `health_check_failure_score` | `|Δ%| ≥ 30` |
-| **Fitness Regression** | Previous generation best fitness | `drop% = (prev−cur)/prev×100`; High if drop > 20%, Medium if drop > 10%. Falls back to absolute drop when `|prev| ≤ 0.001` |
+| **Fitness Regression** | Previous generation best fitness | `drop% = (prev−cur)/prev×100`; High if drop > 20%, Medium if drop > 10%. Falls back to absolute drop when prev is under 1% of the observed scores |
 | **Service Failure Rate** | Baseline per-service failure rate | `|Δ%| ≥ 30` |
 | **Krkn Failure Score** | — (non-zero sentinel) | Non-zero → Medium; above IQR upper fence → High |
 | **HC Response Time** | Baseline `health_check_response_time_score` | `|Δ%| ≥ 30` |

--- a/krkn_ai/dashboard/tabs/config.py
+++ b/krkn_ai/dashboard/tabs/config.py
@@ -1,9 +1,168 @@
+import pandas as pd
 import streamlit as st
 
 
-def render_config(config_data):
-    st.header("Krkn-AI Configuration")
-    if config_data:
-        st.json(config_data)
+def _fitness_frame(items):
+    return pd.DataFrame(
+        [
+            {
+                "name": item["name"],
+                "category": item["category"] or "—",
+                "type": item["type"] or "—",
+                "weight": item["weight"],
+                "status": "in use" if item["enabled"] else "rejected",
+                "reason": item["reason"] or "—",
+                "query": item["query"],
+            }
+            for item in items
+        ]
+    )
+
+
+def render_fitness_section(config_data, items):
+    st.subheader("Fitness Function")
+    fitness_function = (config_data or {}).get("fitness_function") or {}
+
+    flags = [
+        key
+        for key in (
+            "include_krkn_failure",
+            "include_health_check_failure",
+            "include_health_check_response_time",
+        )
+        if fitness_function.get(key)
+    ]
+    st.caption(
+        "Extra score components: " + (", ".join(flags) if flags else "none") + "."
+    )
+
+    if fitness_function.get("query"):
+        st.write("Single-query mode:")
+        st.code(fitness_function["query"], language="promql")
+        st.caption(
+            f"Type: {fitness_function.get('type', 'point')}. Per-query items are "
+            "ignored while `query` is set."
+        )
+
+    if not items:
+        st.info("No per-query fitness items in this config.")
+        return
+
+    st.dataframe(
+        _fitness_frame(items),
+        column_config={
+            "name": st.column_config.TextColumn("Query", width="medium"),
+            "category": st.column_config.TextColumn("Category"),
+            "type": st.column_config.TextColumn("Type"),
+            "weight": st.column_config.NumberColumn("Weight", format="%.4f"),
+            "status": st.column_config.TextColumn("Status"),
+            "reason": st.column_config.TextColumn("Reason", width="medium"),
+            "query": st.column_config.TextColumn("PromQL", width="large"),
+        },
+        width="stretch",
+        hide_index=True,
+    )
+
+
+def render_health_check_section(config_data, health_check_recos):
+    st.subheader("Health Checks")
+    health_checks = (config_data or {}).get("health_checks") or {}
+    applications = health_checks.get("applications") or []
+
+    if applications:
+        st.dataframe(
+            pd.DataFrame(applications),
+            width="stretch",
+            hide_index=True,
+        )
     else:
+        st.info(
+            "No health-check applications configured — health-check scores will "
+            "stay at 0 for every scenario."
+        )
+
+    if health_check_recos:
+        st.caption("Discover found these services but left them commented out:")
+        st.dataframe(
+            pd.DataFrame(health_check_recos),
+            column_config={
+                "name": st.column_config.TextColumn("Service"),
+                "url": st.column_config.TextColumn("URL", width="large"),
+                "reason": st.column_config.TextColumn("Reason"),
+            },
+            width="stretch",
+            hide_index=True,
+        )
+
+
+def render_scenario_section(config_data):
+    st.subheader("Scenarios")
+    scenarios = (config_data or {}).get("scenario") or {}
+    if not scenarios:
+        st.info("No scenario section in this config.")
+        return
+
+    frame = pd.DataFrame(
+        [
+            {"scenario": name, "enabled": bool((value or {}).get("enable"))}
+            for name, value in scenarios.items()
+        ]
+    )
+    enabled_count = int(frame["enabled"].sum())
+    st.caption(f"{enabled_count} of {len(frame)} scenario types enabled.")
+    st.dataframe(
+        frame,
+        column_config={
+            "scenario": st.column_config.TextColumn("Scenario"),
+            "enabled": st.column_config.CheckboxColumn("Enabled"),
+        },
+        width="stretch",
+        hide_index=True,
+    )
+
+
+def render_cluster_section(config_data):
+    st.subheader("Cluster Components")
+    components = (config_data or {}).get("cluster_components") or {}
+    namespaces = components.get("namespaces") or []
+    nodes = components.get("nodes") or []
+
+    cols = st.columns(2)
+    cols[0].metric("Namespaces", len(namespaces))
+    cols[1].metric("Nodes", len(nodes))
+
+    if namespaces:
+        st.dataframe(
+            pd.DataFrame(
+                [
+                    {
+                        "namespace": ns.get("name"),
+                        "pods": len(ns.get("pods") or []),
+                        "services": len(ns.get("services") or []),
+                        "pvcs": len(ns.get("pvcs") or []),
+                        "disabled": bool(ns.get("disabled")),
+                    }
+                    for ns in namespaces
+                ]
+            ),
+            width="stretch",
+            hide_index=True,
+        )
+
+
+def render_config(config_data, items=None, health_check_recos=None):
+    st.header("Krkn-AI Configuration")
+    if not config_data:
         st.write("Configuration file not found.")
+        return
+
+    render_fitness_section(config_data, items or [])
+    st.divider()
+    render_health_check_section(config_data, health_check_recos or [])
+    st.divider()
+    render_scenario_section(config_data)
+    st.divider()
+    render_cluster_section(config_data)
+    st.divider()
+    with st.expander("Raw configuration", expanded=False):
+        st.json(config_data)

--- a/krkn_ai/dashboard/tabs/config.py
+++ b/krkn_ai/dashboard/tabs/config.py
@@ -1,15 +1,17 @@
+import math
+
 import pandas as pd
 import streamlit as st
 
 
 def _fitness_frame(items):
-    return pd.DataFrame(
+    frame = pd.DataFrame(
         [
             {
                 "name": item["name"],
                 "category": item["category"] or "—",
                 "type": item["type"] or "—",
-                "weight": item["weight"],
+                "weight": item["weight"] if item["enabled"] else math.nan,
                 "status": "in use" if item["enabled"] else "rejected",
                 "reason": item["reason"] or "—",
                 "query": item["query"],
@@ -17,6 +19,9 @@ def _fitness_frame(items):
             for item in items
         ]
     )
+    if not frame.empty:
+        frame["weight"] = pd.to_numeric(frame["weight"], errors="coerce")
+    return frame
 
 
 def render_fitness_section(config_data, items):

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -3,6 +3,11 @@ import streamlit as st
 import plotly.express as px
 import plotly.graph_objects as go
 
+from krkn_ai.dashboard.data_loader import map_slo_columns
+
+# Below this, a baseline is treated as zero and deltas are shown in absolute terms.
+ZERO_BASELINE_EPS = 1e-9
+
 
 def render_summary(df):
     st.header("Experiment Summary")
@@ -249,8 +254,15 @@ def create_improvement_trend_plot(df_all):
         return None
 
     bl_fitness = float(bl_rows.iloc[0]["fitness_score"])
-    if bl_fitness == 0:
-        return None
+    # A clean baseline scores 0 on counter-based queries, so fall back to the
+    # absolute delta rather than dividing by zero.
+    relative = abs(bl_fitness) > ZERO_BASELINE_EPS
+    unit = "%" if relative else ""
+
+    def _delta(series):
+        if relative:
+            return (series - bl_fitness) / abs(bl_fitness) * 100
+        return series - bl_fitness
 
     non_bl = df_all[df_all["scenario_id"].astype(str) != "baseline"].copy()
     if non_bl.empty:
@@ -258,9 +270,7 @@ def create_improvement_trend_plot(df_all):
 
     gen_best = non_bl.groupby("generation_id")["fitness_score"].max().reset_index()
     gen_best["gen_display"] = gen_best["generation_id"] + 1
-    gen_best["delta_pct"] = (
-        (gen_best["fitness_score"] - bl_fitness) / abs(bl_fitness) * 100
-    )
+    gen_best["delta_pct"] = _delta(gen_best["fitness_score"])
 
     fig = go.Figure()
 
@@ -278,8 +288,8 @@ def create_improvement_trend_plot(df_all):
                     lambda v: "#22c55e" if v >= 0 else "#ef4444"
                 ),
             ),
-            name="Best Fitness % vs Baseline",
-            hovertemplate="Gen %{x}: %{y:+.2f}% vs baseline<extra></extra>",
+            name=f"Best Fitness {unit or 'Δ'} vs Baseline",
+            hovertemplate=f"Gen %{{x}}: %{{y:+.4f}}{unit} vs baseline<extra></extra>",
         )
     )
 
@@ -287,9 +297,7 @@ def create_improvement_trend_plot(df_all):
     gen_avg = non_bl.groupby("generation_id")["fitness_score"].mean().reset_index()
     if not gen_avg.empty:
         gen_avg["gen_display"] = gen_avg["generation_id"] + 1
-        gen_avg["delta_pct"] = (
-            (gen_avg["fitness_score"] - bl_fitness) / abs(bl_fitness) * 100
-        )
+        gen_avg["delta_pct"] = _delta(gen_avg["fitness_score"])
         fig.add_trace(
             go.Scatter(
                 x=gen_avg["gen_display"],
@@ -297,8 +305,8 @@ def create_improvement_trend_plot(df_all):
                 mode="lines+markers",
                 line=dict(color="#64748b", width=1.5, dash="dot"),
                 marker=dict(size=6),
-                name="Avg Fitness % vs Baseline",
-                hovertemplate="Gen %{x}: avg %{y:+.2f}% vs baseline<extra></extra>",
+                name=f"Avg Fitness {unit or 'Δ'} vs Baseline",
+                hovertemplate=f"Gen %{{x}}: avg %{{y:+.4f}}{unit} vs baseline<extra></extra>",
             )
         )
 
@@ -312,7 +320,9 @@ def create_improvement_trend_plot(df_all):
     fig.update_layout(
         title="Fitness Improvement vs Baseline — per Generation",
         xaxis_title="Generation",
-        yaxis_title="% Improvement vs Baseline",
+        yaxis_title=(
+            "% Improvement vs Baseline" if relative else "Delta vs Baseline (absolute)"
+        ),
         hovermode="x unified",
         xaxis=dict(tickmode="linear", tick0=1, dtick=1),
         legend_title_text="Metric",
@@ -344,26 +354,31 @@ def render_improvement_trend(df_all):
         return
 
     bl_fitness = float(bl_rows.iloc[0]["fitness_score"])
-    if bl_fitness == 0:
-        st.info("Baseline fitness is 0 — cannot compute relative improvement.")
-        return
+    if abs(bl_fitness) <= ZERO_BASELINE_EPS:
+        st.caption(
+            "Baseline fitness is 0 — showing absolute deltas instead of percentages."
+        )
 
     fig = create_improvement_trend_plot(df_all)
     if fig:
         st.plotly_chart(fig, width="stretch")
 
 
-def render_generation_details(df, title="Generation & Scenario Details"):
+def render_generation_details(df, title="Generation & Scenario Details", items=None):
     st.header(title)
     if df is None or df.empty or "generation_id" not in df.columns:
         st.write("No failed scenario details available yet!!")
         return
 
+    key_prefix = title.lower().replace(" ", "_")
+
     # Extract all unique generation numbers for the dropdown
     gen_nums = sorted(df["generation_id"].unique().tolist())
     display_gens = ["All"] + [g + 1 for g in gen_nums]
     selected_gen_disp = st.selectbox(
-        "Select Generation to view executed scenarios:", options=display_gens
+        "Select Generation to view executed scenarios:",
+        options=display_gens,
+        key=f"{key_prefix}_generation",
     )
 
     if selected_gen_disp == "All":
@@ -388,6 +403,15 @@ def render_generation_details(df, title="Generation & Scenario Details"):
         else:
             gen_scenarios["slo_score"] = 0.0
 
+        # ...and optionally break that score back out, one column per query
+        slo_map = map_slo_columns(items or [], gen_scenarios.columns)
+        show_slo = bool(slo_map) and st.checkbox(
+            "Show per-query fitness columns",
+            value=False,
+            key=f"{key_prefix}_show_slo",
+            help="One column per fitness query defined in the run config.",
+        )
+
         display_cols = [
             "generation_id",
             "scenario_id",
@@ -400,6 +424,8 @@ def render_generation_details(df, title="Generation & Scenario Details"):
             "fitness_score",
             "parameters",
         ]
+        if show_slo:
+            display_cols = display_cols[:-1] + list(slo_map) + ["parameters"]
         available_cols = [c for c in display_cols if c in gen_scenarios.columns]
         view = gen_scenarios[available_cols].copy()
         if "generation_id" in view.columns:
@@ -427,6 +453,11 @@ def render_generation_details(df, title="Generation & Scenario Details"):
             ),
             "parameters": st.column_config.TextColumn("Parameters"),
         }
+        if show_slo:
+            for col, item in slo_map.items():
+                column_cfg[col] = st.column_config.NumberColumn(
+                    item["name"], format="%.4f", help=item["query"]
+                )
         st.dataframe(
             view,
             column_config=column_cfg,

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -5,8 +5,14 @@ import plotly.graph_objects as go
 
 from krkn_ai.dashboard.data_loader import map_slo_columns
 
-# Below this, a baseline is treated as zero and deltas are shown in absolute terms.
 ZERO_BASELINE_EPS = 1e-9
+RELATIVE_BASELINE_FRACTION = 0.01
+
+
+def use_relative_baseline(baseline, scores):
+    """True when the baseline is big enough for percentages to mean anything."""
+    scale = float(pd.Series(scores).abs().max() or 0.0)
+    return abs(baseline) > max(ZERO_BASELINE_EPS, RELATIVE_BASELINE_FRACTION * scale)
 
 
 def render_summary(df):
@@ -253,20 +259,18 @@ def create_improvement_trend_plot(df_all):
     if bl_rows.empty:
         return None
 
+    non_bl = df_all[df_all["scenario_id"].astype(str) != "baseline"].copy()
+    if non_bl.empty:
+        return None
+
     bl_fitness = float(bl_rows.iloc[0]["fitness_score"])
-    # A clean baseline scores 0 on counter-based queries, so fall back to the
-    # absolute delta rather than dividing by zero.
-    relative = abs(bl_fitness) > ZERO_BASELINE_EPS
+    relative = use_relative_baseline(bl_fitness, non_bl["fitness_score"])
     unit = "%" if relative else ""
 
     def _delta(series):
         if relative:
             return (series - bl_fitness) / abs(bl_fitness) * 100
         return series - bl_fitness
-
-    non_bl = df_all[df_all["scenario_id"].astype(str) != "baseline"].copy()
-    if non_bl.empty:
-        return None
 
     gen_best = non_bl.groupby("generation_id")["fitness_score"].max().reset_index()
     gen_best["gen_display"] = gen_best["generation_id"] + 1
@@ -354,9 +358,13 @@ def render_improvement_trend(df_all):
         return
 
     bl_fitness = float(bl_rows.iloc[0]["fitness_score"])
-    if abs(bl_fitness) <= ZERO_BASELINE_EPS:
+    non_bl = df_all[df_all["scenario_id"].astype(str) != "baseline"]
+    if not non_bl.empty and not use_relative_baseline(
+        bl_fitness, non_bl["fitness_score"]
+    ):
         st.caption(
-            "Baseline fitness is 0 — showing absolute deltas instead of percentages."
+            f"Baseline fitness ({bl_fitness:.4f}) is too close to 0 for percentages "
+            "to be meaningful — showing absolute deltas."
         )
 
     fig = create_improvement_trend_plot(df_all)
@@ -403,7 +411,6 @@ def render_generation_details(df, title="Generation & Scenario Details", items=N
         else:
             gen_scenarios["slo_score"] = 0.0
 
-        # ...and optionally break that score back out, one column per query
         slo_map = map_slo_columns(items or [], gen_scenarios.columns)
         show_slo = bool(slo_map) and st.checkbox(
             "Show per-query fitness columns",

--- a/krkn_ai/dashboard/tabs/dashboard.py
+++ b/krkn_ai/dashboard/tabs/dashboard.py
@@ -11,7 +11,8 @@ RELATIVE_BASELINE_FRACTION = 0.01
 
 def use_relative_baseline(baseline, scores):
     """True when the baseline is big enough for percentages to mean anything."""
-    scale = float(pd.Series(scores).abs().max() or 0.0)
+    largest = pd.Series(list(scores), dtype="float64").abs().max()
+    scale = 0.0 if pd.isna(largest) else float(largest)
     return abs(baseline) > max(ZERO_BASELINE_EPS, RELATIVE_BASELINE_FRACTION * scale)
 
 

--- a/krkn_ai/dashboard/tabs/fitness.py
+++ b/krkn_ai/dashboard/tabs/fitness.py
@@ -3,9 +3,22 @@ import plotly.express as px
 import plotly.graph_objects as go
 import streamlit as st
 
+from krkn_ai.chaos_engines.fitness import normalize_weights
 from krkn_ai.dashboard.data_loader import map_slo_columns, slo_columns
 
 MAX_BAR_SCENARIOS = 30
+
+
+def runtime_weights(items):
+    """Effective weight per query, normalised the way the engine does."""
+    enabled = [item for item in items if item["enabled"]]
+    if not enabled:
+        return {}
+    try:
+        weights = normalize_weights(item["weight"] for item in enabled)
+    except Exception:
+        return {item["query"]: item["weight"] for item in enabled}
+    return {item["query"]: weight for item, weight in zip(enabled, weights)}
 
 
 def query_color_map(names):
@@ -17,7 +30,7 @@ def query_color_map(names):
 
 
 def build_contribution_frame(df, items):
-    """One row per scenario and query, with what that query added to the score."""
+    """One row per chaos scenario and query, with what that query added."""
     if df is None or df.empty or not items:
         return pd.DataFrame()
 
@@ -25,12 +38,20 @@ def build_contribution_frame(df, items):
     if not mapping:
         return pd.DataFrame()
 
+    working = df
+    if "scenario_id" in working.columns:
+        working = working[working["scenario_id"].astype(str) != "baseline"]
+    if working.empty:
+        return pd.DataFrame()
+
+    weights = runtime_weights(items)
     rows = []
-    for _, row in df.iterrows():
+    for _, row in working.iterrows():
         for col, item in mapping.items():
             value = row.get(col)
             if pd.isna(value):
                 continue
+            weight = weights.get(item["query"], item["weight"])
             weighted = row.get(f"{col}_weighted")
             rows.append(
                 {
@@ -40,11 +61,11 @@ def build_contribution_frame(df, items):
                     "name": item["name"],
                     "category": item["category"] or "—",
                     "query": item["query"],
-                    "weight": item["weight"],
+                    "weight": weight,
                     "raw": float(value),
                     "contribution": float(weighted)
                     if pd.notna(weighted)
-                    else float(value) * item["weight"],
+                    else float(value) * weight,
                 }
             )
     return pd.DataFrame(rows)
@@ -142,17 +163,19 @@ def build_query_summary(long_df):
 def build_weights_frame(items, learned_weights):
     """Configured weight next to the weight this run learned, per query."""
     learned_weights = learned_weights or {}
+    weights = runtime_weights(items)
     rows = []
     for item in items:
         if not item["enabled"]:
             continue
+        configured = weights.get(item["query"], item["weight"])
         learned = learned_weights.get(item["query"])
         rows.append(
             {
                 "name": item["name"],
-                "configured": item["weight"],
+                "configured": configured,
                 "learned": learned,
-                "delta": None if learned is None else learned - item["weight"],
+                "delta": None if learned is None else learned - configured,
                 "query": item["query"],
             }
         )
@@ -222,7 +245,7 @@ def render_fitness(df, items, learned_weights=None, output_dir=None):
     cols = st.columns(3)
     cols[0].metric("Queries In Use", len(enabled))
     cols[1].metric("Queries Rejected", len(disabled))
-    cols[2].metric("Total Weight", f"{sum(item['weight'] for item in enabled):.4f}")
+    cols[2].metric("Total Weight", f"{sum(runtime_weights(items).values()):.4f}")
 
     long_df = build_contribution_frame(df, items)
     if long_df.empty and df is not None and not df.empty:

--- a/krkn_ai/dashboard/tabs/fitness.py
+++ b/krkn_ai/dashboard/tabs/fitness.py
@@ -8,12 +8,16 @@ from krkn_ai.dashboard.data_loader import map_slo_columns, slo_columns
 MAX_BAR_SCENARIOS = 30
 
 
-def build_contribution_frame(df, items):
-    """Long frame of per-query fitness: one row per (scenario, query).
+def query_color_map(names):
+    """Fix a colour per query so it stays the same across every chart on the tab."""
+    palette = px.colors.qualitative.Plotly
+    return {
+        name: palette[i % len(palette)] for i, name in enumerate(sorted(set(names)))
+    }
 
-    `contribution` is the raw query value scaled by its configured weight, which
-    is what the query actually added to the scenario's fitness score.
-    """
+
+def build_contribution_frame(df, items):
+    """One row per scenario and query, with what that query added to the score."""
     if df is None or df.empty or not items:
         return pd.DataFrame()
 
@@ -27,6 +31,7 @@ def build_contribution_frame(df, items):
             value = row.get(col)
             if pd.isna(value):
                 continue
+            weighted = row.get(f"{col}_weighted")
             rows.append(
                 {
                     "scenario_id": str(row.get("scenario_id", "?")),
@@ -37,7 +42,9 @@ def build_contribution_frame(df, items):
                     "query": item["query"],
                     "weight": item["weight"],
                     "raw": float(value),
-                    "contribution": float(value) * item["weight"],
+                    "contribution": float(weighted)
+                    if pd.notna(weighted)
+                    else float(value) * item["weight"],
                 }
             )
     return pd.DataFrame(rows)
@@ -63,6 +70,7 @@ def create_contribution_plot(long_df):
         color="name",
         title="Fitness Contribution by Query",
         hover_data=["category", "raw", "weight"],
+        color_discrete_map=query_color_map(long_df["name"]),
     )
     fig.update_layout(
         barmode="relative",
@@ -81,6 +89,8 @@ def create_query_evolution_plot(long_df, names=None):
     if long_df is None or long_df.empty or "generation_id" not in long_df.columns:
         return None
 
+    colors = query_color_map(long_df["name"])
+
     working = long_df.dropna(subset=["generation_id"])
     if names:
         working = working[working["name"].isin(names)]
@@ -97,6 +107,7 @@ def create_query_evolution_plot(long_df, names=None):
         color="name",
         markers=True,
         title="Query Value Over Generations",
+        color_discrete_map=colors,
     )
     fig.update_layout(
         xaxis_title="Generation",
@@ -149,6 +160,17 @@ def build_weights_frame(items, learned_weights):
     if frame.empty or frame["learned"].isna().all():
         return frame
     return frame.sort_values(by="learned", ascending=False)
+
+
+def build_rejected_frame(items):
+    """The queries discover would not run, with the reason it gave."""
+    return pd.DataFrame(
+        [
+            {"name": item["name"], "reason": item["reason"], "query": item["query"]}
+            for item in items
+            if not item["enabled"]
+        ]
+    )
 
 
 def create_weights_plot(weights_df):
@@ -275,16 +297,7 @@ def render_fitness(df, items, learned_weights=None, output_dir=None):
         st.divider()
         st.subheader("Queries Discover Rejected")
         st.dataframe(
-            pd.DataFrame(
-                [
-                    {
-                        "name": item["name"],
-                        "reason": item["reason"],
-                        "query": item["query"],
-                    }
-                    for item in disabled
-                ]
-            ),
+            build_rejected_frame(items),
             column_config={
                 "name": st.column_config.TextColumn("Query", width="medium"),
                 "reason": st.column_config.TextColumn("Reason", width="medium"),

--- a/krkn_ai/dashboard/tabs/fitness.py
+++ b/krkn_ai/dashboard/tabs/fitness.py
@@ -1,0 +1,348 @@
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+
+from krkn_ai.dashboard.data_loader import map_slo_columns, slo_columns
+
+MAX_BAR_SCENARIOS = 30
+
+
+def build_contribution_frame(df, items):
+    """Long frame of per-query fitness: one row per (scenario, query).
+
+    `contribution` is the raw query value scaled by its configured weight, which
+    is what the query actually added to the scenario's fitness score.
+    """
+    if df is None or df.empty or not items:
+        return pd.DataFrame()
+
+    mapping = map_slo_columns(items, df.columns)
+    if not mapping:
+        return pd.DataFrame()
+
+    rows = []
+    for _, row in df.iterrows():
+        for col, item in mapping.items():
+            value = row.get(col)
+            if pd.isna(value):
+                continue
+            rows.append(
+                {
+                    "scenario_id": str(row.get("scenario_id", "?")),
+                    "scenario": row.get("scenario", "?"),
+                    "generation_id": row.get("generation_id"),
+                    "name": item["name"],
+                    "category": item["category"] or "—",
+                    "query": item["query"],
+                    "weight": item["weight"],
+                    "raw": float(value),
+                    "contribution": float(value) * item["weight"],
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def create_contribution_plot(long_df):
+    """Stacked bar of what each query contributed to every scenario's fitness."""
+    if long_df is None or long_df.empty:
+        return None
+
+    totals = (
+        long_df.groupby("scenario_id")["contribution"]
+        .sum()
+        .sort_values(ascending=False)
+    )
+    keep = totals.head(MAX_BAR_SCENARIOS).index.tolist()
+    working = long_df[long_df["scenario_id"].isin(keep)]
+
+    fig = px.bar(
+        working,
+        x="scenario_id",
+        y="contribution",
+        color="name",
+        title="Fitness Contribution by Query",
+        hover_data=["category", "raw", "weight"],
+    )
+    fig.update_layout(
+        barmode="relative",
+        xaxis_title="Scenario ID",
+        yaxis_title="Weighted Contribution",
+        xaxis=dict(type="category", categoryorder="array", categoryarray=keep),
+        legend_title_text="Query",
+        hovermode="x unified",
+        height=420,
+    )
+    return fig
+
+
+def create_query_evolution_plot(long_df, names=None):
+    """Mean raw value per generation, one line per query."""
+    if long_df is None or long_df.empty or "generation_id" not in long_df.columns:
+        return None
+
+    working = long_df.dropna(subset=["generation_id"])
+    if names:
+        working = working[working["name"].isin(names)]
+    if working.empty:
+        return None
+
+    grouped = working.groupby(["generation_id", "name"])["raw"].mean().reset_index()
+    grouped["generation_id"] = grouped["generation_id"] + 1
+
+    fig = px.line(
+        grouped,
+        x="generation_id",
+        y="raw",
+        color="name",
+        markers=True,
+        title="Query Value Over Generations",
+    )
+    fig.update_layout(
+        xaxis_title="Generation",
+        yaxis_title="Mean Raw Value",
+        xaxis={"tickmode": "linear", "tick0": 1, "dtick": 1},
+        legend_title_text="Query",
+        hovermode="x unified",
+        height=380,
+    )
+    return fig
+
+
+def build_query_summary(long_df):
+    """Per-query stats, flagging the queries that never moved across scenarios."""
+    if long_df is None or long_df.empty:
+        return pd.DataFrame()
+
+    summary = (
+        long_df.groupby(["name", "category", "weight"])
+        .agg(
+            mean_value=("raw", "mean"),
+            max_value=("raw", "max"),
+            spread=("raw", lambda s: float(s.max() - s.min())),
+            mean_contribution=("contribution", "mean"),
+        )
+        .reset_index()
+    )
+    summary["flat"] = summary["spread"] == 0
+    return summary.sort_values(by="mean_contribution", ascending=False)
+
+
+def build_weights_frame(items, learned_weights):
+    """Configured weight next to the weight this run learned, per query."""
+    learned_weights = learned_weights or {}
+    rows = []
+    for item in items:
+        if not item["enabled"]:
+            continue
+        learned = learned_weights.get(item["query"])
+        rows.append(
+            {
+                "name": item["name"],
+                "configured": item["weight"],
+                "learned": learned,
+                "delta": None if learned is None else learned - item["weight"],
+                "query": item["query"],
+            }
+        )
+    frame = pd.DataFrame(rows)
+    if frame.empty or frame["learned"].isna().all():
+        return frame
+    return frame.sort_values(by="learned", ascending=False)
+
+
+def create_weights_plot(weights_df):
+    """Configured vs learned weight, side by side."""
+    if weights_df is None or weights_df.empty or weights_df["learned"].isna().all():
+        return None
+
+    fig = go.Figure()
+    fig.add_trace(
+        go.Bar(
+            x=weights_df["name"],
+            y=weights_df["configured"],
+            name="Configured",
+            marker_color="#64748b",
+        )
+    )
+    fig.add_trace(
+        go.Bar(
+            x=weights_df["name"],
+            y=weights_df["learned"],
+            name="Learned",
+            marker_color="#22c55e",
+        )
+    )
+    fig.update_layout(
+        barmode="group",
+        title="Configured vs Learned Weights",
+        xaxis_title="Query",
+        yaxis_title="Weight",
+        legend_title_text="Source",
+        height=380,
+    )
+    return fig
+
+
+def render_fitness(df, items, learned_weights=None, output_dir=None):
+    st.header("Fitness Breakdown")
+
+    if not items:
+        st.info(
+            "No per-query fitness items in this run's config. The run used a single "
+            "`fitness_function.query`, so there is nothing to break down."
+        )
+        return
+
+    enabled = [item for item in items if item["enabled"]]
+    disabled = [item for item in items if not item["enabled"]]
+
+    cols = st.columns(3)
+    cols[0].metric("Queries In Use", len(enabled))
+    cols[1].metric("Queries Rejected", len(disabled))
+    cols[2].metric("Total Weight", f"{sum(item['weight'] for item in enabled):.4f}")
+
+    long_df = build_contribution_frame(df, items)
+    if long_df.empty and df is not None and not df.empty:
+        present = len(slo_columns(df.columns))
+        if present and present != len(enabled):
+            st.warning(
+                f"`reports/all.csv` has {present} per-query columns but the config "
+                f"lists {len(enabled)} items — they were written by a different "
+                "config, so the breakdown is skipped to avoid mislabelling."
+            )
+        else:
+            st.info("No per-query scores recorded yet.")
+
+    if not long_df.empty:
+        st.divider()
+        fig = create_contribution_plot(long_df)
+        if fig:
+            st.plotly_chart(fig, width="stretch")
+            total_scenarios = long_df["scenario_id"].nunique()
+            if total_scenarios > MAX_BAR_SCENARIOS:
+                st.caption(
+                    f"Showing the top {MAX_BAR_SCENARIOS} scenarios by total "
+                    f"contribution out of {total_scenarios}."
+                )
+
+        st.divider()
+        st.subheader("Query Statistics")
+        summary = build_query_summary(long_df)
+        st.dataframe(
+            summary,
+            column_config={
+                "name": st.column_config.TextColumn("Query", width="medium"),
+                "category": st.column_config.TextColumn("Category"),
+                "weight": st.column_config.NumberColumn("Weight", format="%.4f"),
+                "mean_value": st.column_config.NumberColumn("Mean", format="%.4f"),
+                "max_value": st.column_config.NumberColumn("Max", format="%.4f"),
+                "spread": st.column_config.NumberColumn("Spread", format="%.4f"),
+                "mean_contribution": st.column_config.NumberColumn(
+                    "Mean Contribution", format="%.4f"
+                ),
+                "flat": st.column_config.CheckboxColumn("Flat"),
+            },
+            width="stretch",
+            hide_index=True,
+        )
+        flat = summary[summary["flat"]]["name"].tolist()
+        if flat:
+            st.caption(
+                "Flat queries returned the same value for every scenario and are "
+                f"not steering the search: {', '.join(flat)}."
+            )
+
+        st.divider()
+        st.subheader("Query Evolution")
+        options = sorted(long_df["name"].unique().tolist())
+        selected = st.multiselect(
+            "Queries to plot:",
+            options=options,
+            default=options[:5],
+            help="Mean raw value per generation, before weighting.",
+        )
+        evo = create_query_evolution_plot(long_df, selected)
+        if evo:
+            st.plotly_chart(evo, width="stretch")
+        else:
+            st.write("Select at least one query to plot.")
+
+    st.divider()
+    render_weights(items, learned_weights, output_dir)
+
+    if disabled:
+        st.divider()
+        st.subheader("Queries Discover Rejected")
+        st.dataframe(
+            pd.DataFrame(
+                [
+                    {
+                        "name": item["name"],
+                        "reason": item["reason"],
+                        "query": item["query"],
+                    }
+                    for item in disabled
+                ]
+            ),
+            column_config={
+                "name": st.column_config.TextColumn("Query", width="medium"),
+                "reason": st.column_config.TextColumn("Reason", width="medium"),
+                "query": st.column_config.TextColumn("PromQL", width="large"),
+            },
+            width="stretch",
+            hide_index=True,
+        )
+
+
+def render_weights(items, learned_weights=None, output_dir=None):
+    st.subheader("Fitness Weights")
+    weights_df = build_weights_frame(items, learned_weights)
+    if weights_df.empty:
+        st.info("No weighted fitness items in this run.")
+        return
+
+    if weights_df["learned"].isna().all():
+        st.info(
+            "No `learned_weights.json` in this run directory — it is written when "
+            "a run finishes with per-query fitness items."
+        )
+        st.dataframe(
+            weights_df[["name", "configured", "query"]],
+            column_config={
+                "name": st.column_config.TextColumn("Query", width="medium"),
+                "configured": st.column_config.NumberColumn(
+                    "Configured", format="%.4f"
+                ),
+                "query": st.column_config.TextColumn("PromQL", width="large"),
+            },
+            width="stretch",
+            hide_index=True,
+        )
+        return
+
+    fig = create_weights_plot(weights_df)
+    if fig:
+        st.plotly_chart(fig, width="stretch")
+
+    st.dataframe(
+        weights_df,
+        column_config={
+            "name": st.column_config.TextColumn("Query", width="medium"),
+            "configured": st.column_config.NumberColumn("Configured", format="%.4f"),
+            "learned": st.column_config.NumberColumn("Learned", format="%.4f"),
+            "delta": st.column_config.NumberColumn("Delta", format="%+.4f"),
+            "query": st.column_config.TextColumn("PromQL", width="large"),
+        },
+        width="stretch",
+        hide_index=True,
+    )
+    st.caption(
+        "Learned weights favour the queries that discriminated most between "
+        "scenarios. Feed them into the next discover run:"
+    )
+    st.code(
+        "krkn_ai discover --learned-weights "
+        f"{output_dir or '<run-dir>'}/learned_weights.json --save-strategy merge",
+        language="bash",
+    )

--- a/tests/unit/dashboard/tabs/test_dashboard.py
+++ b/tests/unit/dashboard/tabs/test_dashboard.py
@@ -6,6 +6,7 @@ from krkn_ai.dashboard.tabs.dashboard import (
     create_scenario_fitness_variation_plot,
     create_baseline_delta_plot,
     create_improvement_trend_plot,
+    use_relative_baseline,
 )
 
 
@@ -84,3 +85,24 @@ def test_create_improvement_trend_plot_valid():
     )
     fig = create_improvement_trend_plot(df)
     assert fig is not None
+
+
+def test_use_relative_baseline():
+    scores = [2.0, 2.5, 1.0]
+    assert use_relative_baseline(1.0, scores) is True
+    assert use_relative_baseline(0.0, scores) is False
+    assert use_relative_baseline(0.0105, scores) is False
+
+
+def test_create_improvement_trend_plot_falls_back_to_absolute_delta():
+    """A baseline this small would otherwise plot as a 20,000% improvement."""
+    df = pd.DataFrame(
+        {
+            "scenario_id": ["baseline", "1"],
+            "generation_id": [0, 0],
+            "fitness_score": [0.0105, 2.5105],
+        }
+    )
+    fig = create_improvement_trend_plot(df)
+    assert "absolute" in fig.layout.yaxis.title.text.lower()
+    assert round(float(fig.data[0].y[0]), 4) == 2.5

--- a/tests/unit/dashboard/tabs/test_fitness.py
+++ b/tests/unit/dashboard/tabs/test_fitness.py
@@ -1,0 +1,114 @@
+import pandas as pd
+
+from krkn_ai.dashboard.tabs.fitness import (
+    build_contribution_frame,
+    build_query_summary,
+    build_weights_frame,
+    create_contribution_plot,
+    create_query_evolution_plot,
+    create_weights_plot,
+)
+
+
+def _items():
+    return [
+        {
+            "name": "pod-restarts:default",
+            "category": "availability",
+            "query": "q1",
+            "type": "range",
+            "weight": 0.75,
+            "enabled": True,
+            "reason": "",
+        },
+        {
+            "name": "node-pressure",
+            "category": "node",
+            "query": "q2",
+            "type": "range",
+            "weight": 0.25,
+            "enabled": True,
+            "reason": "",
+        },
+        {
+            "name": "etcd-no-leader",
+            "category": "etcd",
+            "query": "q3",
+            "type": "range",
+            "weight": 0.0,
+            "enabled": False,
+            "reason": "metric(s) not scraped: etcd_server_has_leader",
+        },
+    ]
+
+
+def _df():
+    return pd.DataFrame(
+        {
+            "generation_id": [0, 1],
+            "scenario_id": ["1", "2"],
+            "scenario": ["pod_scenarios", "pod_scenarios"],
+            "slo_0": [2.0, 4.0],
+            "slo_1": [1.0, 1.0],
+        }
+    )
+
+
+def test_build_contribution_frame_empty():
+    assert build_contribution_frame(pd.DataFrame(), _items()).empty
+    assert build_contribution_frame(_df(), []).empty
+
+
+def test_build_contribution_frame_weights_each_query():
+    long_df = build_contribution_frame(_df(), _items())
+    assert len(long_df) == 4
+    first = long_df[
+        (long_df["scenario_id"] == "1") & (long_df["name"] == "pod-restarts:default")
+    ].iloc[0]
+    assert first["raw"] == 2.0
+    assert first["contribution"] == 1.5
+    # the rejected query has no column and must not appear
+    assert "etcd-no-leader" not in set(long_df["name"])
+
+
+def test_build_contribution_frame_skips_mismatched_columns():
+    df = _df().drop(columns=["slo_1"])
+    assert build_contribution_frame(df, _items()).empty
+
+
+def test_create_contribution_plot():
+    assert create_contribution_plot(pd.DataFrame()) is None
+    assert (
+        create_contribution_plot(build_contribution_frame(_df(), _items())) is not None
+    )
+
+
+def test_create_query_evolution_plot():
+    long_df = build_contribution_frame(_df(), _items())
+    assert create_query_evolution_plot(long_df) is not None
+    assert create_query_evolution_plot(long_df, ["node-pressure"]) is not None
+    assert create_query_evolution_plot(long_df, ["missing"]) is None
+
+
+def test_build_query_summary_flags_flat_queries():
+    summary = build_query_summary(build_contribution_frame(_df(), _items()))
+    flat = summary[summary["name"] == "node-pressure"].iloc[0]
+    varying = summary[summary["name"] == "pod-restarts:default"].iloc[0]
+    assert bool(flat["flat"]) is True
+    assert bool(varying["flat"]) is False
+    assert varying["spread"] == 2.0
+
+
+def test_build_weights_frame_without_learned_weights():
+    frame = build_weights_frame(_items(), {})
+    assert list(frame["name"]) == ["pod-restarts:default", "node-pressure"]
+    assert frame["learned"].isna().all()
+    assert create_weights_plot(frame) is None
+
+
+def test_build_weights_frame_with_learned_weights():
+    frame = build_weights_frame(_items(), {"q1": 0.9, "q2": 0.1})
+    row = frame[frame["name"] == "pod-restarts:default"].iloc[0]
+    assert row["learned"] == 0.9
+    assert round(row["delta"], 4) == 0.15
+    assert create_weights_plot(frame) is not None

--- a/tests/unit/dashboard/tabs/test_fitness.py
+++ b/tests/unit/dashboard/tabs/test_fitness.py
@@ -37,7 +37,7 @@ def _items():
             "type": "range",
             "weight": 0.0,
             "enabled": False,
-            "reason": "metric(s) not scraped: etcd_server_has_leader",
+            "reason": "not scraped",
         },
     ]
 
@@ -54,11 +54,6 @@ def _df():
     )
 
 
-def test_build_contribution_frame_empty():
-    assert build_contribution_frame(pd.DataFrame(), _items()).empty
-    assert build_contribution_frame(_df(), []).empty
-
-
 def test_build_contribution_frame_weights_each_query():
     long_df = build_contribution_frame(_df(), _items())
     assert len(long_df) == 4
@@ -67,27 +62,11 @@ def test_build_contribution_frame_weights_each_query():
     ].iloc[0]
     assert first["raw"] == 2.0
     assert first["contribution"] == 1.5
-    # the rejected query has no column and must not appear
     assert "etcd-no-leader" not in set(long_df["name"])
 
 
 def test_build_contribution_frame_skips_mismatched_columns():
-    df = _df().drop(columns=["slo_1"])
-    assert build_contribution_frame(df, _items()).empty
-
-
-def test_create_contribution_plot():
-    assert create_contribution_plot(pd.DataFrame()) is None
-    assert (
-        create_contribution_plot(build_contribution_frame(_df(), _items())) is not None
-    )
-
-
-def test_create_query_evolution_plot():
-    long_df = build_contribution_frame(_df(), _items())
-    assert create_query_evolution_plot(long_df) is not None
-    assert create_query_evolution_plot(long_df, ["node-pressure"]) is not None
-    assert create_query_evolution_plot(long_df, ["missing"]) is None
+    assert build_contribution_frame(_df().drop(columns=["slo_1"]), _items()).empty
 
 
 def test_build_query_summary_flags_flat_queries():
@@ -99,16 +78,24 @@ def test_build_query_summary_flags_flat_queries():
     assert varying["spread"] == 2.0
 
 
-def test_build_weights_frame_without_learned_weights():
-    frame = build_weights_frame(_items(), {})
-    assert list(frame["name"]) == ["pod-restarts:default", "node-pressure"]
-    assert frame["learned"].isna().all()
-    assert create_weights_plot(frame) is None
+def test_query_colours_match_across_charts():
+    long_df = build_contribution_frame(_df(), _items())
+    bars = create_contribution_plot(long_df)
+    lines = create_query_evolution_plot(long_df, ["node-pressure"])
+    assert lines.data[0].name == "node-pressure"
+    assert (
+        lines.data[0].line.color
+        == {t.name: t.marker.color for t in bars.data}["node-pressure"]
+    )
 
 
-def test_build_weights_frame_with_learned_weights():
-    frame = build_weights_frame(_items(), {"q1": 0.9, "q2": 0.1})
-    row = frame[frame["name"] == "pod-restarts:default"].iloc[0]
+def test_build_weights_frame():
+    plain = build_weights_frame(_items(), {})
+    assert list(plain["name"]) == ["pod-restarts:default", "node-pressure"]
+    assert create_weights_plot(plain) is None  # nothing learned yet
+
+    learned = build_weights_frame(_items(), {"q1": 0.9, "q2": 0.1})
+    row = learned[learned["name"] == "pod-restarts:default"].iloc[0]
     assert row["learned"] == 0.9
     assert round(row["delta"], 4) == 0.15
-    assert create_weights_plot(frame) is not None
+    assert create_weights_plot(learned) is not None

--- a/tests/unit/dashboard/tabs/test_fitness.py
+++ b/tests/unit/dashboard/tabs/test_fitness.py
@@ -17,7 +17,7 @@ def _items():
             "category": "availability",
             "query": "q1",
             "type": "range",
-            "weight": 0.75,
+            "weight": 6.0,
             "enabled": True,
             "reason": "",
         },
@@ -26,7 +26,7 @@ def _items():
             "category": "node",
             "query": "q2",
             "type": "range",
-            "weight": 0.25,
+            "weight": 2.0,
             "enabled": True,
             "reason": "",
         },
@@ -45,11 +45,11 @@ def _items():
 def _df():
     return pd.DataFrame(
         {
-            "generation_id": [0, 1],
-            "scenario_id": ["1", "2"],
-            "scenario": ["pod_scenarios", "pod_scenarios"],
-            "slo_0": [2.0, 4.0],
-            "slo_1": [1.0, 1.0],
+            "generation_id": [0, 0, 1],
+            "scenario_id": ["baseline", "1", "2"],
+            "scenario": ["baseline", "pod_scenarios", "pod_scenarios"],
+            "slo_0": [0.0, 2.0, 4.0],
+            "slo_1": [0.0, 1.0, 1.0],
         }
     )
 
@@ -57,6 +57,7 @@ def _df():
 def test_build_contribution_frame_weights_each_query():
     long_df = build_contribution_frame(_df(), _items())
     assert len(long_df) == 4
+    assert "baseline" not in set(long_df["scenario_id"])
     first = long_df[
         (long_df["scenario_id"] == "1") & (long_df["name"] == "pod-restarts:default")
     ].iloc[0]

--- a/tests/unit/dashboard/test_fitness_loader.py
+++ b/tests/unit/dashboard/test_fitness_loader.py
@@ -1,0 +1,135 @@
+import json
+import os
+
+import pytest
+import streamlit as st
+
+from krkn_ai.dashboard.data_loader import (
+    describe_query,
+    load_fitness_items,
+    load_health_check_recos,
+    load_learned_weights,
+    map_slo_columns,
+    slo_columns,
+)
+
+CONFIG = """
+fitness_function:
+  include_krkn_failure: true
+  # Fitness queries validated against the cluster's Prometheus.
+  items:
+  # pod-restarts:default
+  - query: '(sum(increase(kube_pod_container_status_restarts_total{namespace="default"}[$range$]))) or vector(0)'
+    type: range
+    weight: 0.5
+  # node-pressure
+  - query: '(sum(kube_node_status_condition{condition=~"MemoryPressure|DiskPressure|PIDPressure", status="true"})) or vector(0)'
+    type: range
+    weight: 0.5
+  # etcd-no-leader (metric(s) not scraped: etcd_server_has_leader)
+  # - query: '(sum(etcd_server_has_leader == bool 0)) or vector(0)'
+  #   type: range
+
+health_checks:
+  stop_watcher_on_failure: false
+  applications:
+  - name: "cart"
+    url: "http://1.2.3.4:80/health"
+  # (no probe, unreachable)
+  # - name: "payment"
+  #   url: "http://1.2.3.4:81/"
+  # (unreachable)
+  # - name: "user"
+  #   url: "http://1.2.3.4:82/health"
+
+scenario:
+  pod-scenarios:
+    enable: true
+"""
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    st.cache_data.clear()
+
+
+@pytest.fixture
+def run_dir(tmp_path):
+    (tmp_path / "krkn-ai.yaml").write_text(CONFIG)
+    return str(tmp_path)
+
+
+def test_load_fitness_items_reads_enabled_and_rejected(run_dir):
+    items = load_fitness_items(run_dir)
+    assert [item["name"] for item in items] == [
+        "pod-restarts:default",
+        "node-pressure",
+        "etcd-no-leader",
+    ]
+    assert [item["enabled"] for item in items] == [True, True, False]
+    assert items[0]["weight"] == 0.5
+    assert items[0]["type"] == "range"
+    assert items[2]["reason"] == "metric(s) not scraped: etcd_server_has_leader"
+    assert items[2]["query"].startswith("(sum(etcd_server_has_leader")
+
+
+def test_load_fitness_items_labels_from_catalog(run_dir):
+    """Names still resolve when the config carries no comments (merged configs)."""
+    stripped = "\n".join(
+        line for line in CONFIG.splitlines() if not line.strip().startswith("#")
+    )
+    with open(os.path.join(run_dir, "krkn-ai.yaml"), "w") as f:
+        f.write(stripped)
+
+    items = load_fitness_items(run_dir)
+    assert [item["name"] for item in items] == ["pod-restarts:default", "node-pressure"]
+    assert items[0]["category"] == "availability"
+    assert items[1]["category"] == "node"
+
+
+def test_load_fitness_items_missing_config(tmp_path):
+    assert load_fitness_items(str(tmp_path)) == []
+
+
+def test_describe_query_unknown():
+    assert describe_query("sum(made_up_metric)") == (None, None)
+
+
+def test_load_health_check_recos(run_dir):
+    recos = load_health_check_recos(run_dir)
+    assert recos == [
+        {
+            "name": "payment",
+            "url": "http://1.2.3.4:81/",
+            "reason": "no probe, unreachable",
+        },
+        {
+            "name": "user",
+            "url": "http://1.2.3.4:82/health",
+            "reason": "unreachable",
+        },
+    ]
+
+
+def test_load_learned_weights(run_dir):
+    assert load_learned_weights(run_dir) == {}
+    with open(os.path.join(run_dir, "learned_weights.json"), "w") as f:
+        json.dump({"q1": 0.7}, f)
+    st.cache_data.clear()
+    assert load_learned_weights(run_dir) == {"q1": 0.7}
+
+
+def test_slo_columns_ordered_numerically():
+    assert slo_columns(["slo_10", "fitness_score", "slo_2"]) == ["slo_2", "slo_10"]
+
+
+def test_map_slo_columns_requires_matching_counts(run_dir):
+    items = load_fitness_items(run_dir)
+    mapping = map_slo_columns(items, ["slo_0", "slo_1", "fitness_score"])
+    assert [item["name"] for item in mapping.values()] == [
+        "pod-restarts:default",
+        "node-pressure",
+    ]
+    # a rejected query has no column, so three columns cannot be trusted
+    assert map_slo_columns(items, ["slo_0", "slo_1", "slo_2"]) == {}
+    assert map_slo_columns(items, []) == {}

--- a/tests/unit/dashboard/test_fitness_loader.py
+++ b/tests/unit/dashboard/test_fitness_loader.py
@@ -1,14 +1,11 @@
-import json
 import os
 
 import pytest
 import streamlit as st
 
 from krkn_ai.dashboard.data_loader import (
-    describe_query,
     load_fitness_items,
     load_health_check_recos,
-    load_learned_weights,
     map_slo_columns,
     slo_columns,
 )
@@ -87,14 +84,6 @@ def test_load_fitness_items_labels_from_catalog(run_dir):
     assert items[1]["category"] == "node"
 
 
-def test_load_fitness_items_missing_config(tmp_path):
-    assert load_fitness_items(str(tmp_path)) == []
-
-
-def test_describe_query_unknown():
-    assert describe_query("sum(made_up_metric)") == (None, None)
-
-
 def test_load_health_check_recos(run_dir):
     recos = load_health_check_recos(run_dir)
     assert recos == [
@@ -111,25 +100,14 @@ def test_load_health_check_recos(run_dir):
     ]
 
 
-def test_load_learned_weights(run_dir):
-    assert load_learned_weights(run_dir) == {}
-    with open(os.path.join(run_dir, "learned_weights.json"), "w") as f:
-        json.dump({"q1": 0.7}, f)
-    st.cache_data.clear()
-    assert load_learned_weights(run_dir) == {"q1": 0.7}
-
-
-def test_slo_columns_ordered_numerically():
-    assert slo_columns(["slo_10", "fitness_score", "slo_2"]) == ["slo_2", "slo_10"]
-
-
 def test_map_slo_columns_requires_matching_counts(run_dir):
     items = load_fitness_items(run_dir)
+    assert slo_columns(["slo_10", "fitness_score", "slo_2"]) == ["slo_2", "slo_10"]
+
     mapping = map_slo_columns(items, ["slo_0", "slo_1", "fitness_score"])
     assert [item["name"] for item in mapping.values()] == [
         "pod-restarts:default",
         "node-pressure",
     ]
-    # a rejected query has no column, so three columns cannot be trusted
     assert map_slo_columns(items, ["slo_0", "slo_1", "slo_2"]) == {}
     assert map_slo_columns(items, []) == {}


### PR DESCRIPTION
## Description

- Adds a **Fitness** tab: per-query contribution, flat-query flag, query evolution, configured vs learned weights, and the queries `discover` rejected + why
- Queries labelled by name (`pod-restarts:sock-shop`) instead of `slo_0`
- Fixes the improvement-trend chart, which returned nothing at baseline 0 and showed a baseline of 0.0105 as a 20,000% improvement, now uses absolute deltas near zero
- Configuration tab: structured sections instead of a raw `st.json` dump
- Health Checks tab distinguishes "none configured" from "no data yet"
- Matching Fitness section in the HTML export (sample attached)

  ## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:

## Generated Report
[krkn_ai_report_20260818_140750.html.zip](https://github.com/user-attachments/files/31173856/krkn_ai_report_20260818_140750.html.zip)

## Testing

- All test pass locally.
- Ran the dashboard against a generated 17-scenario run and inspected every tab


## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors