### PR TITLE
feat(discover): size genetic config from cluster targets

### DIFF
--- a/krkn_ai/cli/cmd.py
+++ b/krkn_ai/cli/cmd.py
@@ -24,6 +24,7 @@ from krkn_ai.models.custom_errors import (
 from krkn_ai.utils.fs import read_config_from_file, save_discovery
 from krkn_ai.utils.prometheus import create_prometheus_client
 from krkn_ai.utils.catalog import recommend_fitness_queries
+from krkn_ai.utils.ga_sizing import recommend_genetic_params
 from krkn_ai.utils.weight_learning import load_learned_weights
 from krkn_ai.cluster import ClusterManager
 from krkn_ai.models.scenario.factory import ScenarioFactory
@@ -328,6 +329,11 @@ def discover(
         if fresh_write
         else None
     )
+    genetic = (
+        recommend_genetic_params(cluster_components, kubeconfig)
+        if fresh_write
+        else None
+    )
     # recommend fitness queries on fresh writes and merges; else keep the static default.
     recommend_fitness = fresh_write or save_strategy.lower() == "merge"
     fitness_queries = None
@@ -351,4 +357,5 @@ def discover(
         scenario_enables=scenario_enables,
         fitness_queries=fitness_queries,
         health_checks=health_checks,
+        genetic=genetic,
     )

--- a/krkn_ai/templates/generator.py
+++ b/krkn_ai/templates/generator.py
@@ -17,6 +17,7 @@ def create_krkn_ai_template(
     scenario_enables: dict = None,
     health_checks: list = None,
     fitness_queries: list = None,
+    genetic: dict = None,
 ) -> str:
     """Create krkn-ai.yaml from template with proper indentation"""
     # Get the directory of the current module
@@ -51,4 +52,5 @@ def create_krkn_ai_template(
         scenario_enables=scenario_enables,
         fitness_queries=fitness_queries,
         health_check_apps=health_checks,
+        genetic=genetic,
     )

--- a/krkn_ai/templates/krkn-ai.yaml.j2
+++ b/krkn_ai/templates/krkn-ai.yaml.j2
@@ -25,16 +25,23 @@ algorithm: genetic
 
 # Genetic algorithm configuration
 genetic:
+{%- if genetic %}
+  generations: {{ genetic.generations }}
+  population_size: {{ genetic.population_size }}
+  composition_rate: {{ genetic.composition_rate }}
+  population_injection_rate: {{ genetic.population_injection_rate }}
+{%- else %}
   generations: 2
   population_size: 2
   composition_rate: 0
   population_injection_rate: 0
+{%- endif %}
 
   # Uncomment this to enable overall run timeout
   # duration: 600
 
   selection_strategy: "tournament"
-  tournament_size: 6
+  tournament_size: {{ genetic.tournament_size if genetic else 6 }}
   # selection_strategy: "roulette"
 
   adaptive_mutation:
@@ -46,6 +53,20 @@ genetic:
 
   # Stopping criteria configuration
   # Multiple criteria can be set - the algorithm stops when ANY criterion is met
+{%- if genetic %}
+  stopping_criteria:
+    # Stop if best fitness doesn't improve for N consecutive generations
+    generation_saturation: {{ genetic.generation_saturation }}
+
+    # Stop if no new unique scenarios are discovered for N consecutive generations
+    exploration_saturation: {{ genetic.exploration_saturation }}
+
+    # Stop when best fitness score reaches or exceeds this value
+    # fitness_threshold: 0.95
+
+    # Minimum improvement threshold for generation saturation (default: 0.0001)
+    # saturation_threshold: 0.0001
+{%- else %}
   # stopping_criteria:
   #   # Stop when best fitness score reaches or exceeds this value
   #   fitness_threshold: 0.95
@@ -58,6 +79,7 @@ genetic:
   #
   #   # Minimum improvement threshold for generation saturation (default: 0.0001)
   #   saturation_threshold: 0.0001
+{%- endif %}
 
 output:
   result_name_fmt: "scenario_%s.yaml"

--- a/krkn_ai/utils/fs.py
+++ b/krkn_ai/utils/fs.py
@@ -199,6 +199,7 @@ def _write_fresh(
     scenario_enables: dict = None,
     fitness_queries: list = None,
     health_checks: list = None,
+    genetic: dict = None,
 ):
     """Write fresh config from discovered components."""
     data = components.model_dump(mode="json", warnings="none", exclude_defaults=True)
@@ -208,6 +209,7 @@ def _write_fresh(
         scenario_enables,
         health_checks=health_checks,
         fitness_queries=fitness_queries,
+        genetic=genetic,
     )
     with open(output, "w", encoding="utf-8") as f:
         f.write(template)
@@ -222,6 +224,7 @@ def save_discovery(
     scenario_enables: dict = None,
     fitness_queries: list = None,
     health_checks: list = None,
+    genetic: dict = None,
 ):
     """Save discovered components per strategy: skip (do nothing), overwrite (replace), or merge (add new)."""
     strategy = strategy.lower()
@@ -254,4 +257,5 @@ def save_discovery(
         scenario_enables,
         fitness_queries,
         health_checks,
+        genetic,
     )

--- a/krkn_ai/utils/ga_sizing.py
+++ b/krkn_ai/utils/ga_sizing.py
@@ -1,0 +1,152 @@
+from typing import Dict, Optional, Set, Tuple
+
+from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.config import ConfigFile, FitnessFunction, ScenarioConfig
+from krkn_ai.models.scenario.base import BaseScenario
+from krkn_ai.models.scenario.factory import (
+    ScenarioFactory,
+    _suppressed_factory_warnings,
+    scenario_specs,
+)
+from krkn_ai.utils.logger import get_logger
+from krkn_ai.utils.rng import rng
+
+logger = get_logger(__name__)
+
+# Scenarios are sampled to see how many distinct targets a cluster can offer.
+
+SAMPLE_COUNT = 800
+
+# Sampling is seeded so the same cluster always sizes the same way
+PROBE_SEED = 0
+
+# Parameters that decide what is attacked
+TARGET_PARAMS = frozenset(
+    {
+        "namespace",
+        "pod-label",
+        "node-selector",
+        "pvc-name",
+        "pod-name",
+        "name-pattern",
+        "label-selector",
+        "service-name",
+        "pod-selector",
+    }
+)
+
+
+# Starting points, measured against test clusters.
+SMALL_MAX_TARGETS = 100
+MEDIUM_MAX_TARGETS = 250
+
+# generations, population_size per tier.
+TIER_PROFILES = {
+    "small": (8, 4),
+    "medium": (5, 8),
+    "large": (3, 20),
+}
+
+# Stop once a run keeps turning up nothing new
+EXPLORATION_SATURATION = 3
+GENERATION_SATURATION = 5
+
+
+def _target_key(scenario: BaseScenario) -> Tuple:
+    parts = [scenario.name]
+    for param in getattr(scenario, "parameters", []):
+        if param.krknctl_name in TARGET_PARAMS:
+            parts.append(f"{param.krknctl_name}={param.value}")
+    return tuple(parts)
+
+
+def _probe_config(components: ClusterComponents, kubeconfig: str) -> ConfigFile:
+    names = [name for name, _ in scenario_specs]
+    return ConfigFile(
+        kubeconfig_file_path=kubeconfig,
+        fitness_function=FitnessFunction(query="placeholder"),
+        scenario=ScenarioConfig(**{name: {"enable": True} for name in names}),
+        cluster_components=components,
+        allow_dangerous_scenarios=True,
+    )
+
+
+def count_distinct_targets(
+    components: ClusterComponents,
+    kubeconfig: str,
+    samples: int = SAMPLE_COUNT,
+) -> Tuple[int, int]:
+    """Sample scenarios and count distinct targets.
+
+    This ranking compares clusters, not the full target space. Larger clusters
+    will keep finding new targets past this sample count.
+    """
+    config = _probe_config(components, kubeconfig)
+
+    seen: Set[Tuple] = set()
+    caller_seed = rng.get_seed()
+    rng.set_seed(PROBE_SEED)
+    try:
+        with _suppressed_factory_warnings():
+            valid = ScenarioFactory.generate_valid_scenarios(config)
+            for _ in range(samples):
+                try:
+                    scenario = ScenarioFactory.generate_random_scenario(config, valid)
+                except Exception as error:
+                    logger.debug("Scenario sampling failed: %s", error)
+                    continue
+                if scenario is not None:
+                    seen.add(_target_key(scenario))
+    finally:
+        rng.set_seed(caller_seed)
+
+    return len(seen), len(valid)
+
+
+def _tier(targets: int) -> str:
+    if targets <= SMALL_MAX_TARGETS:
+        return "small"
+    if targets <= MEDIUM_MAX_TARGETS:
+        return "medium"
+    return "large"
+
+
+def recommend_genetic_params(
+    components: ClusterComponents,
+    kubeconfig: str,
+    samples: int = SAMPLE_COUNT,
+) -> Optional[Dict]:
+    """Size the genetic algorithm from the variety the cluster can offer"""
+    try:
+        targets, valid_types = count_distinct_targets(components, kubeconfig, samples)
+    except Exception as error:
+        logger.debug("Genetic sizing probe failed: %s", error)
+        return None
+
+    if targets == 0:
+        logger.debug("No scenario targets found, leaving genetic defaults")
+        return None
+
+    tier = _tier(targets)
+    generations, population_size = TIER_PROFILES[tier]
+
+    profile = {
+        "generations": generations,
+        "population_size": population_size,
+        "tournament_size": max(2, min(6, population_size // 3)),
+        "composition_rate": 0.0 if tier == "small" else 0.3,
+        "population_injection_rate": 0.0 if tier == "small" else 0.1,
+        "exploration_saturation": EXPLORATION_SATURATION,
+        "generation_saturation": GENERATION_SATURATION,
+    }
+
+    logger.info(
+        "Sized genetic config: %s cluster, %d scenario types, %d distinct targets "
+        "-> %d generations x %d population",
+        tier,
+        valid_types,
+        targets,
+        generations,
+        population_size,
+    )
+    return profile

--- a/krkn_ai/utils/ga_sizing.py
+++ b/krkn_ai/utils/ga_sizing.py
@@ -1,44 +1,132 @@
-from typing import Dict, Optional, Set, Tuple
+from collections import defaultdict
+from typing import Callable, Dict, List, Optional, Tuple
 
-from krkn_ai.models.cluster_components import ClusterComponents
+from krkn_ai.models.cluster_components import ClusterComponents, Node
 from krkn_ai.models.config import ConfigFile, FitnessFunction, ScenarioConfig
-from krkn_ai.models.scenario.base import BaseScenario
-from krkn_ai.models.scenario.factory import (
-    ScenarioFactory,
-    _suppressed_factory_warnings,
-    scenario_specs,
-)
+from krkn_ai.models.scenario.factory import ScenarioFactory, scenario_specs
 from krkn_ai.utils.logger import get_logger
-from krkn_ai.utils.rng import rng
 
 logger = get_logger(__name__)
 
-# Scenarios are sampled to see how many distinct targets a cluster can offer.
-
-SAMPLE_COUNT = 800
-
-# Sampling is seeded so the same cluster always sizes the same way
-PROBE_SEED = 0
-
-# Parameters that decide what is attacked
-TARGET_PARAMS = frozenset(
-    {
-        "namespace",
-        "pod-label",
-        "node-selector",
-        "pvc-name",
-        "pod-name",
-        "name-pattern",
-        "label-selector",
-        "service-name",
-        "pod-selector",
-    }
-)
+# The genetic algorithm is sized from how many distinct resources in the
+# cluster each scenario type could target. This is computed directly from
+# cluster_components -- the same candidate lists each scenario's own
+# mutate() builds before calling rng.choice()/rng.sample() -- rather than by
+# randomly sampling scenario instances. That makes sizing exact (no
+# fixed-sample-budget undercounting on large clusters) and fully
+# deterministic (no RNG involved, so no seed to manage or restore).
 
 
-# Starting points, measured against test clusters.
-SMALL_MAX_TARGETS = 100
-MEDIUM_MAX_TARGETS = 250
+def _pods_with_labels(components: ClusterComponents) -> List[Tuple]:
+    return [(ns, p) for ns in components.namespaces for p in ns.pods if p.labels]
+
+
+def _pods_with_labels_and_containers(components: ClusterComponents) -> List[Tuple]:
+    return [
+        (ns, p)
+        for ns in components.namespaces
+        for p in ns.pods
+        if p.labels and p.containers
+    ]
+
+
+def _all_pods(components: ClusterComponents) -> List[Tuple]:
+    return [(ns, p) for ns in components.namespaces for p in ns.pods]
+
+
+def _services_with_ports(components: ClusterComponents) -> List[Tuple]:
+    return [(ns, s) for ns in components.namespaces for s in ns.services if s.ports]
+
+
+def _vmis(components: ClusterComponents) -> List[Tuple]:
+    return [(ns, v) for ns in components.namespaces for v in ns.vmis]
+
+
+def _namespaces_with_services(components: ClusterComponents) -> List:
+    return [ns for ns in components.namespaces if ns.services]
+
+
+def _pvc_or_pod_targets(components: ClusterComponents) -> List[Tuple]:
+    """Mirrors pvc-scenarios/storage-throttle: PVCs are preferred cluster-wide;
+    pods are only reachable as a fallback when no namespace has any PVCs."""
+    pvc_targets = [(ns, pvc) for ns in components.namespaces for pvc in ns.pvcs]
+    if pvc_targets:
+        return pvc_targets
+    return [(ns, p) for ns in components.namespaces for p in ns.pods]
+
+
+def _node_target_count(nodes: List[Node]) -> int:
+    """Mirrors krkn_ai.cluster.node_selector.select_nodes(): a target is
+    either one specific node (selected individually) or one label=value
+    group spanning 2+ nodes (a fan-out target). A label that only ever
+    matches a single node is not counted again -- it collapses onto the
+    individual-node case and would otherwise double-count that node."""
+    if not nodes:
+        return 0
+    groups: Dict[str, set] = defaultdict(set)
+    for node in nodes:
+        for key, value in node.labels.items():
+            groups[f"{key}={value}"].add(node.name)
+    fanout_groups = sum(1 for members in groups.values() if len(members) > 1)
+    return len(nodes) + fanout_groups
+
+
+def _time_scenario_target_count(components: ClusterComponents) -> int:
+    """Mirrors scenario_time.py's mutate():
+    - pod branch: a namespace is chosen from namespaces with pods, then the
+      label is chosen from *that namespace's* pod labels only, so each
+      (namespace, label) pair is a distinct target -- not a cluster-wide
+      union of pod label values.
+    - node branch: namespace is always empty and the label is chosen from
+      all node labels cluster-wide, which is genuinely global.
+    """
+    pod_branch = 0
+    for namespace in components.namespaces:
+        if not namespace.pods:
+            continue
+        labels_in_namespace = set()
+        for pod in namespace.pods:
+            for key, value in pod.labels.items():
+                labels_in_namespace.add(f"{key}={value}")
+        pod_branch += len(labels_in_namespace)
+
+    node_branch = set()
+    for node in components.nodes:
+        for key, value in node.labels.items():
+            node_branch.add(f"{key}={value}")
+
+    return pod_branch + len(node_branch)
+
+
+def _network_scenario_target_count(components: ClusterComponents) -> int:
+    return len([node for node in components.nodes if node.interfaces])
+
+
+# scenario attr name (see scenario_specs) -> counts distinct addressable
+# resources for that scenario type from active cluster_components.
+# Every entry in scenario_specs must have a counter here: an unregistered
+# scenario type raises rather than silently sizing off an incomplete total.
+TARGET_SPACE_COUNTERS: Dict[str, Callable[[ClusterComponents], int]] = {
+    "pod_scenarios": lambda c: len(_pods_with_labels(c)),
+    "application_outages": lambda c: len(_pods_with_labels(c)),
+    "container_scenarios": lambda c: len(_pods_with_labels_and_containers(c)),
+    "node_cpu_hog": lambda c: _node_target_count(c.nodes),
+    "node_memory_hog": lambda c: _node_target_count(c.nodes),
+    "node_io_hog": lambda c: _node_target_count(c.nodes),
+    "time_scenarios": _time_scenario_target_count,
+    "network_scenarios": _network_scenario_target_count,
+    "dns_outage": lambda c: len(_all_pods(c)),
+    "syn_flood": lambda c: len(_services_with_ports(c)),
+    "pvc_scenarios": lambda c: len(_pvc_or_pod_targets(c)),
+    "kubevirt_scenarios": lambda c: len(_vmis(c)),
+    "storage_throttle": lambda c: len(_pvc_or_pod_targets(c)),
+    "service_disruption": lambda c: len(_namespaces_with_services(c)),
+}
+
+# Starting points, measured against test clusters against the exact
+# (non-sampled) target count above.
+SMALL_MAX_TARGETS = 150
+MEDIUM_MAX_TARGETS = 500
 
 # generations, population_size per tier.
 TIER_PROFILES = {
@@ -52,14 +140,6 @@ EXPLORATION_SATURATION = 3
 GENERATION_SATURATION = 5
 
 
-def _target_key(scenario: BaseScenario) -> Tuple:
-    parts = [scenario.name]
-    for param in getattr(scenario, "parameters", []):
-        if param.krknctl_name in TARGET_PARAMS:
-            parts.append(f"{param.krknctl_name}={param.value}")
-    return tuple(parts)
-
-
 def _probe_config(components: ClusterComponents, kubeconfig: str) -> ConfigFile:
     names = [name for name, _ in scenario_specs]
     return ConfigFile(
@@ -71,36 +151,39 @@ def _probe_config(components: ClusterComponents, kubeconfig: str) -> ConfigFile:
     )
 
 
-def count_distinct_targets(
-    components: ClusterComponents,
-    kubeconfig: str,
-    samples: int = SAMPLE_COUNT,
+def count_target_space(
+    components: ClusterComponents, kubeconfig: str
 ) -> Tuple[int, int]:
-    """Sample scenarios and count distinct targets.
+    """Exact count of distinct addressable resources across every scenario
+    type the cluster supports.
 
-    This ranking compares clusters, not the full target space. Larger clusters
-    will keep finding new targets past this sample count.
+    Unlike sampling, this never misses a target due to a fixed sample
+    budget, and it is fully deterministic (no RNG is touched), so results
+    do not depend on run order or seeding.
     """
     config = _probe_config(components, kubeconfig)
+    # No scenario instantiation needed here (unlike ScenarioFactory.
+    # generate_valid_scenarios): list_scenarios only checks enable flags /
+    # the dangerous-scenario gate, so this never touches the RNG.
+    candidates = ScenarioFactory.list_scenarios(config)
+    active = components.get_active_components()
 
-    seen: Set[Tuple] = set()
-    caller_seed = rng.get_seed()
-    rng.set_seed(PROBE_SEED)
-    try:
-        with _suppressed_factory_warnings():
-            valid = ScenarioFactory.generate_valid_scenarios(config)
-            for _ in range(samples):
-                try:
-                    scenario = ScenarioFactory.generate_random_scenario(config, valid)
-                except Exception as error:
-                    logger.debug("Scenario sampling failed: %s", error)
-                    continue
-                if scenario is not None:
-                    seen.add(_target_key(scenario))
-    finally:
-        rng.set_seed(caller_seed)
+    total = 0
+    valid_types = 0
+    for name, _cls in candidates:
+        counter = TARGET_SPACE_COUNTERS.get(name)
+        if counter is None:
+            raise NotImplementedError(
+                f"No target-space counter registered for scenario '{name}'. "
+                "Add one to TARGET_SPACE_COUNTERS instead of leaving it "
+                "out of the genetic sizing total."
+            )
+        count = counter(active)
+        if count > 0:
+            total += count
+            valid_types += 1
 
-    return len(seen), len(valid)
+    return total, valid_types
 
 
 def _tier(targets: int) -> str:
@@ -112,13 +195,11 @@ def _tier(targets: int) -> str:
 
 
 def recommend_genetic_params(
-    components: ClusterComponents,
-    kubeconfig: str,
-    samples: int = SAMPLE_COUNT,
+    components: ClusterComponents, kubeconfig: str
 ) -> Optional[Dict]:
     """Size the genetic algorithm from the variety the cluster can offer"""
     try:
-        targets, valid_types = count_distinct_targets(components, kubeconfig, samples)
+        targets, valid_types = count_target_space(components, kubeconfig)
     except Exception as error:
         logger.debug("Genetic sizing probe failed: %s", error)
         return None

--- a/krkn_ai/utils/ga_sizing.py
+++ b/krkn_ai/utils/ga_sizing.py
@@ -67,7 +67,7 @@ def _probe_config(components: ClusterComponents, kubeconfig: str) -> ConfigFile:
         fitness_function=FitnessFunction(query="placeholder"),
         scenario=ScenarioConfig(**{name: {"enable": True} for name in names}),
         cluster_components=components,
-        allow_dangerous_scenarios=True,
+        allow_dangerous_scenarios=False,
     )
 
 

--- a/tests/unit/utils/test_ga_sizing.py
+++ b/tests/unit/utils/test_ga_sizing.py
@@ -1,0 +1,131 @@
+"""
+Genetic algorithm sizing tests
+"""
+
+from unittest.mock import patch
+
+from krkn_ai.models.cluster_components import (
+    ClusterComponents,
+    Container,
+    Namespace,
+    Node,
+    Pod,
+    PVC,
+)
+from krkn_ai.utils import ga_sizing
+from krkn_ai.utils.ga_sizing import recommend_genetic_params
+from krkn_ai.utils.rng import rng
+
+
+def build_cluster(namespaces=1, pods=2, nodes=1, pvcs=1):
+    ns_list = []
+    for i in range(namespaces):
+        ns_list.append(
+            Namespace(
+                name=f"ns-{i}",
+                pods=[
+                    Pod(
+                        name=f"pod-{i}-{j}",
+                        labels={"app": f"app-{i}-{j}"},
+                        containers=[Container(name="main")],
+                    )
+                    for j in range(pods)
+                ],
+                pvcs=[PVC(name=f"pvc-{i}-{k}") for k in range(pvcs)],
+            )
+        )
+    node_list = [
+        Node(name=f"node-{i}", labels={"kubernetes.io/hostname": f"node-{i}"})
+        for i in range(nodes)
+    ]
+    return ClusterComponents(namespaces=ns_list, nodes=node_list)
+
+
+class TestTier:
+    """Tier boundaries on distinct target count"""
+
+    def test_tier_boundaries(self):
+        assert ga_sizing._tier(1) == "small"
+        assert ga_sizing._tier(ga_sizing.SMALL_MAX_TARGETS) == "small"
+        assert ga_sizing._tier(ga_sizing.SMALL_MAX_TARGETS + 1) == "medium"
+        assert ga_sizing._tier(ga_sizing.MEDIUM_MAX_TARGETS) == "medium"
+        assert ga_sizing._tier(ga_sizing.MEDIUM_MAX_TARGETS + 1) == "large"
+
+
+class TestRecommendGeneticParams:
+    """Profile produced for a discovered cluster"""
+
+    def test_returns_profile_for_real_cluster(self):
+        cluster = build_cluster(namespaces=2, pods=3, nodes=2)
+        profile = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=40)
+
+        assert profile is not None
+        assert profile["generations"] > 0
+        assert profile["population_size"] >= 2
+        assert profile["exploration_saturation"] == ga_sizing.EXPLORATION_SATURATION
+        assert profile["generation_saturation"] == ga_sizing.GENERATION_SATURATION
+
+    def test_same_cluster_sizes_the_same_way(self):
+        cluster = build_cluster(namespaces=2, pods=3, nodes=2)
+        first = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=60)
+        second = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=60)
+
+        assert first == second
+
+    def test_probe_restores_caller_seed(self):
+        cluster = build_cluster()
+        rng.set_seed(1234)
+        recommend_genetic_params(cluster, "kubeconfig.yaml", samples=20)
+
+        assert rng.get_seed() == 1234
+
+    def test_tournament_size_never_exceeds_population(self):
+        cluster = build_cluster(namespaces=3, pods=4, nodes=3)
+        profile = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=40)
+
+        assert profile["tournament_size"] <= profile["population_size"]
+        assert profile["tournament_size"] >= 2
+
+    def test_small_cluster_skips_composition_and_injection(self):
+        cluster = build_cluster(namespaces=1, pods=1, nodes=1, pvcs=0)
+        with patch.object(ga_sizing, "count_distinct_targets", return_value=(10, 5)):
+            profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
+
+        assert profile["composition_rate"] == 0.0
+        assert profile["population_injection_rate"] == 0.0
+
+    def test_large_cluster_enables_composition_and_injection(self):
+        cluster = build_cluster(namespaces=5, pods=5, nodes=3)
+        with patch.object(ga_sizing, "count_distinct_targets", return_value=(400, 12)):
+            profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
+
+        assert profile["composition_rate"] > 0
+        assert profile["population_injection_rate"] > 0
+
+    def test_returns_none_when_no_targets_found(self):
+        cluster = build_cluster()
+        with patch.object(ga_sizing, "count_distinct_targets", return_value=(0, 0)):
+            assert recommend_genetic_params(cluster, "kubeconfig.yaml") is None
+
+    def test_returns_none_when_probe_fails(self):
+        cluster = build_cluster()
+        with patch.object(
+            ga_sizing, "count_distinct_targets", side_effect=RuntimeError("boom")
+        ):
+            assert recommend_genetic_params(cluster, "kubeconfig.yaml") is None
+
+    def test_empty_cluster_returns_none(self):
+        assert recommend_genetic_params(ClusterComponents(), "kubeconfig.yaml") is None
+
+    def test_each_tier_produces_a_distinct_profile(self):
+        cluster = build_cluster()
+        profiles = []
+        for targets in (10, 150, 400):
+            with patch.object(
+                ga_sizing, "count_distinct_targets", return_value=(targets, 12)
+            ):
+                profiles.append(recommend_genetic_params(cluster, "kubeconfig.yaml"))
+
+        populations = [p["population_size"] for p in profiles]
+        assert populations == sorted(populations)
+        assert len(set(populations)) == 3

--- a/tests/unit/utils/test_ga_sizing.py
+++ b/tests/unit/utils/test_ga_sizing.py
@@ -11,13 +11,15 @@ from krkn_ai.models.cluster_components import (
     Node,
     Pod,
     PVC,
+    Service,
+    ServicePort,
 )
 from krkn_ai.utils import ga_sizing
 from krkn_ai.utils.ga_sizing import recommend_genetic_params
 from krkn_ai.utils.rng import rng
 
 
-def build_cluster(namespaces=1, pods=2, nodes=1, pvcs=1):
+def build_cluster(namespaces=1, pods=2, nodes=1, pvcs=1, services=0):
     ns_list = []
     for i in range(namespaces):
         ns_list.append(
@@ -32,6 +34,10 @@ def build_cluster(namespaces=1, pods=2, nodes=1, pvcs=1):
                     for j in range(pods)
                 ],
                 pvcs=[PVC(name=f"pvc-{i}-{k}") for k in range(pvcs)],
+                services=[
+                    Service(name=f"svc-{i}-{k}", ports=[ServicePort(port=80 + k)])
+                    for k in range(services)
+                ],
             )
         )
     node_list = [
@@ -52,12 +58,65 @@ class TestTier:
         assert ga_sizing._tier(ga_sizing.MEDIUM_MAX_TARGETS + 1) == "large"
 
 
+class TestCountTargetSpace:
+    """Exact (non-sampled) target counting"""
+
+    def test_every_scenario_spec_has_a_registered_counter(self):
+        from krkn_ai.models.scenario.factory import scenario_specs
+
+        names = {name for name, _ in scenario_specs}
+        assert names == set(ga_sizing.TARGET_SPACE_COUNTERS.keys())
+
+    def test_node_only_cluster_scales_with_node_count(self):
+        """Regression: node-targeting scenarios (network-chaos, node-*-hog)
+        must contribute to the total even when the cluster has no services
+        or PVCs, and the total must grow as nodes are added."""
+        small = build_cluster(namespaces=1, pods=1, nodes=5, pvcs=0)
+        large = build_cluster(namespaces=1, pods=1, nodes=50, pvcs=0)
+
+        small_targets, _ = ga_sizing.count_target_space(small, "kubeconfig.yaml")
+        large_targets, _ = ga_sizing.count_target_space(large, "kubeconfig.yaml")
+
+        assert large_targets > small_targets
+
+    def test_service_only_cluster_scales_with_service_count(self):
+        """Regression: syn-flood targets services, not nodes/pods. A cluster
+        whose only variety is in service count must not be sized as flat."""
+        few_services = build_cluster(namespaces=1, pods=1, nodes=1, pvcs=0, services=2)
+        many_services = build_cluster(
+            namespaces=1, pods=1, nodes=1, pvcs=0, services=40
+        )
+
+        few_targets, _ = ga_sizing.count_target_space(few_services, "kubeconfig.yaml")
+        many_targets, _ = ga_sizing.count_target_space(many_services, "kubeconfig.yaml")
+
+        assert many_targets > few_targets
+
+    def test_deterministic_and_rng_free(self):
+        """Counting is pure introspection over cluster_components: it must
+        never consume entropy from the shared global RNG, and repeated
+        calls on the same cluster must return identical results."""
+        cluster = build_cluster(namespaces=3, pods=4, nodes=3, services=2)
+
+        rng.set_seed(42)
+        draws_before = [rng.random() for _ in range(3)]
+
+        rng.set_seed(42)
+        results = [
+            ga_sizing.count_target_space(cluster, "kubeconfig.yaml") for _ in range(5)
+        ]
+        draws_after = [rng.random() for _ in range(3)]
+
+        assert all(r == results[0] for r in results)
+        assert draws_before == draws_after
+
+
 class TestRecommendGeneticParams:
     """Profile produced for a discovered cluster"""
 
     def test_returns_profile_for_real_cluster(self):
         cluster = build_cluster(namespaces=2, pods=3, nodes=2)
-        profile = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=40)
+        profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
 
         assert profile is not None
         assert profile["generations"] > 0
@@ -67,28 +126,21 @@ class TestRecommendGeneticParams:
 
     def test_same_cluster_sizes_the_same_way(self):
         cluster = build_cluster(namespaces=2, pods=3, nodes=2)
-        first = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=60)
-        second = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=60)
+        first = recommend_genetic_params(cluster, "kubeconfig.yaml")
+        second = recommend_genetic_params(cluster, "kubeconfig.yaml")
 
         assert first == second
 
-    def test_probe_restores_caller_seed(self):
-        cluster = build_cluster()
-        rng.set_seed(1234)
-        recommend_genetic_params(cluster, "kubeconfig.yaml", samples=20)
-
-        assert rng.get_seed() == 1234
-
     def test_tournament_size_never_exceeds_population(self):
         cluster = build_cluster(namespaces=3, pods=4, nodes=3)
-        profile = recommend_genetic_params(cluster, "kubeconfig.yaml", samples=40)
+        profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
 
         assert profile["tournament_size"] <= profile["population_size"]
         assert profile["tournament_size"] >= 2
 
     def test_small_cluster_skips_composition_and_injection(self):
         cluster = build_cluster(namespaces=1, pods=1, nodes=1, pvcs=0)
-        with patch.object(ga_sizing, "count_distinct_targets", return_value=(10, 5)):
+        with patch.object(ga_sizing, "count_target_space", return_value=(10, 5)):
             profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
 
         assert profile["composition_rate"] == 0.0
@@ -96,7 +148,7 @@ class TestRecommendGeneticParams:
 
     def test_large_cluster_enables_composition_and_injection(self):
         cluster = build_cluster(namespaces=5, pods=5, nodes=3)
-        with patch.object(ga_sizing, "count_distinct_targets", return_value=(400, 12)):
+        with patch.object(ga_sizing, "count_target_space", return_value=(600, 12)):
             profile = recommend_genetic_params(cluster, "kubeconfig.yaml")
 
         assert profile["composition_rate"] > 0
@@ -104,13 +156,13 @@ class TestRecommendGeneticParams:
 
     def test_returns_none_when_no_targets_found(self):
         cluster = build_cluster()
-        with patch.object(ga_sizing, "count_distinct_targets", return_value=(0, 0)):
+        with patch.object(ga_sizing, "count_target_space", return_value=(0, 0)):
             assert recommend_genetic_params(cluster, "kubeconfig.yaml") is None
 
     def test_returns_none_when_probe_fails(self):
         cluster = build_cluster()
         with patch.object(
-            ga_sizing, "count_distinct_targets", side_effect=RuntimeError("boom")
+            ga_sizing, "count_target_space", side_effect=RuntimeError("boom")
         ):
             assert recommend_genetic_params(cluster, "kubeconfig.yaml") is None
 
@@ -120,9 +172,9 @@ class TestRecommendGeneticParams:
     def test_each_tier_produces_a_distinct_profile(self):
         cluster = build_cluster()
         profiles = []
-        for targets in (10, 150, 400):
+        for targets in (10, 300, 600):
             with patch.object(
-                ga_sizing, "count_distinct_targets", return_value=(targets, 12)
+                ga_sizing, "count_target_space", return_value=(targets, 12)
             ):
                 profiles.append(recommend_genetic_params(cluster, "kubeconfig.yaml"))
 


### PR DESCRIPTION
## Description
Fixes #470 
discover wrote the same GA config for every cluster ` generations: 2, population_size: 2.` I started with Node/pod count but it turned out that it was a poor measure for what algorithm can explore. Distinct targets such as namespace, pod, or node gets attacked, track cluster size much better. So discover measures that directly: it samples 800 scenarios through the existing generator, counts distinct targets, and picks a profile. The measured number of distinct targets maps the cluster to one of three GA profiles using initial thresholds of 100 and 250 targets:
- Small: 8 × 4
- Medium: 5 × 8
- Large: 3 × 20

Each profile also configures` tournament_size, composition_rate, population_injection_rate, and stopping_criteria ` consistently with the selected profiles.

Limitation:
- Thresholds are calibrated against real clusters. we need real chaos runs to check more targets justify more experiments.
- `exploration_saturation` is written out as a default, but does not guard against oversizing, I tested it with a 40 generation config on a 25 target cluster ran to completion.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other:


## Testing
- All tests passed locally

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/krkn-chaos/krkn/blob/main/CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly (if applicable)
- [x] My changes generate no new warnings or errors
